### PR TITLE
Dockerfile.rlserver: copy IoTDB runtime config file

### DIFF
--- a/Dockerfile.rlserver
+++ b/Dockerfile.rlserver
@@ -69,6 +69,7 @@ COPY --from=builder /build/server/transport_sec/transportSec.json ../transport_s
 COPY --from=builder /build/server/vissv2server/atServer/purposelist.json atServer/purposelist.json
 COPY --from=builder /build/server/vissv2server/atServer/scopelist.json atServer/scopelist.json
 COPY --from=builder /build/server/vissv2server/uds-registration.docker.json uds-registration.json
+COPY --from=builder /build/server/vissv2server/iotdb-config.json iotdb-config.json
 COPY --from=builder /build/server/vissv2server/vss_vissv2.binary .
 COPY --from=builder /build/server/agt_server/agt_public_key.rsa .
 


### PR DESCRIPTION
Copy the runtime config file for connections to Apache IoTDB to the docker image. This is required when IoTDB is used as the VISSR data store backend.

The [config file in question](https://github.com/COVESA/vissr/blob/master/server/vissv2server/iotdb-config.json) is already (always) in the VISSR source tree so there is no danger of breaking docker image build when IoTDB is not in use.