### PR TITLE
Refactor: extract gRPC dispatch helpers (4 of 6)

### DIFF
--- a/server/vissv2server/grpcMgr/grpcMgr.go
+++ b/server/vissv2server/grpcMgr/grpcMgr.go
@@ -220,35 +220,47 @@ func initGrpcServer() {
 	}
 }
 
+// dispatchGrpcUnaryRequest sends a JSON request payload to the manager
+// hub via grpcClientChan[0], waits for the response on a freshly
+// allocated channel, and returns it. Used by the three unary RPC
+// stubs (GetRequest, SetRequest, UnsubscribeRequest) which all share
+// the same per-message handshake. Extracted in PR #127 so the
+// handshake can be unit-tested without a live gRPC server. See
+// grpcMgr_dispatch_test.go.
+func dispatchGrpcUnaryRequest(vssReq string) string {
+	grpcResponseChan := make(chan string)
+	grpcClientChan[0] <- GrpcRequestMessage{vssReq, grpcResponseChan}
+	return <-grpcResponseChan
+}
+
+// classifySubscribeResponse inspects a response coming back from the
+// manager hub during a streaming subscribe RPC and tells the caller
+// whether the response indicates an error (subscribe should
+// terminate) or a kill message (the unsubscribe sibling told us to
+// stop). Extracted from SubscribeRequest's response arm in PR #127 so
+// the classification logic can be table-tested without a live gRPC
+// stream. See grpcMgr_dispatch_test.go.
+func classifySubscribeResponse(vssResp string) (isError bool, isKill bool) {
+	isError = strings.Contains(vssResp, `"error"`)
+	isKill = strings.Contains(vssResp, KILL_MESSAGE)
+	return
+}
+
 func (s *Server) GetRequest(ctx context.Context, in *pb.GetRequestMessage) (*pb.GetResponseMessage, error) {
 	vssReq := utils.GetRequestPbToJson(in)
-	grpcResponseChan := make(chan string)
-	var grpcRequestMessage = GrpcRequestMessage{vssReq, grpcResponseChan}
-	utils.Info.Println(grpcRequestMessage.VssReq)
-	grpcClientChan[0] <- grpcRequestMessage // forward to mgr hub,
-	vssResp := <-grpcResponseChan           //  and wait for response
-	pbResp := utils.GetResponseJsonToPb(vssResp)
-	return pbResp, nil
+	utils.Info.Println(vssReq)
+	vssResp := dispatchGrpcUnaryRequest(vssReq)
+	return utils.GetResponseJsonToPb(vssResp), nil
 }
 
 func (s *Server) SetRequest(ctx context.Context, in *pb.SetRequestMessage) (*pb.SetResponseMessage, error) {
-	vssReq := utils.SetRequestPbToJson(in)
-	grpcResponseChan := make(chan string)
-	var grpcRequestMessage = GrpcRequestMessage{vssReq, grpcResponseChan}
-	grpcClientChan[0] <- grpcRequestMessage // forward to mgr hub,
-	vssResp := <-grpcResponseChan           //  and wait for response
-	pbResp := utils.SetResponseJsonToPb(vssResp)
-	return pbResp, nil
+	vssResp := dispatchGrpcUnaryRequest(utils.SetRequestPbToJson(in))
+	return utils.SetResponseJsonToPb(vssResp), nil
 }
 
 func (s *Server) UnsubscribeRequest(ctx context.Context, in *pb.UnsubscribeRequestMessage) (*pb.UnsubscribeResponseMessage, error) {
-	vssReq := utils.UnsubscribeRequestPbToJson(in)
-	grpcResponseChan := make(chan string)
-	var grpcRequestMessage = GrpcRequestMessage{vssReq, grpcResponseChan}
-	grpcClientChan[0] <- grpcRequestMessage // forward to mgr hub,
-	vssResp := <-grpcResponseChan           //  and wait for response
-	pbResp := utils.UnsubscribeResponseJsonToPb(vssResp)
-	return pbResp, nil
+	vssResp := dispatchGrpcUnaryRequest(utils.UnsubscribeRequestPbToJson(in))
+	return utils.UnsubscribeResponseJsonToPb(vssResp), nil
 }
 
 func (s *Server) SubscribeRequest(in *pb.SubscribeRequestMessage, stream pb.VISS_SubscribeRequestServer) error {
@@ -266,10 +278,11 @@ func (s *Server) SubscribeRequest(in *pb.SubscribeRequestMessage, stream pb.VISS
 			resetGrpcRoutingData(subscribeClientId)
 			return nil
 		case vssResp := <-grpcResponseChan: //  forward subscribe response and following events
-			if strings.Contains(vssResp, `"error"`) { // error message
+			isError, isKill := classifySubscribeResponse(vssResp)
+			if isError { // error message
 				return nil
 			}
-			if strings.Contains(vssResp, KILL_MESSAGE) { //issued by unsubscribe thread
+			if isKill { // issued by unsubscribe thread
 				clientId := extractClientId(vssResp)
 				resetGrpcRoutingData(clientId)
 				return nil
@@ -293,6 +306,42 @@ func extractClientId(killMessage string) int { // mesage contains clientId:xyz
 	return clientId
 }
 
+// isMultipleEventsRequest classifies a VSS request as one that will
+// produce a stream of events (i.e. an active subscribe) rather than a
+// one-shot response. Used by handleGrpcNewClientSession to set up the
+// right routing flag. Extracted in PR #127 so the classification can
+// be table-tested.
+func isMultipleEventsRequest(vssReq string) bool {
+	return !strings.Contains(vssReq, "unsubscribe") && strings.Contains(vssReq, "subscribe")
+}
+
+// handleGrpcTransportResponse logs the response coming back from the
+// manager hub and routes it back to the original gRPC client via
+// RemoveRoutingForwardResponse. Extracted from GrpcMgrInit's
+// for/select loop in PR #127.
+func handleGrpcTransportResponse(respMessage string) {
+	utils.Info.Printf("gRPC mgr hub: Response from server core:%s", respMessage)
+	RemoveRoutingForwardResponse(respMessage)
+}
+
+// handleGrpcNewClientSession allocates a new gRPC clientId, sets up
+// routing data, and either forwards the request to the transport
+// manager or short-circuits with a max-clients error response.
+// Extracted from GrpcMgrInit's for/select loop in PR #127 so the
+// allocation/short-circuit behaviour can be unit-tested.
+func handleGrpcNewClientSession(reqMessage GrpcRequestMessage, mgrId int, transportMgrChan chan string) {
+	clientId := getClientId()
+	utils.Info.Print("****************** New gRPC client session ************************: " + reqMessage.VssReq + " clientId=" + strconv.Itoa(clientId))
+	if clientId != -1 {
+		isMultipleEvents := isMultipleEventsRequest(reqMessage.VssReq)
+		setGrpcRoutingData(clientId, reqMessage.GrpcRespChan, isMultipleEvents)
+		utils.AddRoutingForwardRequest(reqMessage.VssReq, mgrId, clientId, transportMgrChan)
+		return
+	}
+	utils.Warning.Printf("Max no of gRPC clients reached.")
+	reqMessage.GrpcRespChan <- `{"action": "get","requestId": "9999","error": {"number": "404", "reason": "max_client_sessions", "description": "Max no of gRPC client sessions reached."},"ts": "2000-01-01T13:37:00Z"}` // requestId and ts values incorrect
+}
+
 func GrpcMgrInit(mgrId int, transportMgrChan chan string) {
 	utils.ReadTransportSecConfig()
 	grpcMgrId = mgrId
@@ -308,22 +357,9 @@ func GrpcMgrInit(mgrId int, transportMgrChan chan string) {
 	for {
 		select {
 		case respMessage := <-transportMgrChan:
-			utils.Info.Printf("gRPC mgr hub: Response from server core:%s", respMessage)
-			RemoveRoutingForwardResponse(respMessage)
+			handleGrpcTransportResponse(respMessage)
 		case reqMessage := <-grpcClientChan[0]:
-			clientId := getClientId()
-			utils.Info.Print("****************** New gRPC client session ************************: " + reqMessage.VssReq + " clientId=" + strconv.Itoa(clientId))
-			if clientId != -1 {
-				isMultipleEvents := false
-				if !strings.Contains(reqMessage.VssReq, "unsubscribe") && strings.Contains(reqMessage.VssReq, "subscribe") {
-					isMultipleEvents = true
-				}
-				setGrpcRoutingData(clientId, reqMessage.GrpcRespChan, isMultipleEvents)
-				utils.AddRoutingForwardRequest(reqMessage.VssReq, mgrId, clientId, transportMgrChan)
-			} else {
-				utils.Warning.Printf("Max no of gRPC clients reached.")
-				reqMessage.GrpcRespChan <- `{"action": "get","requestId": "9999","error": {"number": "404", "reason": "max_client_sessions", "description": "Max no of gRPC client sessions reached."},"ts": "2000-01-01T13:37:00Z"}` // requestId and ts values incorrect
-			}
+			handleGrpcNewClientSession(reqMessage, mgrId, transportMgrChan)
 		}
 	}
 }

--- a/server/vissv2server/grpcMgr/grpcMgr_dispatch_test.go
+++ b/server/vissv2server/grpcMgr/grpcMgr_dispatch_test.go
@@ -1,0 +1,266 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* Tests for the per-message dispatch helpers extracted from grpcMgr in
+* PR #127 (this PR):
+*
+*   - dispatchGrpcUnaryRequest   (the shared GetRequest/SetRequest/
+*                                  UnsubscribeRequest handshake)
+*   - classifySubscribeResponse  (error vs kill-message vs normal event)
+*   - isMultipleEventsRequest    (subscribe vs unsubscribe vs one-shot)
+*   - handleGrpcTransportResponse (response arm of GrpcMgrInit)
+*   - handleGrpcNewClientSession (request arm of GrpcMgrInit, including
+*                                  the max-clients short-circuit)
+*   - extractClientId             (parses "kill subscription clientId:N")
+*
+* Same shape as the udsMgr / httpMgr / wsMgr dispatch tests landed in
+* PRs #124 and #126.
+**/
+package grpcMgr
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/covesa/vissr/utils"
+)
+
+// TestMain initialises utils.Info / utils.Error and the package-level
+// state used by the helpers (grpcClientIndexList, grpcRoutingDataList)
+// so the dispatch functions don't nil-deref under test conditions.
+func TestMain(m *testing.M) {
+	utils.InitLog("grpcMgr-dispatch-test.log", os.TempDir(), false, "error")
+	grpcClientIndexList = make([]bool, MAXGRPCCLIENTS)
+	grpcRoutingDataList = make([]GrpcRoutingData, MAXGRPCCLIENTS)
+	resetGrpcStateForTest()
+	os.Exit(m.Run())
+}
+
+// resetGrpcStateForTest puts the package-level routing/client-id
+// tables back into a known-clean state. Called by tests that mutate
+// them so they don't leak state into each other.
+func resetGrpcStateForTest() {
+	initClientIdList()
+	iniGrpcRoutingDataList()
+}
+
+// TestExtractClientId pins the parsing of the "kill subscription
+// clientId:N" message the unsubscribe thread sends to the subscribe
+// thread. extractClientId is one line but the message format is the
+// contract between two goroutines, so a regression here would be
+// silent.
+func TestExtractClientId(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want int
+	}{
+		{"kill subscription clientId:5", 5},
+		{"kill subscription clientId:42", 42},
+		{"kill subscription clientId:0", 0},
+		{"x:99", 99},
+	}
+	for _, tc := range cases {
+		if got := extractClientId(tc.msg); got != tc.want {
+			t.Errorf("extractClientId(%q) = %d; want %d", tc.msg, got, tc.want)
+		}
+	}
+}
+
+// TestIsMultipleEventsRequest covers the predicate that decides
+// whether a request will produce a stream of events (active
+// subscribe) versus a one-shot response. The tricky case is
+// "unsubscribe" — it contains "subscribe" as a substring and must
+// still return false.
+func TestIsMultipleEventsRequest(t *testing.T) {
+	cases := []struct {
+		req  string
+		want bool
+	}{
+		{`{"action":"subscribe","path":"Vehicle.Speed","requestId":"1"}`, true},
+		{`{"action":"unsubscribe","subscriptionId":"abc","requestId":"2"}`, false},
+		{`{"action":"get","path":"Vehicle.Speed","requestId":"3"}`, false},
+		{`{"action":"set","path":"Vehicle.Speed","value":"100","requestId":"4"}`, false},
+		{``, false},
+	}
+	for _, tc := range cases {
+		if got := isMultipleEventsRequest(tc.req); got != tc.want {
+			t.Errorf("isMultipleEventsRequest(%q) = %v; want %v", tc.req, got, tc.want)
+		}
+	}
+}
+
+// TestClassifySubscribeResponse pins the classification used by the
+// streaming SubscribeRequest arm — error short-circuit vs kill-message
+// short-circuit vs ordinary subscribe event.
+func TestClassifySubscribeResponse(t *testing.T) {
+	cases := []struct {
+		resp         string
+		wantIsError  bool
+		wantIsKill   bool
+	}{
+		{`{"action":"subscribe","error":{"number":"401"},"requestId":"1"}`, true, false},
+		{"kill subscription clientId:5", false, true},
+		{`{"action":"subscribe","subscriptionId":"abc","ts":"2026-01-01T00:00:00Z"}`, false, false},
+		{``, false, false},
+	}
+	for _, tc := range cases {
+		gotErr, gotKill := classifySubscribeResponse(tc.resp)
+		if gotErr != tc.wantIsError || gotKill != tc.wantIsKill {
+			t.Errorf("classifySubscribeResponse(%q) = (%v, %v); want (%v, %v)",
+				tc.resp, gotErr, gotKill, tc.wantIsError, tc.wantIsKill)
+		}
+	}
+}
+
+// TestDispatchGrpcUnaryRequest verifies the shared
+// GetRequest/SetRequest/UnsubscribeRequest handshake: the helper
+// pushes the request onto grpcClientChan[0] and waits for the hub to
+// reply on the per-call response channel. We simulate the hub with a
+// goroutine that reads the request and writes a canned reply.
+func TestDispatchGrpcUnaryRequest(t *testing.T) {
+	resetGrpcStateForTest()
+
+	hubDone := make(chan struct{})
+	go func() {
+		req := <-grpcClientChan[0]
+		if req.VssReq != "the-payload" {
+			t.Errorf("hub got %q; want %q", req.VssReq, "the-payload")
+		}
+		req.GrpcRespChan <- "the-response"
+		close(hubDone)
+	}()
+
+	resultCh := make(chan string, 1)
+	go func() { resultCh <- dispatchGrpcUnaryRequest("the-payload") }()
+
+	select {
+	case got := <-resultCh:
+		if got != "the-response" {
+			t.Fatalf("dispatchGrpcUnaryRequest returned %q; want %q", got, "the-response")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("dispatchGrpcUnaryRequest did not return within 1s")
+	}
+	<-hubDone
+}
+
+// TestHandleGrpcNewClientSession_AllocatesClientAndForwards exercises
+// the happy path: a clientId is available, routing data is set, and
+// the request is forwarded to the transport manager.
+func TestHandleGrpcNewClientSession_AllocatesClientAndForwards(t *testing.T) {
+	resetGrpcStateForTest()
+	transportMgrChan := make(chan string, 4)
+	respChan := make(chan string, 1)
+	req := GrpcRequestMessage{
+		VssReq:       `{"action":"get","path":"Vehicle.Speed","requestId":"7"}`,
+		GrpcRespChan: respChan,
+	}
+
+	handleGrpcNewClientSession(req, 0, transportMgrChan)
+
+	// We should see exactly one message forwarded to the transport
+	// manager, and respChan should not have received a max-clients
+	// error.
+	select {
+	case forwarded := <-transportMgrChan:
+		if !strings.Contains(forwarded, "Vehicle.Speed") {
+			t.Fatalf("forwarded message lost the original payload: %q", forwarded)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("nothing forwarded to transportMgrChan")
+	}
+	select {
+	case errResp := <-respChan:
+		t.Fatalf("respChan should be empty on the happy path; got %q", errResp)
+	default:
+	}
+}
+
+// TestHandleGrpcNewClientSession_MaxClientsReturnsError fills every
+// slot in grpcClientIndexList so getClientId returns -1, then
+// confirms the helper pushes the canned max-clients error back to the
+// caller instead of forwarding.
+func TestHandleGrpcNewClientSession_MaxClientsReturnsError(t *testing.T) {
+	resetGrpcStateForTest()
+	for i := 0; i < MAXGRPCCLIENTS; i++ {
+		grpcClientIndexList[i] = true
+	}
+	transportMgrChan := make(chan string, 4)
+	respChan := make(chan string, 1)
+	req := GrpcRequestMessage{
+		VssReq:       `{"action":"get","path":"Vehicle.Speed","requestId":"7"}`,
+		GrpcRespChan: respChan,
+	}
+
+	handleGrpcNewClientSession(req, 0, transportMgrChan)
+
+	select {
+	case errResp := <-respChan:
+		if !strings.Contains(errResp, "max_client_sessions") {
+			t.Fatalf("expected max_client_sessions error; got %q", errResp)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("max-clients path did not push error to respChan")
+	}
+	select {
+	case forwarded := <-transportMgrChan:
+		t.Fatalf("nothing should be forwarded on max-clients path; got %q", forwarded)
+	default:
+	}
+}
+
+// TestHandleGrpcTransportResponse_RoutesToRegisteredClient seeds the
+// routing table with a known clientId, sends a response carrying that
+// clientId via the RouterId field, and confirms the trimmed response
+// arrives on the registered client's channel.
+func TestHandleGrpcTransportResponse_RoutesToRegisteredClient(t *testing.T) {
+	resetGrpcStateForTest()
+	clientId := getClientId()
+	if clientId == -1 {
+		t.Fatalf("getClientId returned -1 after reset; routing table likely full")
+	}
+	respChan := make(chan string, 1)
+	if !setGrpcRoutingData(clientId, respChan, false) {
+		t.Fatalf("setGrpcRoutingData refused to register clientId=%d", clientId)
+	}
+
+	// utils.RemoveInternalData expects "RouterId":"mgrId?clientId" with
+	// a comma immediately following the close quote.
+	response := `{"action":"get","RouterId":"0?` +
+		strconv.Itoa(clientId) + `","value":"100"}`
+
+	handleGrpcTransportResponse(response)
+
+	select {
+	case trimmed := <-respChan:
+		if !strings.Contains(trimmed, `"value":"100"`) {
+			t.Fatalf("trimmed response lost the value payload: %q", trimmed)
+		}
+		if strings.Contains(trimmed, "RouterId") {
+			t.Fatalf("RouterId was not stripped from response: %q", trimmed)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("registered client did not receive routed response")
+	}
+}
+
+// TestHandleGrpcTransportResponse_UnknownClientDoesNotPanic covers the
+// "missing routing data" branch — RemoveRoutingForwardResponse should
+// log an error and return, not crash.
+func TestHandleGrpcTransportResponse_UnknownClientDoesNotPanic(t *testing.T) {
+	resetGrpcStateForTest()
+	// clientId 49 is in range but not registered.
+	response := `{"action":"get","RouterId":"0?49","value":"100"}`
+	// Must not panic.
+	handleGrpcTransportResponse(response)
+}
+


### PR DESCRIPTION
Fourth in the refactor+test series after #124 (udsMgr+httpMgr), #125 (feederv4), and #126 (wsMgr).

Pulls the per-message bodies out of `GrpcMgrInit` and the four streaming RPC stubs in `server/vissv2server/grpcMgr/grpcMgr.go` into named functions so they can be unit-tested without spinning up a live gRPC server.

### Extracted

- `dispatchGrpcUnaryRequest` — shared channel handshake used by `GetRequest`, `SetRequest`, and `UnsubscribeRequest`. Previously duplicated verbatim three times.
- `classifySubscribeResponse` — error vs kill-message vs ordinary event classifier from `SubscribeRequest`'s response arm.
- `isMultipleEventsRequest` — the subscribe/unsubscribe predicate used by routing setup. Notably has to treat `"unsubscribe"` as **not** a multiple-events request even though `"unsubscribe"` contains `"subscribe"` — exactly the kind of thing worth a unit test.
- `handleGrpcTransportResponse` — response arm of `GrpcMgrInit`.
- `handleGrpcNewClientSession` — request arm of `GrpcMgrInit`, including the max-clients short-circuit.

The three unary RPCs collapse to two lines each as a result. `SubscribeRequest` keeps its `for/select` shape but its response arm now uses `classifySubscribeResponse` instead of inline `strings.Contains` checks.

### Tests (`server/vissv2server/grpcMgr/grpcMgr_dispatch_test.go`)

| Test | What it pins |
|---|---|
| `TestExtractClientId` | the "kill subscription clientId:N" parse |
| `TestIsMultipleEventsRequest` | subscribe / unsubscribe / get / set / empty |
| `TestClassifySubscribeResponse` | error / kill / normal event / empty |
| `TestDispatchGrpcUnaryRequest` | mocks the hub, verifies request and response on the right channels |
| `TestHandleGrpcNewClientSession_AllocatesClientAndForwards` | happy path: clientId allocated, routing set, request forwarded |
| `TestHandleGrpcNewClientSession_MaxClientsReturnsError` | all slots taken: max-clients error JSON pushed back to caller, nothing forwarded |
| `TestHandleGrpcTransportResponse_RoutesToRegisteredClient` | response with `RouterId` reaches the registered client's channel, `RouterId` stripped |
| `TestHandleGrpcTransportResponse_UnknownClientDoesNotPanic` | missing routing data branch is a log-and-return, not a panic |

All 8 tests pass with `-race`.

### Behaviour preservation

This is a straight code move plus one piece of deduplication (the unary handshake). No logic changes.