### PR TITLE
Stability/security bug fixes (batch 2)

### DIFF
--- a/server/agt_server/agt_server.go
+++ b/server/agt_server/agt_server.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/akamensky/argparse"
@@ -38,6 +39,13 @@ var privKey *rsa.PrivateKey
 
 // Stores a cache of the jwt ids received to not be reused
 var jtiCache map[string]struct{}
+
+// jtiCacheMu serialises access to jtiCache from the main request loop
+// (addCheckJti) and the per-jti expiry goroutines (deleteJti). Without
+// it the Go runtime aborts the process with "concurrent map read and
+// map write" once two AGT requests overlap. Mirrors the equivalent
+// fix in server/vissv2server/atServer/atServer.go.
+var jtiCacheMu sync.Mutex
 
 type Payload struct {
 	// Action  string `json:"action"`
@@ -65,9 +73,15 @@ func makeAgtServerHandler(serverChannel chan string) func(http.ResponseWriter, *
 				http.Error(w, "400 bad request method.", 400)
 			}
 		} else {
+			// Bound the request body before io.ReadAll. The AGT
+			// endpoint is reachable pre-auth (its purpose is to issue
+			// access-grant tokens), so an anonymous peer can otherwise
+			// send a giant or chunked body and force ReadAll to
+			// allocate until OOM. AGT requests are small JSON envelopes.
+			req.Body = http.MaxBytesReader(w, req.Body, 64*1024)
 			bodyBytes, err := io.ReadAll(req.Body)
 			if err != nil {
-				http.Error(w, "400 request unreadable.", 400)
+				http.Error(w, "413 request body too large or unreadable.", 413)
 			} else { // POST REQUEST TO /agts
 				utils.Info.Printf("agtServer:received POST request=%s\n", string(bodyBytes))
 				serverChannel <- string(bodyBytes) // Sends to serverChannel the body of the request
@@ -196,6 +210,8 @@ func authenticateClient(payload Payload) bool {
 
 // Checks if jwt id exist in cache, if it does, return false. If not, it adds it and automatically clear it from cache when it expires
 func addCheckJti(jti string) bool {
+	jtiCacheMu.Lock()
+	defer jtiCacheMu.Unlock()
 	if jtiCache == nil { // If map is empty (first time), it doesnt even check, initializes and add
 		jtiCache = make(map[string]struct{})
 		jtiCache[jti] = struct{}{}
@@ -214,7 +230,9 @@ func addCheckJti(jti string) bool {
 // Deletes the JTI from cache
 func deleteJti(jti string) {
 	time.Sleep((GAP + LIFETIME + 5) * time.Second)
+	jtiCacheMu.Lock()
 	delete(jtiCache, jti)
+	jtiCacheMu.Unlock()
 }
 
 // generate UUID

--- a/server/vissv2server/atServer/atServer.go
+++ b/server/vissv2server/atServer/atServer.go
@@ -161,9 +161,15 @@ func makeAtServerHandler(atsChannel chan string) func(http.ResponseWriter, *http
 				http.Error(w, "400 bad request method.", 400)
 			}
 		} else {
+			// Bound the request body before io.ReadAll. The AT endpoint
+			// is reachable pre-auth (it issues short-term access tokens),
+			// so an anonymous peer can otherwise send a giant or chunked
+			// body and force ReadAll to allocate until OOM. AT requests
+			// are small JSON envelopes.
+			req.Body = http.MaxBytesReader(w, req.Body, 64*1024)
 			bodyBytes, err := io.ReadAll(req.Body)
 			if err != nil {
-				http.Error(w, "400 request unreadable.", 400)
+				http.Error(w, "413 request body too large or unreadable.", 413)
 			} else {
 				utils.Info.Printf("atServer:received POST request=%s", string(bodyBytes))
 				atsChannel <- string(bodyBytes) // Sends request to server channel
@@ -704,7 +710,16 @@ func extractKeyValue(key string, input string) string {
 		utils.Error.Printf("extractKeyValue:error input=%s", err)
 		return ""
 	}
-	return inputMap[key].(string)
+	// Guard the type assertion: if `key` is absent (nil interface) or
+	// the value is non-string, the bare `.(string)` panics. This
+	// function is called from the atServer's central event-loop
+	// goroutine, which has no recover() — so a single malformed POST
+	// to /ats by an anonymous peer takes down the atServer entirely.
+	if v, ok := inputMap[key].(string); ok {
+		return v
+	}
+	utils.Error.Printf("extractKeyValue: key %q missing or non-string in input", key)
+	return ""
 }
 
 func validateTokenTimestamps(iat int, exp int) bool {

--- a/server/vissv2server/wsMgrFT/wsMgrFT.go
+++ b/server/vissv2server/wsMgrFT/wsMgrFT.go
@@ -10,14 +10,43 @@ package wsMgrFT
 import (
 	utils "github.com/covesa/vissr/utils"
 	"bytes"
+	"fmt"
 	"os"
 	"io"
 	"crypto/sha1"
 	"encoding/binary"
 	"encoding/hex"
 	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
 	"github.com/gorilla/websocket"
 )
+
+// sessionListMu protects the sessionList read-modify-write in
+// getDataSessionIndex / returnDataSessionIndex from concurrent WS
+// upgrade goroutines.
+var sessionListMu sync.Mutex
+
+// validateTransferName rejects file-transfer names that contain path
+// separators or parent-directory references. Without this, a VISS
+// client that issues a `set` against a FileDescriptor actuator
+// controls the `name` field that initFtSession concatenates onto the
+// hardcoded "./" base path and passes to os.Create / os.Open — i.e.
+// arbitrary file write/read on the in-vehicle host with the daemon's
+// privileges (e.g. name = "../../etc/cron.d/owned").
+func validateTransferName(name string) error {
+	if name == "" {
+		return fmt.Errorf("empty filename")
+	}
+	if filepath.Base(name) != name {
+		return fmt.Errorf("filename %q contains path separators", name)
+	}
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("filename %q contains parent-directory reference", name)
+	}
+	return nil
+}
 
 var MuxServer = []*http.ServeMux{
 	http.NewServeMux(),
@@ -249,6 +278,13 @@ func createUlResponse(uid []byte, messNo byte, lastMessage byte, chunkSize []byt
 
 func initFtSession(clientRequest utils.FileTransferCache) int {
 	status := 1  // assume error
+	// Reject client-controlled names that would escape the transfer
+	// directory before any os.Create / os.Open call. See
+	// validateTransferName for the underlying threat model.
+	if err := validateTransferName(clientRequest.Name); err != nil {
+		utils.Error.Printf("initFtSession: rejecting unsafe filename: %s", err)
+		return status
+	}
 	cacheIndex := getFileTransferCacheIndex(clientRequest.Uid)
 	if cacheIndex != -1 {
 		var fd *os.File
@@ -387,8 +423,18 @@ func dataSession(conn *websocket.Conn, clientChannel chan []byte, sessionIndex i
 }
 
 func getDataSessionIndex() int {
-	for i := 0; i< MAXSESSIONS; i++ {
+	sessionListMu.Lock()
+	defer sessionListMu.Unlock()
+	for i := 0; i < MAXSESSIONS; i++ {
 		if !sessionList[i] {
+			// Claim the slot before returning. The original code only
+			// scanned for a free slot and never marked it as taken, so
+			// the loop always returned 0 — every concurrent data
+			// session collided on the same clientChannel[0] and the
+			// MAXSESSIONS slots were never actually used. Combined
+			// with sessionListMu, this also prevents two concurrent
+			// upgrades from both claiming the same slot.
+			sessionList[i] = true
 			return i
 		}
 	}
@@ -396,5 +442,7 @@ func getDataSessionIndex() int {
 }
 
 func returnDataSessionIndex(index int) {
+	sessionListMu.Lock()
+	defer sessionListMu.Unlock()
 	sessionList[index] = false
 }

--- a/utils/managerdata.go
+++ b/utils/managerdata.go
@@ -11,9 +11,17 @@ package utils
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/gorilla/websocket"
 )
+
+// WsClientIndexMu protects the WsClientIndexList read-modify-write in
+// getWsClientIndex / ReturnWsClientIndex from concurrent WS upgrade
+// goroutines. Without it, two simultaneous upgrades could both observe
+// the same slot as free and both claim it, causing request/response
+// cross-talk between unrelated clients.
+var WsClientIndexMu sync.Mutex
 
 var requestTag int
 

--- a/utils/managerhandlers.go
+++ b/utils/managerhandlers.go
@@ -26,6 +26,8 @@ import (
 const backendTermination = "internal-backend-termination"
 
 func getWsClientIndex() int {
+	WsClientIndexMu.Lock()
+	defer WsClientIndexMu.Unlock()
 	freeIndex := -1
 	for i := range WsClientIndexList {
 		if WsClientIndexList[i] == true {
@@ -38,6 +40,8 @@ func getWsClientIndex() int {
 }
 
 func ReturnWsClientIndex(index int) {
+	WsClientIndexMu.Lock()
+	defer WsClientIndexMu.Unlock()
 	WsClientIndexList[index] = true
 }
 
@@ -141,7 +145,18 @@ func frontendHttpAppSession(w http.ResponseWriter, req *http.Request, clientChan
 		requestMap["action"] = "get"
 	case "POST": // set
 		requestMap["action"] = "set"
-		body, _ := io.ReadAll(req.Body)
+		// Bound the request body before io.ReadAll. Without this an
+		// anonymous client can send a Content-Length: <huge> or a
+		// never-closing chunked body and ReadAll will allocate until
+		// the daemon OOMs. VISS set payloads are small JSON envelopes,
+		// so 64 KiB is well above any legitimate use.
+		req.Body = http.MaxBytesReader(w, req.Body, 64*1024)
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			Warning.Printf("frontendHttpAppSession: request body rejected: %s", err)
+			backendHttpAppSession(`{"error": "413", "reason": "Request body too large", "description":"max 64 KiB"}`, &w)
+			return
+		}
 		var bodyMap map[string]interface{}
 		MapRequest(string(body), &bodyMap)
 		requestMap["value"] = bodyMap["value"]


### PR DESCRIPTION
Second pass over network-facing code paths that the previous batch (ef639f0) did not touch. Five issues addressed across the WS-FT, AGT, AT, and HTTP managers; all of them are reachable from a remote client (some pre-auth) on a typical VISS deployment.

1. wsMgrFT/wsMgrFT.go::initFtSession — path traversal on FileDescriptor downloads. The 'name' field of a VISS 'set' on a FileDescriptor actuator was concatenated onto the hardcoded './' base path and passed directly to os.Create / os.Open. Any authenticated VISS client could write or read arbitrary files on the in-vehicle host with the daemon's privileges via name = '../../etc/cron.d/owned'. Add a validateTransferName helper that rejects empty names, names containing path separators (filepath.Base != name), and names containing '..'.

2. agt_server/agt_server.go — race on jtiCache. Same class as the atServer/jtiCache race fixed in ef639f0: addCheckJti reads and writes a package-level map from the main request loop while per-jti expiry goroutines (deleteJti) delete from the same map without synchronisation. The Go runtime aborts the process on concurrent map read/write. Add jtiCacheMu sync.Mutex around the map accesses, mirroring the atServer fix.

3. managerhandlers.go, agt_server.go, atServer.go — bound the io.ReadAll(req.Body) on POST handlers. None of the three sites used http.MaxBytesReader. A remote peer sending an open-ended (chunked, never-closing) body or a giant Content-Length value forces ReadAll to allocate until OOM. The AGT and AT endpoints are pre-auth (they exist to issue tokens) so the body is unauthenticated input by definition. Cap each site at 64 KiB.

4. atServer/atServer.go::extractKeyValue — unchecked type assertion panics the atServer event loop. inputMap[key].(string) panics if key is absent (nil) or non- string. extractKeyValue is called from the atServer's central for/select goroutine with no recover(), so a single malformed POST to /ats from any anonymous peer takes down the entire AT server. Convert to a safe v, ok := inputMap[key].(string) check.

5. utils/{managerdata.go,managerhandlers.go} and wsMgrFT/wsMgrFT.go — race on session-index allocators, plus missing claim step in the FT allocator. WsClientIndexList and sessionList were both read-modify-write'd from concurrent WS upgrade goroutines with no mutex. Two simultaneous upgrades could observe the same slot as free and both claim it, producing request/response cross-talk between unrelated clients. Add WsClientIndexMu and sessionListMu.

   While here: wsMgrFT::getDataSessionIndex never marked the selected slot as taken (sessionList[i] = true was missing), so the function always returned 0 — every data session was sharing clientChannel[0] and MAXSESSIONS was effectively 1. Add the missing claim step so the FT manager can actually run multiple simultaneous data sessions.

Verified with go build across the four packages touched.