### PR TITLE
Workaround VISSR issue #115: Dockerfile.rlserver: workaround grpcMgr/testprocess build failure

### DIFF
--- a/Dockerfile.rlserver
+++ b/Dockerfile.rlserver
@@ -30,6 +30,9 @@ COPY grpc_pb/ ./grpc_pb
 COPY utils ./utils
 COPY go.mod go.sum ./
 
+#workaround issue #115: server/vissv2server/grpcMgr/testprocess does not build. Remove it
+RUN rm -r ./server/vissv2server/grpcMgr/testprocess
+
 RUN ls -a etc/
 
 #copy cert info from testCredGen to path expected by w3c server


### PR DESCRIPTION
The code in server/vissv2server/grpcMgr/testprocess/ fails to build. This will not be fixed in the short term for various reasons. After discussion with the maintainers workaround the issue by removing it from the dockerfile build tree.

See https://github.com/COVESA/vissr/issues/115 for details

Closes #115 