### PR TITLE
Stability/security bug fixes (batch 4)

### DIFF
--- a/client/client-1.0/filetransfer_client/filetransfer_client.go
+++ b/client/client-1.0/filetransfer_client/filetransfer_client.go
@@ -23,10 +23,29 @@ import (
 	"github.com/gorilla/websocket"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 )
+
+// safeServerFilename rejects filenames from the server that contain
+// path separators, parent-directory references, or absolute-path
+// prefixes. A compromised (or MITM'd) server would otherwise control
+// the os.Create path on the client side, allowing arbitrary file
+// write outside the client's working directory.
+func safeServerFilename(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("empty filename from server")
+	}
+	if filepath.Base(name) != name {
+		return "", fmt.Errorf("server filename %q contains path separators", name)
+	}
+	if strings.Contains(name, "..") {
+		return "", fmt.Errorf("server filename %q contains parent-directory reference", name)
+	}
+	return name, nil
+}
 
 var serverUrl string
 
@@ -268,12 +287,22 @@ func uploadFile(ctrlChannel chan string, dataChannel chan []byte) {
 			utils.Error.Printf("Server responded with error message=%s", ctrlResp)
 			return
 		} else {
-			ulFile, hash, uidString = getFileDescriptorData(responseMap["value"].(interface{}))
+			ulFile, hash, uidString = getFileDescriptorData(responseMap["value"])
 		}
 	} else {
 		utils.Error.Printf("Response=%s is corrupt", ctrlResp)
 		return
 	}
