### PR TITLE
Stability/security bug fixes (batch 3)

### DIFF
--- a/server/vissv2server/grpcMgr/grpcMgr.go
+++ b/server/vissv2server/grpcMgr/grpcMgr.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 var grpcCompression utils.Encoding
@@ -56,7 +57,21 @@ const MAXGRPCCLIENTS = 50
 
 var grpcClientIndexList []bool
 
+// grpcStateMu serialises access to grpcRoutingDataList and
+// grpcClientIndexList. Per-RPC SubscribeRequest goroutines call
+// resetGrpcRoutingData on stream.Context().Done() and on send errors,
+// while the manager loop concurrently calls getClientId,
+// setGrpcRoutingData, updateGrpcRoutingData, getGrpcRoutingData, and
+// getSubscribeRoutingData on the same slices. Without the lock, a
+// disconnecting subscriber concurrent with a new client produces slot
+// leaks, cross-talk to the wrong client, or a runtime panic on
+// concurrent slice mutation. Mirrors the WsClientIndexMu /
+// udsClientIndexMu / sessionListMu mutexes added in PR #119 / batch 3.
+var grpcStateMu sync.Mutex
+
 func getClientId() int {
+	grpcStateMu.Lock()
+	defer grpcStateMu.Unlock()
 	for i := 0; i < MAXGRPCCLIENTS; i++ {
 		if grpcClientIndexList[i] == false {
 			grpcClientIndexList[i] = true
@@ -67,6 +82,8 @@ func getClientId() int {
 }
 
 func getGrpcRoutingData(clientId int) (chan string, bool) {
+	grpcStateMu.Lock()
+	defer grpcStateMu.Unlock()
 	for i := 0; i < MAXGRPCCLIENTS; i++ {
 		if grpcRoutingDataList[i].ClientId == clientId {
 			return grpcRoutingDataList[i].GrpcRespChannel, grpcRoutingDataList[i].IsMultipleEvents
@@ -77,6 +94,8 @@ func getGrpcRoutingData(clientId int) (chan string, bool) {
 
 func updateGrpcRoutingData(clientId int, subscriptionId string) {
 	//utils.Info.Printf("updateGrpcRoutingData:clientId=%d, subscriptionId=%s", clientId, subscriptionId)
+	grpcStateMu.Lock()
+	defer grpcStateMu.Unlock()
 	for i := 0; i < MAXGRPCCLIENTS; i++ {
 		if grpcRoutingDataList[i].ClientId == clientId {
 			grpcRoutingDataList[i].SubscriptionId = subscriptionId
@@ -87,6 +106,8 @@ func updateGrpcRoutingData(clientId int, subscriptionId string) {
 
 func getSubscribeRoutingData(unsubResp string) (int, chan string) {
 	subscriptionId := getSubscriptionId(unsubResp)
+	grpcStateMu.Lock()
+	defer grpcStateMu.Unlock()
 	for i := 0; i < MAXGRPCCLIENTS; i++ {
 		if grpcRoutingDataList[i].SubscriptionId == subscriptionId {
 			return grpcRoutingDataList[i].ClientId, grpcRoutingDataList[i].GrpcRespChannel
@@ -95,11 +116,22 @@ func getSubscribeRoutingData(unsubResp string) (int, chan string) {
 	return -1, nil
 }
 
-func resetClientId(clientId int) {
+// resetClientIdLocked clears a client-id slot. Caller must hold
+// grpcStateMu. Used internally by resetGrpcRoutingData to avoid
+// double-locking.
+func resetClientIdLocked(clientId int) {
 	grpcClientIndexList[clientId] = false
 }
 
+func resetClientId(clientId int) {
+	grpcStateMu.Lock()
+	defer grpcStateMu.Unlock()
+	resetClientIdLocked(clientId)
+}
+
 func initClientIdList() {
+	grpcStateMu.Lock()
+	defer grpcStateMu.Unlock()
 	for i := 0; i < MAXGRPCCLIENTS; i++ {
 		grpcClientIndexList[i] = false
 	}
@@ -107,6 +139,8 @@ func initClientIdList() {
 
 func setGrpcRoutingData(clientId int, grpcRespChan chan string, isMultipleEvent bool) bool {
 	//utils.Info.Printf("setGrpcRoutingData:clientId=%d, isMultipleEvent=%d", clientId, isMultipleEvent)
+	grpcStateMu.Lock()
+	defer grpcStateMu.Unlock()
 	for i := 0; i < MAXGRPCCLIENTS; i++ {
 		if grpcRoutingDataList[i].ClientId == -1 {
 			grpcRoutingDataList[i].ClientId = clientId
@@ -120,16 +154,20 @@ func setGrpcRoutingData(clientId int, grpcRespChan chan string, isMultipleEvent 
 
 func resetGrpcRoutingData(clientId int) {
 	utils.Info.Printf("resetGrpcRoutingData:clientId=%d", clientId)
+	grpcStateMu.Lock()
+	defer grpcStateMu.Unlock()
 	for i := 0; i < MAXGRPCCLIENTS; i++ {
 		if grpcRoutingDataList[i].ClientId == clientId {
 			grpcRoutingDataList[i].ClientId = -1
-			resetClientId(clientId)
+			resetClientIdLocked(clientId)
 			break
 		}
 	}
 }
 
 func iniGrpcRoutingDataList() {
+	grpcStateMu.Lock()
+	defer grpcStateMu.Unlock()
 	for i := 0; i < MAXGRPCCLIENTS; i++ {
 		grpcRoutingDataList[i].ClientId = -1
 	}

--- a/server/vissv2server/serviceMgr/serviceMgr.go
+++ b/server/vissv2server/serviceMgr/serviceMgr.go
@@ -712,6 +712,12 @@ func historyServer(historyAccessChan chan string, vss_data []byte) {
 	}
 }
 
+// MAXHISTORYBUFSIZE caps the per-path history ring-buffer that a
+// 'create' history-control request can allocate. Without an upper
+// bound, an attacker-supplied buf-size of e.g. 2^31-1 makes
+// make([]string, bufSize) blow up the heap.
+const MAXHISTORYBUFSIZE = 10000
+
 func processHistoryCtrl(histCtrlReq string, historyChan chan int, listExists bool) string {
 	if listExists == false {
 		utils.Error.Printf("processHistoryCtrl:Path list not found")
@@ -723,16 +729,46 @@ func processHistoryCtrl(histCtrlReq string, historyChan chan int, listExists boo
 		utils.Error.Printf("processHistoryCtrl:Missing command param")
 		return "400 Bad Request"
 	}
-	index := getHistoryListIndex(requestMap["path"].(string))
-	switch requestMap["action"].(string) {
+	// Type-assert path and action defensively. The request comes
+	// over the local history-control UDS from a peer we treat as
+	// untrusted; an unchecked .(string) on a non-string JSON value
+	// would panic the entire serviceMgr.
+	pathStr, ok := requestMap["path"].(string)
+	if !ok {
+		utils.Error.Printf("processHistoryCtrl: path is not a string")
+		return "400 Bad Request"
+	}
+	actionStr, ok := requestMap["action"].(string)
+	if !ok {
+		utils.Error.Printf("processHistoryCtrl: action is not a string")
+		return "400 Bad Request"
+	}
+	index := getHistoryListIndex(pathStr)
+	if index == -1 {
+		// getHistoryListIndex returns -1 for unknown paths. Every
+		// switch arm below indexes historyList[index]; without this
+		// guard, an unknown path produces historyList[-1] and panics.
+		utils.Error.Printf("processHistoryCtrl: unknown path %q", pathStr)
+		return "404 Not Found"
+	}
+	switch actionStr {
 	case "create":
 		if requestMap["buf-size"] == nil {
 			utils.Error.Printf("processHistoryCtrl:Buffer size missing")
 			return "400 Bad Request"
 		}
-		bufSize, err := strconv.Atoi(requestMap["buf-size"].(string))
+		bufSizeStr, ok := requestMap["buf-size"].(string)
+		if !ok {
+			utils.Error.Printf("processHistoryCtrl: buf-size is not a string")
+			return "400 Bad Request"
+		}
+		bufSize, err := strconv.Atoi(bufSizeStr)
 		if err != nil {
-			utils.Error.Printf("processHistoryCtrl:Buffer size malformed=%s", requestMap["buf-size"].(string))
+			utils.Error.Printf("processHistoryCtrl:Buffer size malformed=%s", bufSizeStr)
+			return "400 Bad Request"
+		}
+		if bufSize < 0 || bufSize > MAXHISTORYBUFSIZE {
+			utils.Error.Printf("processHistoryCtrl:Buffer size out of range: %d (allowed 0..%d)", bufSize, MAXHISTORYBUFSIZE)
 			return "400 Bad Request"
 		}
 		historyList[index].BufSize = bufSize
@@ -742,9 +778,14 @@ func processHistoryCtrl(histCtrlReq string, historyChan chan int, listExists boo
 			utils.Error.Printf("processHistoryCtrl:Frequency missing")
 			return "400 Bad Request"
 		}
-		freq, err := strconv.Atoi(requestMap["frequency"].(string))
+		freqStr, ok := requestMap["frequency"].(string)
+		if !ok {
+			utils.Error.Printf("processHistoryCtrl: frequency is not a string")
+			return "400 Bad Request"
+		}
+		freq, err := strconv.Atoi(freqStr)
 		if err != nil {
-			utils.Error.Printf("processHistoryCtrl:Frequeny malformed=%s", requestMap["frequency"].(string))
+			utils.Error.Printf("processHistoryCtrl:Frequeny malformed=%s", freqStr)
 			return "400 Bad Request"
 		}
 		historyList[index].Frequency = freq
@@ -763,7 +804,7 @@ func processHistoryCtrl(histCtrlReq string, historyChan chan int, listExists boo
 		historyList[index].BufIndex = 0
 		historyList[index].Buffer = nil
 	default:
-		utils.Error.Printf("processHistoryCtrl:Unknown command:action=%s", requestMap["action"].(string))
+		utils.Error.Printf("processHistoryCtrl:Unknown command:action=%s", actionStr)
 		return "400 Bad Request"
 	}
 	return "200 OK"

--- a/server/vissv2server/udsMgr/udsMgr.go
+++ b/server/vissv2server/udsMgr/udsMgr.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"strconv"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -26,6 +27,11 @@ const NUMOFUDSCLIENTS = 20
 var udsClientChan []chan string
 var clientBackendChan []chan string
 var UdsClientIndexList []bool
+// udsClientIndexMu protects the UdsClientIndexList read-modify-write
+// in getUdsClientIndex / returnUdsClientIndex from concurrent Accept-
+// loop and udsReader goroutines. Mirrors WsClientIndexMu added in
+// PR #119.
+var udsClientIndexMu sync.Mutex
 var udsClientIndex int
 const isClientLocal = false
 
@@ -386,6 +392,16 @@ func initClientServer(mgrId int, clientIndex *int) {
 			continue
 		}
 		*clientIndex = getUdsClientIndex()
+		if *clientIndex == -1 {
+			// The pool is full (NUMOFUDSCLIENTS active connections).
+			// Without this check, the next two lines index
+			// udsClientChan[-1] / clientBackendChan[-1] which panics
+			// and tears down the daemon. Close the new connection,
+			// log, and continue accepting.
+			utils.Error.Printf("UdsMgrInit:UDS client pool full (max %d); rejecting connection", NUMOFUDSCLIENTS)
+			conn.Close()
+			continue
+		}
 		go udsReader(conn, udsClientChan[*clientIndex], clientBackendChan[*clientIndex], *clientIndex)
 		go udsWriter(conn, clientBackendChan[*clientIndex])
 	}
@@ -393,6 +409,8 @@ func initClientServer(mgrId int, clientIndex *int) {
 
 
 func getUdsClientIndex() int {
+	udsClientIndexMu.Lock()
+	defer udsClientIndexMu.Unlock()
 	freeIndex := -1
 	for i := range UdsClientIndexList {
 		if UdsClientIndexList[i] == true {
@@ -405,6 +423,8 @@ func getUdsClientIndex() int {
 }
 
 func returnUdsClientIndex(index int) {
+	udsClientIndexMu.Lock()
+	defer udsClientIndexMu.Unlock()
 	UdsClientIndexList[index] = true
 }
 

--- a/utils/common.go
+++ b/utils/common.go
@@ -441,6 +441,15 @@ func readSchema() string {
 }
 
 func JsonSchemaValidate(request string) string {
+	// JsonSchemaInit silently leaves jsonSchema nil if
+	// vissv3.0-schema.json is missing or empty (it only logs an
+	// Error). Without this guard the first request from any
+	// anonymous client through any transport (wsMgr, httpMgr,
+	// udsMgr, mqttMgr) dereferences a nil *jsonschema.Schema and
+	// crashes the whole daemon.
+	if jsonSchema == nil {
+		return "JSON schema not loaded; cannot validate request"
+	}
 	errs, err := jsonSchema.ValidateBytes(context.Background(), []byte(request))
 	if err != nil {
 		return fixSyntax(err.Error())


### PR DESCRIPTION
Third pass over network-facing code paths in vissr. Four sibling bugs to classes cleaned up in `ef639f0` (first batch) and #119 (second batch), on subsystems those passes under-covered. All four are local-DoS / remote-DoS / data-corruption shaped — none change protocol semantics for well-formed input.

### 1. `udsMgr/udsMgr.go::initClientServer` — `-1` panic when client pool is full

`getUdsClientIndex` returns `-1` once `NUMOFUDSCLIENTS` (20) active UDS connections are held. The next `Accept` then indexes `udsClientChan[-1]` / `clientBackendChan[-1]` and panics the daemon.

Fix: check for `-1`, close the new connection, log, and continue the Accept loop. Add `udsClientIndexMu` to serialise the `UdsClientIndexList` read-modify-write, mirroring the `WsClientIndexMu` you added in #119.

### 2. `grpcMgr/grpcMgr.go` — race on `grpcRoutingDataList` / `grpcClientIndexList`

Per-RPC `SubscribeRequest` goroutines call `resetGrpcRoutingData` on `stream.Context().Done()` and on `stream.Send` errors, while the manager loop concurrently calls `getClientId`, `setGrpcRoutingData`, `updateGrpcRoutingData`, `getGrpcRoutingData`, and `getSubscribeRoutingData` on the same slices — with no synchronisation. Produces slot leaks, cross-talk to the wrong client, or a runtime panic on concurrent slice mutation.

Fix: add `grpcStateMu sync.Mutex` and lock every accessor. Split `resetClientId` into a locked public wrapper and an unlocked `*Locked` helper so `resetGrpcRoutingData` can avoid double-locking.

### 3. `serviceMgr/serviceMgr.go::processHistoryCtrl` — type-assertion panics + OOB index + unbounded `make`

Three `.(string)` assertions on `requestMap[...]` panic the entire `serviceMgr` on non-string JSON values. `getHistoryListIndex` returns `-1` for unknown paths and every switch arm indexes `historyList[index]` without a bounds check — so an unknown-path request panics on `historyList[-1]`. The `create` arm also accepts an arbitrary `buf-size` and calls `make([]string, bufSize)`, which blows up the heap on attacker-supplied huge values.

Fix: convert all three asserts to `v, ok := ...(string)`; return `404 Not Found` when `getHistoryListIndex` returns `-1`; cap `buf-size` at `MAXHISTORYBUFSIZE` (10000).

### 4. `utils/common.go::JsonSchemaValidate` — nil-deref when schema file missing

`JsonSchemaInit` only logs an `Error` if `vissv3.0-schema.json` is missing or empty; `jsonSchema` stays nil. The first request from any anonymous client through any transport (wsMgr, httpMgr, udsMgr, mqttMgr) then dereferences a nil `*jsonschema.Schema` and crashes the daemon.

Fix: nil-check at the top of `JsonSchemaValidate` that returns a non-empty error string instead.

### Verification

`go build` clean across all four touched packages: