### PR TITLE
Refactor: extract WS session dispatch helpers (3 of 6)

### DIFF
--- a/server/vissv2server/wsMgr/wsMgr.go
+++ b/server/vissv2server/wsMgr/wsMgr.go
@@ -365,6 +365,38 @@ func compressPaths(respMessage string, sortedList []string) string {
 	return respMessage
 }
 
+// handleWsTransportResponse processes a single response from the server
+// core: applies compression-response post-processing and forwards to
+// the connected WS client via RemoveRoutingForwardResponse. Extracted
+// from WsMgrInit's for/select loop so the response path can be unit-
+// tested independently of the goroutine machinery — see
+// wsMgr_dispatch_test.go.
+func handleWsTransportResponse(respMessage string, transportMgrChan chan string) {
+	utils.Info.Printf("WS mgr hub: Response from server core:%s", respMessage)
+	respMessage = checkCompressionResponse(respMessage)
+	RemoveRoutingForwardResponse(respMessage, transportMgrChan)
+}
+
+// handleWsClientRequest processes a single inbound WS-client request.
+// Extracted from WsMgrInit so the validation / compression /
+// forwarding behaviour can be unit-tested. Matches the shape of
+// handleUdsClientRequest in udsMgr (see PR #124).
+func handleWsClientRequest(reqMessage string, mgrId int, clientId int, transportMgrChan chan string) {
+	if !strings.Contains(reqMessage, `"internal-killsubscriptions"`) {
+		validationError := utils.JsonSchemaValidate(reqMessage)
+		if len(validationError) > 0 {
+			requestMap := make(map[string]interface{})
+			requestMap["action"] = utils.ExtractFromRequest(reqMessage, "action")
+			requestMap["requestId"] = utils.ExtractFromRequest(reqMessage, "requestId")
+			utils.SetErrorResponse(requestMap, errorResponseMap, 0, validationError) //bad_request
+			wsClientChan[clientId] <- utils.FinalizeMessage(errorResponseMap)
+			return
+		}
+		checkCompressionRequest(reqMessage)
+	}
+	utils.AddRoutingForwardRequest(reqMessage, mgrId, clientId, transportMgrChan)
+}
+
 func WsMgrInit(mgrId int, transportMgrChan chan string) {
 	var reqMessage string
 	var clientId int
@@ -378,9 +410,7 @@ func WsMgrInit(mgrId int, transportMgrChan chan string) {
 	for {
 		select {
 		case respMessage := <-transportMgrChan:
-			utils.Info.Printf("WS mgr hub: Response from server core:%s", respMessage)
-			respMessage = checkCompressionResponse(respMessage)
-			RemoveRoutingForwardResponse(respMessage, transportMgrChan)
+			handleWsTransportResponse(respMessage, transportMgrChan)
 			continue
 		case reqMessage = <-wsClientChan[0]: clientId = 0
 		case reqMessage = <-wsClientChan[1]: clientId = 1
@@ -403,18 +433,6 @@ func WsMgrInit(mgrId int, transportMgrChan chan string) {
 		case reqMessage = <-wsClientChan[18]: clientId = 18
 		case reqMessage = <-wsClientChan[19]: clientId = 19
 		}
-		if !strings.Contains(reqMessage, `"internal-killsubscriptions"`) {
-			validationError := utils.JsonSchemaValidate(reqMessage)
-			if len(validationError) > 0 {
-				requestMap := make(map[string]interface{})
-				requestMap["action"] = utils.ExtractFromRequest(reqMessage, "action")
-				requestMap["requestId"] = utils.ExtractFromRequest(reqMessage, "requestId")
-				utils.SetErrorResponse(requestMap, errorResponseMap, 0, validationError) //bad_request
-				wsClientChan[clientId] <- utils.FinalizeMessage(errorResponseMap)
-				continue
-			}
-			checkCompressionRequest(reqMessage)
-		}
-		utils.AddRoutingForwardRequest(reqMessage, mgrId, clientId, transportMgrChan)
+		handleWsClientRequest(reqMessage, mgrId, clientId, transportMgrChan)
 	}
 }

--- a/server/vissv2server/wsMgr/wsMgr_dispatch_test.go
+++ b/server/vissv2server/wsMgr/wsMgr_dispatch_test.go
@@ -1,0 +1,121 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* Tests for handleWsClientRequest and handleWsTransportResponse,
+* extracted from WsMgrInit's for/select loop in PR #126 (this PR).
+* Same shape as the udsMgr dispatch tests landed in PR #124.
+**/
+package wsMgr
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/covesa/vissr/utils"
+)
+
+// TestMain initialises utils.Info / utils.Error and the package-level
+// state used by the helpers (wsClientChan, errorResponseMap, dcCache)
+// so the dispatch functions don't nil-deref under test conditions.
+func TestMain(m *testing.M) {
+	utils.InitLog("wsMgr-dispatch-test.log", os.TempDir(), false, "error")
+	initChannels()
+	initDcCache()
+	os.Exit(m.Run())
+}
+
+// TestHandleWsClientRequest_KillBypassesValidation: an
+// internal-killsubscriptions request skips JSON-schema validation and
+// reaches the routing-forward step.
+func TestHandleWsClientRequest_KillBypassesValidation(t *testing.T) {
+	transportMgrChan := make(chan string, 4)
+	killMsg := `{"action":"internal-killsubscriptions"}`
+
+	done := make(chan struct{})
+	go func() {
+		handleWsClientRequest(killMsg, 0, 0, transportMgrChan)
+		close(done)
+	}()
+	select {
+	case forwarded := <-transportMgrChan:
+		if !strings.Contains(forwarded, "internal-killsubscriptions") {
+			t.Fatalf("forwarded message lost original action: %q", forwarded)
+		}
+	case <-done:
+		t.Fatalf("handler returned without forwarding the killMsg")
+	}
+	<-done
+}
+
+// TestHandleWsClientRequest_DoesNotBlock confirms the function returns
+// through one of the two channels (validation error to wsClientChan,
+// or forward to transportMgrChan) without blocking forever.
+func TestHandleWsClientRequest_DoesNotBlock(t *testing.T) {
+	transportMgrChan := make(chan string, 4)
+	req := `{"action":"get","path":"Vehicle.Speed","requestId":"42"}`
+
+	done := make(chan struct{})
+	go func() {
+		handleWsClientRequest(req, 0, 0, transportMgrChan)
+		close(done)
+	}()
+	select {
+	case <-wsClientChan[0]:
+	case <-transportMgrChan:
+	}
+	<-done
+}
+
+// TestHandleWsTransportResponse_ForwardsToClient verifies that a
+// well-formed response with a RouterId reaches wsClientChan[0] via
+// checkCompressionResponse + RemoveRoutingForwardResponse.
+func TestHandleWsTransportResponse_ForwardsToClient(t *testing.T) {
+	transportMgrChan := make(chan string, 4)
+	resp := `{"action":"get","path":"Vehicle.Speed","value":"100","RouterId":"0?0"}`
+
+	done := make(chan struct{})
+	go func() {
+		handleWsTransportResponse(resp, transportMgrChan)
+		close(done)
+	}()
+
+	select {
+	case forwarded := <-wsClientChan[0]:
+		if !strings.Contains(forwarded, "Vehicle.Speed") {
+			t.Fatalf("client channel received %q; want it to contain Vehicle.Speed", forwarded)
+		}
+	case <-done:
+		t.Fatalf("handler completed without forwarding to wsClientChan[0]")
+	}
+	<-done
+}
+
+// TestHandleWsTransportResponse_ErrorPassesThrough exercises the
+// short-circuit branch of checkCompressionResponse.
+func TestHandleWsTransportResponse_ErrorPassesThrough(t *testing.T) {
+	transportMgrChan := make(chan string, 4)
+	resp := `{"action":"get","error":{"number":"401"},"RouterId":"0?0"}`
+
+	done := make(chan struct{})
+	go func() {
+		handleWsTransportResponse(resp, transportMgrChan)
+		close(done)
+	}()
+
+	select {
+	case forwarded := <-wsClientChan[0]:
+		if !strings.Contains(forwarded, "error") {
+			t.Fatalf("error response wasn't preserved: %q", forwarded)
+		}
+	case <-done:
+		t.Fatalf("handler completed without forwarding")
+	}
+	<-done
+}

--- a/utils/managerhandlers.go
+++ b/utils/managerhandlers.go
@@ -157,6 +157,31 @@ func frontendHttpAppSession(w http.ResponseWriter, req *http.Request, clientChan
 }
 
 // Receives the message from client, sends it to the manager hub, and waits for the response
+// decodeWsRequestPayload converts a raw inbound WS message into the
+// JSON string the manager hub expects. Extracted from
+// frontendWSAppSession so the encoding-dispatch (Protobuf vs JSON
+// passthrough) can be unit-tested without a live WebSocket. See
+// managerhandlers_dispatch_test.go.
+func decodeWsRequestPayload(msg []byte, encoding Encoding) string {
+	if encoding == PROTOBUF {
+		return ProtobufToJson(msg)
+	}
+	return string(msg)
+}
+
+// forwardWsRequest takes a decoded payload from a WS client, forwards
+// it to the manager hub via clientChannel, waits for the hub's
+// response, and pushes the response on to the backend channel for
+// backendWSAppSession to write back to the WS. Extracted from
+// frontendWSAppSession so the per-message request/response handshake
+// can be unit-tested independently of the goroutine machinery — see
+// managerhandlers_dispatch_test.go.
+func forwardWsRequest(payload string, clientChannel chan string, clientBackendChannel chan string) {
+	clientChannel <- payload
+	response := <-clientChannel
+	clientBackendChannel <- response
+}
+
 func frontendWSAppSession(conn *websocket.Conn, clientChannel chan string, clientBackendChannel chan string, clientId int, encoding Encoding) {
 	for {
 		_, msg, err := conn.ReadMessage() // Reads message from websocket
@@ -167,20 +192,22 @@ func frontendWSAppSession(conn *websocket.Conn, clientChannel chan string, clien
 			ReturnWsClientIndex(clientId)
 			return
 		}
-		// Generates payload from encoding
-		var payload string
-		if encoding == PROTOBUF {
-			payload = ProtobufToJson(msg)
-		} else {
-			payload = string(msg)
-		}
+		payload := decodeWsRequestPayload(msg, encoding)
 		Info.Printf("%s request: %s, len=%d", conn.RemoteAddr(), payload, len(payload))
-
-		clientChannel <- payload    // forward to mgr hub,
-		response := <-clientChannel //  and wait for response
-
-		clientBackendChannel <- response // Forwards the response to the backendWSAppSession
+		forwardWsRequest(payload, clientChannel, clientBackendChannel)
 	}
+}
+
+// encodeWsResponsePayload converts a JSON response message into the
+// raw bytes + WebSocket message type expected by gorilla/websocket's
+// WriteMessage. Extracted from backendWSAppSession so the encoding
+// dispatch (Protobuf binary vs JSON text) can be unit-tested without
+// a live WebSocket.
+func encodeWsResponsePayload(message string, encoding Encoding) (messageType int, response []byte) {
+	if encoding == PROTOBUF {
+		return websocket.BinaryMessage, []byte(JsonToProtobuf(message))
+	}
+	return websocket.TextMessage, []byte(message)
 }
 
 // Receives a response for the client through the channel. Then writes the response back to the client.
@@ -194,16 +221,7 @@ func backendWSAppSession(conn *websocket.Conn, clientBackendChannel chan string,
 			break
 		}
 		// Write response/notification back to app client
-		var response []byte
-		var messageType int
-
-		if encoding == PROTOBUF {
-			response = []byte(JsonToProtobuf(message))
-			messageType = websocket.BinaryMessage
-		} else {
-			response = []byte(message)
-			messageType = websocket.TextMessage
-		}
+		messageType, response := encodeWsResponsePayload(message, encoding)
 		err := conn.WriteMessage(messageType, response)
 		if err != nil {
 			Error.Print("App client write error:", err)
@@ -331,7 +349,7 @@ func GetTLSConfig(host string, caCertFile string, certOpt tls.ClientAuthType, se
 	if certOpt > tls.RequestClientCert { // If a client certificate is required, then the CA certificate is needed
 		caCert, err = os.ReadFile(caCertFile)
 		if err != nil {
-			Error.Printf("Error opening cert file", caCertFile, ", error ", err)
+			Error.Printf("Error opening cert file %s, error %v", caCertFile, err)
 			return nil
 		}
 		caCertPool = x509.NewCertPool()

--- a/utils/managerhandlers_dispatch_test.go
+++ b/utils/managerhandlers_dispatch_test.go
@@ -1,0 +1,135 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* Tests for decodeWsRequestPayload, forwardWsRequest, and
+* encodeWsResponsePayload — the three small helpers extracted from
+* frontendWSAppSession / backendWSAppSession in PR #126 (this PR).
+*
+* These cover the encoding-dispatch (PROTOBUF vs JSON passthrough) and
+* the per-message request/response handshake without needing a live
+* WebSocket connection. They mirror the udsMgr / httpMgr / wsMgr
+* dispatch tests landed in PRs #124 and #125.
+**/
+package utils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+// TestMain initialises utils.Info / utils.Error so the helpers can
+// log without nil-deref under test conditions.
+func TestMain(m *testing.M) {
+	InitLog("utils-managerhandlers-dispatch-test.log", os.TempDir(), false, "error")
+	os.Exit(m.Run())
+}
+
+// TestDecodeWsRequestPayload_JsonPassthrough confirms that with the
+// default (non-PROTOBUF) encoding the helper returns the raw bytes
+// unchanged as a string — i.e. the manager hub gets exactly what the
+// WS client wrote.
+func TestDecodeWsRequestPayload_JsonPassthrough(t *testing.T) {
+	msg := []byte(`{"action":"get","path":"Vehicle.Speed","requestId":"42"}`)
+
+	got := decodeWsRequestPayload(msg, NONE)
+
+	if got != string(msg) {
+		t.Fatalf("JSON passthrough mangled the payload:\n got:  %q\n want: %q", got, string(msg))
+	}
+}
+
+// TestDecodeWsRequestPayload_ProtobufBranchIsTaken verifies that the
+// PROTOBUF arm routes to ProtobufToJson rather than the passthrough.
+// ProtobufToJson returns "" when handed bytes that are not a valid
+// pb.ProtobufMessage, which is a reliable signal that the helper
+// dispatched to it (the passthrough would have returned the literal
+// string instead).
+func TestDecodeWsRequestPayload_ProtobufBranchIsTaken(t *testing.T) {
+	msg := []byte("definitely-not-protobuf")
+
+	got := decodeWsRequestPayload(msg, PROTOBUF)
+
+	if got == string(msg) {
+		t.Fatalf("PROTOBUF branch fell through to passthrough; got %q", got)
+	}
+}
+
+// TestForwardWsRequest_PerformsHandshake exercises the
+// send-payload → receive-response → push-to-backend sequence using
+// buffered channels. We pre-load the response on clientChannel so the
+// helper's receive completes without needing a separate goroutine for
+// the hub.
+func TestForwardWsRequest_PerformsHandshake(t *testing.T) {
+	clientChannel := make(chan string, 2)
+	clientBackendChannel := make(chan string, 1)
+
+	// Pre-seed the response so the helper's <-clientChannel returns
+	// immediately after its send.
+	clientChannel <- "fake-hub-response"
+
+	done := make(chan struct{})
+	go func() {
+		forwardWsRequest("the-payload", clientChannel, clientBackendChannel)
+		close(done)
+	}()
+
+	select {
+	case got := <-clientBackendChannel:
+		if got != "fake-hub-response" {
+			t.Fatalf("backend got %q; want the response we pre-seeded", got)
+		}
+	case <-done:
+		t.Fatalf("forwardWsRequest returned without pushing to backend channel")
+	}
+	<-done
+
+	// The helper should have pushed the payload to clientChannel
+	// before reading. That send is what the manager hub would
+	// normally pick up, so it should still be queued.
+	select {
+	case forwarded := <-clientChannel:
+		if forwarded != "the-payload" {
+			t.Fatalf("clientChannel got %q; want %q", forwarded, "the-payload")
+		}
+	default:
+		t.Fatalf("payload was never sent on clientChannel")
+	}
+}
+
+// TestEncodeWsResponsePayload_JsonReturnsTextMessage confirms the
+// default (non-PROTOBUF) arm returns gorilla's TextMessage frame type
+// and the raw bytes of the input string.
+func TestEncodeWsResponsePayload_JsonReturnsTextMessage(t *testing.T) {
+	message := `{"action":"get","path":"Vehicle.Speed","value":"100"}`
+
+	mt, payload := encodeWsResponsePayload(message, NONE)
+
+	if mt != websocket.TextMessage {
+		t.Fatalf("JSON arm returned message type %d; want websocket.TextMessage (%d)", mt, websocket.TextMessage)
+	}
+	if string(payload) != message {
+		t.Fatalf("JSON arm mangled the payload:\n got:  %q\n want: %q", string(payload), message)
+	}
+}
+
+// TestEncodeWsResponsePayload_ProtobufReturnsBinaryMessage exercises
+// the PROTOBUF arm and confirms gorilla's BinaryMessage frame type is
+// returned. We don't pin the serialised bytes themselves because the
+// proto schema may change; the dispatch is what matters here.
+func TestEncodeWsResponsePayload_ProtobufReturnsBinaryMessage(t *testing.T) {
+	message := `{"action":"get","path":"Vehicle.Speed","value":"100","requestId":"42"}`
+
+	mt, _ := encodeWsResponsePayload(message, PROTOBUF)
+
+	if mt != websocket.BinaryMessage {
+		t.Fatalf("PROTOBUF arm returned message type %d; want websocket.BinaryMessage (%d)", mt, websocket.BinaryMessage)
+	}
+}

--- a/utils/pbutils.go
+++ b/utils/pbutils.go
@@ -29,7 +29,7 @@ func JsonToProtobuf(jsonMessage string) []byte {
 	protoMessage = populateProtoFromJson(jsonMessage)
 	serialisedMessage, err := proto.Marshal(protoMessage)
 	if err != nil {
-		Error.Printf("Marshaling error: ", err)
+		Error.Printf("Marshaling error: %v", err)
 		return nil
 	}
 	return serialisedMessage


### PR DESCRIPTION
Third in the refactor+test series after #124 (udsMgr+httpMgr) and #125 (feederv4).

Pulls the per-message bodies out of:

- `WsMgrInit`'s for/select loop in `server/vissv2server/wsMgr/wsMgr.go`
- `frontendWSAppSession` and `backendWSAppSession` in `utils/managerhandlers.go`

into named functions so they can be unit-tested without spinning up real WebSocket connections.

### Extracted

**wsMgr (`server/vissv2server/wsMgr/wsMgr.go`)**
- `handleWsClientRequest` — kill-subscriptions bypass + JSON-schema validation + routing-forward
- `handleWsTransportResponse` — compression check + remove-routing-forward

**utils/managerhandlers (`utils/managerhandlers.go`)**
- `decodeWsRequestPayload` — PROTOBUF vs JSON passthrough on inbound WS bytes
- `forwardWsRequest` — clientChannel send/recv + push to backend channel
- `encodeWsResponsePayload` — `websocket.BinaryMessage` vs `websocket.TextMessage` framing on outbound

Behaviour-preserving — straight code moves, no logic changes.

### Tests added

`server/vissv2server/wsMgr/wsMgr_dispatch_test.go`
- kill-subscriptions request bypasses validation and reaches forwarding
- valid request returns through one of the two channels without blocking
- response with RouterId forwards to `wsClientChan[0]`
- error response short-circuits through `checkCompressionResponse`

`utils/managerhandlers_dispatch_test.go`
- PROTOBUF decode dispatches to `ProtobufToJson`; JSON arm passes raw bytes through
- `forwardWsRequest` performs send/recv/push handshake correctly
- PROTOBUF encode returns `websocket.BinaryMessage`; JSON returns `websocket.TextMessage`

All tests pass with `-race`.

### Drive-by fixes

Two pre-existing `Printf`-without-format-verb warnings in the `utils` package had to be cleaned up, otherwise `go vet ./utils/...` (which `go test` runs) refuses to compile the package and the new dispatch tests can't run:

- `utils/managerhandlers.go:352` — `Error.Printf("Error opening cert file", caCertFile, ", error ", err)` → proper format string
- `utils/pbutils.go:32` — `Error.Printf("Marshaling error: ", err)` → proper format string

Both were producing garbled log output as-is.

### Depends on

PRs #124 and #125 merging upstream before the broader package will build cleanly outside the scope of these new tests (same caveat as on the previous PRs in the series). The `wsMgr` and `utils` tests themselves pass on this branch in isolation.