+	// The 'name' the server hands us ends up in os.Create directly.
+	// A compromised or MITM'd server can therefore write outside the
+	// client's working directory by returning name="../../etc/...".
+	// Reject any name that isn't a plain filename.
+	safeName, err := safeServerFilename(ulFile)
+	if err != nil {
+		utils.Error.Printf("uploadFile: rejecting server-supplied filename: %s", err)
+		return
+	}
+	ulFile = safeName
 	uid, _ := hex.DecodeString(uidString)
 	file, err := os.Create(ulFile)  // overwriting any existing file...
 	if err != nil {

--- a/feeder/feeder-template/feederv4/feederv4.go
+++ b/feeder/feeder-template/feederv4/feederv4.go
@@ -339,8 +339,19 @@ func udsReader(conn net.Conn, inputChan chan DomainData, udsChan chan string, co
 				case "unsubscribe":
 					pathList := serverMessageMap["path"].([]interface{})
 					for i := 0; i < len(pathList); i++ {
-						if onNotificationList(pathList[i].(string)) != -1 {
-							notificationList = slices.Delete(notificationList, i, i+1)
+						// Use the index returned by onNotificationList,
+						// not the loop counter i — i is an index into
+						// pathList, not into notificationList. The
+						// previous code panicked on slices.Delete when
+						// len(pathList) > len(notificationList), and
+						// deleted the wrong entry otherwise (state
+						// corruption).
+						pathStr, ok := pathList[i].(string)
+						if !ok {
+							continue
+						}
+						if idx := onNotificationList(pathStr); idx != -1 {
+							notificationList = slices.Delete(notificationList, idx, idx+1)
 						}
 					}
 				case "update":

--- a/server/vissv2server/mqttMgr/mqttMgr.go
+++ b/server/vissv2server/mqttMgr/mqttMgr.go
@@ -85,8 +85,14 @@ func mqttSubscribe(brokerSocket string, topic string) MQTT.Client {
 		return nil
 	}
 	if token := c.Subscribe(topic, 0, nil); token.Wait() && token.Error() != nil {
-		utils.Error.Println(token.Error())
-		os.Exit(1)
+		// Previously this called os.Exit(1) on subscribe failure, which
+		// terminates the whole vissv2server process (mqttMgr runs in-
+		// proc) — a transient broker outage or a hostile broker would
+		// take WS/HTTP/UDS/gRPC clients down with MQTT. Log and return
+		// nil so the caller can fall back / retry instead.
+		utils.Error.Printf("mqttSubscribe failed: %s", token.Error())
+		c.Disconnect(250)
+		return nil
 	}
 	return c
 }
@@ -157,8 +163,11 @@ func publishMessage(brokerSocket string, topic string, payload string) {
 
 	c := MQTT.NewClient(opts)
 	if token := c.Connect(); token.Wait() && token.Error() != nil {
-		utils.Error.Println(token.Error())
-		os.Exit(1)
+		// Same rationale as the subscribe-failure path above: do not
+		// tear the whole server down when an MQTT broker hiccups or
+		// rejects the connect.
+		utils.Error.Printf("publishMessage: connect failed: %s", token.Error())
+		return
 	}
 	token := c.Publish(topic, 0, false, payload)
 	token.Wait()

--- a/server/vissv2server/serviceMgr/serviceMgr.go
+++ b/server/vissv2server/serviceMgr/serviceMgr.go
@@ -790,9 +790,33 @@ func convertFromIsoTime(isoTime string) (time.Time, error) {
 func processHistoryGet(request string) string { // {"path":"X", "period":"Y"}
 	var requestMap = make(map[string]interface{})
 	utils.MapRequest(request, &requestMap)
-	index := getHistoryListIndex(requestMap["path"].(string))
+	// Sibling of processHistoryCtrl. Same defensive shape: type-
+	// assert path/period safely, reject unknown path before any
+	// historyList[index] read. The previous version would panic the
+	// entire serviceMgr on a malformed subscribe/history request,
+	// reachable from any anonymous network peer when --history is
+	// enabled.
+	pathStr, ok := requestMap["path"].(string)
+	if !ok {
+		utils.Error.Printf("processHistoryGet: path is not a string")
+		return ""
+	}
+	periodStr, ok := requestMap["period"].(string)
+	if !ok {
+		utils.Error.Printf("processHistoryGet: period is not a string")
+		return ""
+	}
+	index := getHistoryListIndex(pathStr)
+	if index == -1 {
+		utils.Error.Printf("processHistoryGet: unknown path %q", pathStr)
+		return ""
+	}
 	currentTs := getCurrentUtcTime()
-	periodTime, _ := convertFromIsoTime(requestMap["period"].(string))
+	periodTime, err := convertFromIsoTime(periodStr)
+	if err != nil {
+		utils.Error.Printf("processHistoryGet: period %q malformed: %s", periodStr, err)
+		return ""
+	}
 	oldTs := currentTs.Add(time.Hour*(time.Duration)((24*periodTime.Day()+periodTime.Hour())*(-1)) -
 		time.Minute*(time.Duration)(periodTime.Minute()) - time.Second*(time.Duration)(periodTime.Second())).UTC()
 	var matches int

--- a/server/vissv2server/vissv2server.go
+++ b/server/vissv2server/vissv2server.go
@@ -468,12 +468,29 @@ func issueServiceRequest(requestMap map[string]interface{}, tDChanIndex int, sDC
 			backendChan[tDChanIndex] <- errorResponseMap
 			return
 		}
-		if requestMap["action"] == "set" && strings.Contains(utils.VSSgetDatatype(searchData[0].NodeHandle)[:5], "Types") {
-			res := verifyStruct(requestMap["value"].(map[string]interface{}), utils.VSSgetDatatype(searchData[0].NodeHandle), 0)
-			if res != "ok" {
-				utils.SetErrorResponse(requestMap, errorResponseMap, 1, res) //invalid_data
-				backendChan[tDChanIndex] <- errorResponseMap
-				return
+		if requestMap["action"] == "set" {
+			// Use HasPrefix instead of the previous unconditional
+			// dt[:5] slice. The slice panicked on any leaf datatype
+			// shorter than 5 characters (e.g. "int8" = 4) and on
+			// branch nodes where VSSgetDatatype returns "": a single
+			// SET to an int8 actuator was enough to take down the
+			// daemon. Also type-assert the value defensively — a
+			// schema-passing 'set' on a struct-typed actuator with a
+			// non-object value otherwise panics on .(map[...]).
+			dt := utils.VSSgetDatatype(searchData[0].NodeHandle)
+			if strings.HasPrefix(dt, "Types") {
+				value, ok := requestMap["value"].(map[string]interface{})
+				if !ok {
+					utils.SetErrorResponse(requestMap, errorResponseMap, 1, "value is not an object for struct-typed actuator")
+					backendChan[tDChanIndex] <- errorResponseMap
+					return
+				}
+				res := verifyStruct(value, dt, 0)
+				if res != "ok" {
+					utils.SetErrorResponse(requestMap, errorResponseMap, 1, res) //invalid_data
+					backendChan[tDChanIndex] <- errorResponseMap
+					return
+				}
 			}
 		}
 		totalMatches += matches
@@ -691,10 +708,30 @@ func initiateFileTransfer(requestMap map[string]interface{}, nodeType string, pa
 	var ftInitData utils.FileTransferCache
 	var responseMap = map[string]interface{}{}
 	if requestMap["action"] == "set" && nodeType == utils.ACTUATOR { // download
+		// requestMap["value"] arrives from client JSON. If the client
+		// sends a non-object value (e.g. a bare string) for a
+		// FileDescriptor actuator, the previous direct
+		// .(interface{}) cast plus getFileDescriptorData's internal
+		// .(map[string]interface{}) panic-walked into a daemon
+		// crash. Type-check up front and reject malformed inputs.
+		if requestMap["value"] == nil {
+			utils.SetErrorResponse(requestMap, errorResponseMap, 1, "missing value for FileDescriptor set")
+			return errorResponseMap
+		}
 		var uidString string
 		ftInitData.UploadTransfer = false
-		ftInitData.Name, ftInitData.Hash, uidString = getFileDescriptorData(requestMap["value"].(interface{}))
-		uidByte, _ := hex.DecodeString(uidString)
+		ftInitData.Name, ftInitData.Hash, uidString = getFileDescriptorData(requestMap["value"])
+		if ftInitData.Name == "" {
+			utils.SetErrorResponse(requestMap, errorResponseMap, 1, "FileDescriptor value malformed")
+			return errorResponseMap
+		}
+		uidByte, err := hex.DecodeString(uidString)
+		if err != nil || len(uidByte) != utils.UIDLEN {
+			// Go ≥1.20 panics on [N]byte(slice) when len(slice) != N.
+			// Reject malformed uids before the array conversion.
+			utils.SetErrorResponse(requestMap, errorResponseMap, 1, "FileDescriptor uid malformed")
+			return errorResponseMap
+		}
 		ftInitData.Uid = [utils.UIDLEN]byte(uidByte)
 		ftInitData.Path = "./"  //get it from statestorage when vss-tools have updated.
 		ftChannel <- ftInitData
@@ -708,7 +745,7 @@ func initiateFileTransfer(requestMap map[string]interface{}, nodeType string, pa
 			utils.SetErrorResponse(requestMap, errorResponseMap, 7, "") //service_unavailable
 			return errorResponseMap
 		}
-		
+
 	} else if requestMap["action"] == "get" && nodeType == utils.SENSOR { //upload
 		if requestMap["path"] != nil {
 			path := requestMap["path"].(string)
@@ -759,7 +796,15 @@ func getInternalFileName(path string) (string, string) {  // maps between tree p
 
 func getFileDescriptorData(value interface{}) (string, string, string) { // {"name": "xxx","hash": "yyy","uid": "zzz"}
 	var name, hash, uid string
-	for k, v := range value.(map[string]interface{}) {
+	// Type-assert defensively. The caller (initiateFileTransfer)
+	// passes requestMap["value"] straight through from client JSON,
+	// and a non-object value (bare string, array, etc.) used to
+	// panic the daemon here.
+	valueMap, ok := value.(map[string]interface{})
+	if !ok {
+		return "", "", ""
+	}
+	for k, v := range valueMap {
 		switch vv := v.(type) {
 		case string:
 //			utils.Info.Println(k, "is string", vv)


### PR DESCRIPTION
Fourth pass over network-facing and client-facing code paths. Six fixes covering panic-prevention and path-traversal hardening on inputs arriving from the network or from a peer server.

### 1. `vissv2server.go::issueServiceRequest` — `dt[:5]` panic on short datatypes

```go
if requestMap["action"] == "set" && strings.Contains(utils.VSSgetDatatype(searchData[0].NodeHandle)[:5], "Types") {
```

Panics on any leaf datatype shorter than 5 characters (`int8` = 4) and on branch nodes where `VSSgetDatatype` returns `""`. A single `set` request against an `int8` actuator crashes the daemon. Replaced with `strings.HasPrefix(dt, "Types")` plus a defensive type-assert on `requestMap["value"]` for the struct-validation path.

### 2. `vissv2server.go::initiateFileTransfer` + `getFileDescriptorData` — unchecked type-assert + `[N]byte(slice)` panic

Three issues stacked on the FileDescriptor `set` path:

- `requestMap["value"].(interface{})` is a no-op cast that doesn't protect against a non-object value.
- `getFileDescriptorData` then does `value.(map[string]interface{})` unguarded — panics if the client sent e.g. a bare string for `value`.
- `[utils.UIDLEN]byte(uidByte)` panics in Go ≥1.20 when `len(uidByte) != UIDLEN`. A short or empty `uid` field crashes the daemon.

Reject nil/malformed values, type-assert the map defensively inside `getFileDescriptorData`, and length-check `uidByte` before the array conversion.

### 3. `serviceMgr.go::processHistoryGet` — sibling of `processHistoryCtrl`

Same class as the bug patched in #120. Three unchecked `.(string)` assertions on `requestMap[...]` and an unguarded `historyList[index]` read after a `-1` from `getHistoryListIndex`. Apply the same defensive pattern: ok-check the type assertions, reject unknown paths, log malformed periods.

### 4. `client/.../filetransfer_client.go::uploadFile` — server-controlled filename → arbitrary client-side file write

```go
ulFile, hash, uidString = getFileDescriptorData(responseMap["value"])
...
file, err := os.Create(ulFile)  // overwriting any existing file...
```

A compromised or MITM'd server returns `value.name = "../../etc/cron.d/owned"` and the client writes attacker-supplied chunk data there. Adds `safeServerFilename` that rejects empty names, path separators, `..`, and absolute paths.

### 5. `feeder/feeder-template/feederv4/feederv4.go` — wrong index in `slices.Delete`

```go
for i := 0; i < len(pathList); i++ {
    if onNotificationList(pathList[i].(string)) != -1 {
        notificationList = slices.Delete(notificationList, i, i+1)
    }
}
```

`i` indexes `pathList`, not `notificationList`. When `len(pathList) > len(notificationList)` this panics on OOB; otherwise it deletes the wrong entry. Use the index returned by `onNotificationList`, and type-assert defensively.

### 6. `mqttMgr.go::createSubscribeClient` + `publishMessage` — `os.Exit(1)` on broker error kills the entire server

`mqttMgr` runs in-process inside `vissv2server`. A transient broker outage or an attacker who can speak to the broker drops all WS/HTTP/UDS/gRPC clients along with MQTT. Replaced with log + return so other transports continue serving.

### Verification

`go build` clean across all five touched packages. Diff: +137 / −19 across 5 files.