### PR TITLE
Refactor: extract vissv2server core dispatch helpers (5 of 6)

### DIFF
--- a/server/vissv2server/vissv2server.go
+++ b/server/vissv2server/vissv2server.go
@@ -358,11 +358,88 @@ func getTokenContext(reqMap map[string]interface{}) string {
 	return ""
 }
 
+// isInternalAction reports whether the request is one of the
+// internal-only control actions (kill-subscriptions, cancel-subscription)
+// that bypass the normal validation/auth path and go straight to
+// serviceDataChan. Extracted from issueServiceRequest in PR #128 so the
+// predicate can be unit-tested. See vissv2server_dispatch_test.go.
+func isInternalAction(action string) bool {
+	return action == "internal-killsubscriptions" || action == "internal-cancelsubscription"
+}
+
+// isUnsubscribeRequest reports whether the request action is the
+// client-driven "unsubscribe" — these are forwarded directly to
+// serviceDataChan from serveRequest without going through the
+// validation/auth pipeline in issueServiceRequest. Extracted in PR #128.
+func isUnsubscribeRequest(action string) bool {
+	return action == "unsubscribe"
+}
+
+// setErrorAndForward fills errorResponseMap with the given error code
+// and description (using the request fields from requestMap) and pushes
+// it to the backend channel for the transport manager identified by
+// tDChanIndex. Extracted in PR #128 — the SetErrorResponse → backendChan
+// → return pattern was duplicated inline six times inside
+// issueServiceRequest, and the function-level deduplication makes the
+// happy path much easier to read.
+func setErrorAndForward(requestMap map[string]interface{}, tDChanIndex int, errorIndex int, description string) {
+	utils.SetErrorResponse(requestMap, errorResponseMap, errorIndex, description)
+	backendChan[tDChanIndex] <- errorResponseMap
+}
+
+// expandPathFilter takes the Parameter from a "paths" filter and the
+// request's rootPath, and returns the fully-qualified search paths.
+// The parameter is either a single path string or a JSON array of path
+// strings. Returns (paths, false) on malformed JSON so the caller can
+// emit the appropriate bad-request response. Extracted from
+// issueServiceRequest's filter loop in PR #128.
+func expandPathFilter(parameter string, rootPath string) ([]string, bool) {
+	if strings.Contains(parameter, "[") {
+		var searchPath []string
+		if err := json.Unmarshal([]byte(parameter), &searchPath); err != nil {
+			return nil, false
+		}
+		for i := range searchPath {
+			searchPath[i] = rootPath + "." + utils.UrlToPath(searchPath[i])
+		}
+		return searchPath, true
+	}
+	return []string{rootPath + "." + utils.UrlToPath(parameter)}, true
+}
+
+// authorizeAccess runs the per-request authorization check used by
+// issueServiceRequest. It encapsulates the (slightly tricky) logic of
+// when the auth token is actually consulted:
+//   - no authorization header  → errorCode 2 (auth required)
+//   - non-set request and the resource is write-only (validation%10==2
+//     would mean read-also-restricted) → skip the check entirely
+//   - authorization header present but not a string → errorCode 1
+//   - otherwise → delegate to verifyToken
+//
+// Extracted from issueServiceRequest in PR #128 so the dispatch
+// branches can be table-tested without the atsChannel goroutine.
+// (The verifyToken delegation path itself still requires a live ats
+// goroutine and is not covered by the new tests — same as before.)
+func authorizeAccess(requestMap map[string]interface{}, paths string, maxValidation int) (errorCode int, tokenHandle string, gatingId string) {
+	if requestMap["authorization"] == nil {
+		return 2, "", ""
+	}
+	action, _ := requestMap["action"].(string)
+	if action != "set" && maxValidation%10 != 2 { // no validation for get/sub when resource is write-only
+		return 0, "", ""
+	}
+	authToken, ok := requestMap["authorization"].(string)
+	if !ok {
+		return 1, "", ""
+	}
+	return verifyToken(authToken, action, paths, maxValidation)
+}
+
 func serveRequest(requestMap map[string]interface{}, tDChanIndex int, sDChanIndex int) {
 	if requestMap["path"] != nil {
 		requestMap["path"] = utils.UrlToPath(requestMap["path"].(string)) // replace slash with dot
 	}
-	if requestMap["action"] == "unsubscribe" {
+	if action, _ := requestMap["action"].(string); isUnsubscribeRequest(action) {
 		serviceDataChan[sDChanIndex] <- requestMap
 		return
 	}
@@ -370,7 +447,7 @@ func serveRequest(requestMap map[string]interface{}, tDChanIndex int, sDChanInde
 }
 
 func issueServiceRequest(requestMap map[string]interface{}, tDChanIndex int, sDChanIndex int) {
-	if requestMap["action"] == "internal-killsubscriptions" || requestMap["action"] == "internal-cancelsubscription" {
+	if action, _ := requestMap["action"].(string); isInternalAction(action) {
 		serviceDataChan[sDChanIndex] <- requestMap // internal message
 		return
 	}
@@ -379,8 +456,7 @@ func issueServiceRequest(requestMap map[string]interface{}, tDChanIndex int, sDC
 	if !(rootPath == "HIM" && requestMap["action"] == "get" && requestMap["filter"] != nil) {
 		VSSTreeRoot = utils.SetRootNodePointer(rootPath)
 		if VSSTreeRoot == nil {
-			utils.SetErrorResponse(requestMap, errorResponseMap, 0, "") //bad_request
-			backendChan[tDChanIndex] <- errorResponseMap
+			setErrorAndForward(requestMap, tDChanIndex, 0, "") //bad_request
 			return
 		}
 		requestMap["infoType"] = utils.GetInfoType(VSSTreeRoot)
@@ -396,21 +472,13 @@ func issueServiceRequest(requestMap map[string]interface{}, tDChanIndex int, sDC
 //			utils.Info.Printf("filterList[%d].Type=%s, filterList[%d].Parameter=%s", i, filterList[i].Type, i, filterList[i].Parameter)
 			// PATH FILTER
 			if filterList[i].Type == "paths" {
-				if strings.Contains(filterList[i].Parameter, "[") { // Various paths to search
-					err := json.Unmarshal([]byte(filterList[i].Parameter), &searchPath) // Writes in search path all values in filter
-					if err != nil {
-						utils.Error.Printf("Unmarshal filter path array failed.")
-						utils.SetErrorResponse(requestMap, errorResponseMap, 0, "") //bad_request
-						backendChan[tDChanIndex] <- errorResponseMap
-						return
-					}
-					for i := 0; i < len(searchPath); i++ {
-						searchPath[i] = rootPath + "." + utils.UrlToPath(searchPath[i]) // replaces slash with dot
-					}
-				} else { // Single path to search
-					searchPath = make([]string, 1)
-					searchPath[0] = rootPath + "." + utils.UrlToPath(filterList[i].Parameter) // replaces slash with dot
+				expanded, ok := expandPathFilter(filterList[i].Parameter, rootPath)
+				if !ok {
+					utils.Error.Printf("Unmarshal filter path array failed.")
+					setErrorAndForward(requestMap, tDChanIndex, 0, "") //bad_request
+					return
 				}
+				searchPath = expanded
 				break // only one paths object is allowed
 			}
 
@@ -439,8 +507,7 @@ func issueServiceRequest(requestMap map[string]interface{}, tDChanIndex int, sDC
 				}
 				}
 				utils.Error.Printf("Metadata error")
-				utils.SetErrorResponse(requestMap, errorResponseMap, 0, "") //bad_request
-				backendChan[tDChanIndex] <- errorResponseMap
+				setErrorAndForward(requestMap, tDChanIndex, 0, "") //bad_request
 				return
 			}
 		}
@@ -464,15 +531,13 @@ func issueServiceRequest(requestMap map[string]interface{}, tDChanIndex int, sDC
 			paths += "\"" + string(searchData[i].NodePath[:pathLen]) + "\", "
 		}
 		if matches == 0 {
-			utils.SetErrorResponse(requestMap, errorResponseMap, 6, "") //unavailable_data
-			backendChan[tDChanIndex] <- errorResponseMap
+			setErrorAndForward(requestMap, tDChanIndex, 6, "") //unavailable_data
 			return
 		}
 		if requestMap["action"] == "set" && strings.Contains(utils.VSSgetDatatype(searchData[0].NodeHandle)[:5], "Types") {
 			res := verifyStruct(requestMap["value"].(map[string]interface{}), utils.VSSgetDatatype(searchData[0].NodeHandle), 0)
 			if res != "ok" {
-				utils.SetErrorResponse(requestMap, errorResponseMap, 1, res) //invalid_data
-				backendChan[tDChanIndex] <- errorResponseMap
+				setErrorAndForward(requestMap, tDChanIndex, 1, res) //invalid_data
 				return
 			}
 		}
@@ -486,8 +551,7 @@ func issueServiceRequest(requestMap map[string]interface{}, tDChanIndex int, sDC
 	}
 	errorIndex, errorDescription := validateData(requestMap, searchData, filterList)
 	if errorIndex != -1 {
-		utils.SetErrorResponse(requestMap, errorResponseMap, errorIndex, errorDescription)
-		backendChan[tDChanIndex] <- errorResponseMap
+		setErrorAndForward(requestMap, tDChanIndex, errorIndex, errorDescription)
 		return
 	}
 	paths = paths[:len(paths)-2]
@@ -506,27 +570,16 @@ func issueServiceRequest(requestMap map[string]interface{}, tDChanIndex int, sDC
 	case 1:
 		fallthrough
 	case 2:
-		errorCode := 0
-		if requestMap["authorization"] == nil {
-			errorCode = 2
-		} else {
-			if requestMap["action"] == "set" || maxValidation%10 == 2 { // no validation for get/subscribe when validation is 1 (write-only)
-				// checks if requestmap authorization is a string
-				if authToken, ok := requestMap["authorization"].(string); !ok {
-					errorCode = 1
-				} else {
-					errorCode, tokenHandle, gatingId = verifyToken(authToken, requestMap["action"].(string), paths, maxValidation)
-				}
-			}
-		}
+		errorCode, handle, gId := authorizeAccess(requestMap, paths, maxValidation)
+		tokenHandle = handle
+		gatingId = gId
 		if errorCode != 0 {
 			setTokenErrorResponse(requestMap, errorCode)
 			backendChan[tDChanIndex] <- errorResponseMap
 			return
 		}
 	default: // should not be possible...
-		utils.SetErrorResponse(requestMap, errorResponseMap, 7, "") //service_unavailable
-		backendChan[tDChanIndex] <- errorResponseMap
+		setErrorAndForward(requestMap, tDChanIndex, 7, "") //service_unavailable
 		return
 	}
 	if totalMatches == 1 {

--- a/server/vissv2server/vissv2server_dispatch_test.go
+++ b/server/vissv2server/vissv2server_dispatch_test.go
@@ -1,0 +1,269 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* Tests for the helpers extracted from serveRequest / issueServiceRequest
+* in PR #128 (this PR):
+*
+*   - isInternalAction       (kill/cancel-subscriptions predicate)
+*   - isUnsubscribeRequest   (client-driven unsubscribe predicate)
+*   - setErrorAndForward     (dedup of the SetErrorResponse -> backendChan
+*                              -> return pattern that appeared 6x inline)
+*   - expandPathFilter       (single path vs JSON-array path-filter expansion)
+*   - authorizeAccess        (token-verification dispatch logic, minus the
+*                              live verifyToken delegation path which needs
+*                              the atsChannel goroutine)
+*
+* Same shape as the dispatch tests in PRs #124 (udsMgr+httpMgr), #125
+* (feederv4), #126 (wsMgr), and #127 (grpcMgr).
+**/
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/covesa/vissr/utils"
+)
+
+// TestMain initialises utils.Info / utils.Error and provides a small
+// buffered backendChan slice so setErrorAndForward (which is called by
+// several of the tests below) doesn't block. We deliberately don't call
+// the production initChannels() — its channels are unbuffered, and only
+// one transport-manager slot is needed for these tests.
+func TestMain(m *testing.M) {
+	utils.InitLog("vissv2server-dispatch-test.log", os.TempDir(), false, "error")
+	backendChan = []chan map[string]interface{}{
+		make(chan map[string]interface{}, 4),
+	}
+	os.Exit(m.Run())
+}
+
+// resetErrorResponseMap clears the shared errorResponseMap between
+// tests so leftover keys from a previous case don't taint the next
+// assertion. (errorResponseMap is a package-level global; the
+// production code mutates it in place under the assumption that only
+// one request is being processed at a time.)
+func resetErrorResponseMap() {
+	for k := range errorResponseMap {
+		delete(errorResponseMap, k)
+	}
+}
+
+// TestIsInternalAction covers the predicate that decides whether a
+// request bypasses the validation/auth pipeline and goes straight to
+// serviceDataChan.
+func TestIsInternalAction(t *testing.T) {
+	cases := []struct {
+		action string
+		want   bool
+	}{
+		{"internal-killsubscriptions", true},
+		{"internal-cancelsubscription", true},
+		{"get", false},
+		{"set", false},
+		{"subscribe", false},
+		{"unsubscribe", false},
+		{"", false},
+		// Defensive: must match the exact action string, not a prefix.
+		{"internal-killsubscriptions-extra", false},
+	}
+	for _, tc := range cases {
+		if got := isInternalAction(tc.action); got != tc.want {
+			t.Errorf("isInternalAction(%q) = %v; want %v", tc.action, got, tc.want)
+		}
+	}
+}
+
+// TestIsUnsubscribeRequest pins the predicate used by serveRequest to
+// short-circuit unsubscribe requests to serviceDataChan.
+func TestIsUnsubscribeRequest(t *testing.T) {
+	cases := []struct {
+		action string
+		want   bool
+	}{
+		{"unsubscribe", true},
+		{"subscribe", false},
+		{"get", false},
+		{"set", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isUnsubscribeRequest(tc.action); got != tc.want {
+			t.Errorf("isUnsubscribeRequest(%q) = %v; want %v", tc.action, got, tc.want)
+		}
+	}
+}
+
+// TestExpandPathFilter_SinglePath confirms a bare path string gets the
+// rootPath prefix and URL-to-dot translation applied.
+func TestExpandPathFilter_SinglePath(t *testing.T) {
+	got, ok := expandPathFilter("Speed", "Vehicle")
+	if !ok {
+		t.Fatalf("expandPathFilter returned ok=false for a valid single path")
+	}
+	want := []string{"Vehicle.Speed"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expandPathFilter single-path: got %v, want %v", got, want)
+	}
+}
+
+// TestExpandPathFilter_PathArray confirms a JSON array parameter is
+// expanded into a slice of rooted paths.
+func TestExpandPathFilter_PathArray(t *testing.T) {
+	got, ok := expandPathFilter(`["Speed","Acceleration.Longitudinal"]`, "Vehicle")
+	if !ok {
+		t.Fatalf("expandPathFilter returned ok=false for a valid JSON array")
+	}
+	want := []string{"Vehicle.Speed", "Vehicle.Acceleration.Longitudinal"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expandPathFilter path-array: got %v, want %v", got, want)
+	}
+}
+
+// TestExpandPathFilter_MalformedJsonReturnsFalse confirms the helper
+// signals failure (ok=false) on broken JSON so the caller can emit
+// the appropriate bad-request response.
+func TestExpandPathFilter_MalformedJsonReturnsFalse(t *testing.T) {
+	got, ok := expandPathFilter(`["Speed","Acceleration"`, "Vehicle") // missing closing bracket
+	if ok {
+		t.Fatalf("expandPathFilter should have returned ok=false on malformed JSON; got %v", got)
+	}
+	if got != nil {
+		t.Fatalf("expandPathFilter should return nil paths on failure; got %v", got)
+	}
+}
+
+// TestSetErrorAndForward verifies the helper populates
+// errorResponseMap with the right error metadata for the given index
+// and pushes it onto backendChan[tDChanIndex]. The alt-description
+// case also verifies that the override message replaces the default
+// for the chosen index.
+func TestSetErrorAndForward(t *testing.T) {
+	cases := []struct {
+		name        string
+		errorIndex  int
+		altDesc     string // alternate description override; "" means use default
+		wantNumber  string
+		wantReason  string
+		wantDescIs  string // expected exact description; "" means just non-empty
+	}{
+		{"bad_request", 0, "", "400", "bad_request", ""},
+		{"invalid_data", 1, "", "400", "invalid_data", ""},
+		{"unavailable_data", 6, "", "404", "unavailable_data", ""},
+		{"service_unavailable", 7, "", "503", "service_unavailable", ""},
+		{"alt_description", 1, "Forbidden write", "400", "invalid_data", "Forbidden write"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetErrorResponseMap()
+			// Drain any leftover messages on backendChan[0].
+			drainBackendChan()
+
+			req := map[string]interface{}{
+				"action":    "get",
+				"requestId": "42",
+				"RouterId":  "0?0",
+			}
+			setErrorAndForward(req, 0, tc.errorIndex, tc.altDesc)
+
+			select {
+			case got := <-backendChan[0]:
+				errMap, ok := got["error"].(map[string]interface{})
+				if !ok {
+					t.Fatalf("forwarded map missing error sub-map; got %v", got)
+				}
+				if errMap["number"] != tc.wantNumber {
+					t.Errorf("error.number = %v; want %v", errMap["number"], tc.wantNumber)
+				}
+				if errMap["reason"] != tc.wantReason {
+					t.Errorf("error.reason = %v; want %v", errMap["reason"], tc.wantReason)
+				}
+				desc, _ := errMap["description"].(string)
+				if tc.wantDescIs != "" && desc != tc.wantDescIs {
+					t.Errorf("error.description = %q; want exactly %q", desc, tc.wantDescIs)
+				}
+				if tc.wantDescIs == "" && desc == "" {
+					t.Errorf("error.description was empty")
+				}
+				// Forwarded action/requestId/RouterId should come from req.
+				if got["action"] != "get" {
+					t.Errorf("forwarded action = %v; want get", got["action"])
+				}
+				if got["requestId"] != "42" {
+					t.Errorf("forwarded requestId = %v; want 42", got["requestId"])
+				}
+				if got["RouterId"] != "0?0" {
+					t.Errorf("forwarded RouterId = %v; want 0?0", got["RouterId"])
+				}
+			case <-time.After(time.Second):
+				t.Fatalf("nothing forwarded to backendChan[0]")
+			}
+		})
+	}
+}
+
+// drainBackendChan empties backendChan[0] without blocking. Used by
+// tests that may have left a message behind from a previous case
+// running under t.Run.
+func drainBackendChan() {
+	for {
+		select {
+		case <-backendChan[0]:
+		default:
+			return
+		}
+	}
+}
+
+// TestAuthorizeAccess_NoAuthorizationHeader covers the "auth required
+// but missing" branch — returns errorCode 2 immediately.
+func TestAuthorizeAccess_NoAuthorizationHeader(t *testing.T) {
+	req := map[string]interface{}{
+		"action":    "set",
+		"requestId": "1",
+		// no "authorization" key
+	}
+	errorCode, handle, gatingId := authorizeAccess(req, "Vehicle.Speed", 1)
+	if errorCode != 2 || handle != "" || gatingId != "" {
+		t.Fatalf("no-auth-header: got (%d, %q, %q); want (2, \"\", \"\")", errorCode, handle, gatingId)
+	}
+}
+
+// TestAuthorizeAccess_GetWithWriteOnlyResourceSkipsCheck covers the
+// "skip the check entirely" branch. Per the original inline comment
+// in issueServiceRequest, validation%10 == 1 means the resource is
+// write-only — so a get/subscribe against it doesn't need the auth
+// path to run, and the helper short-circuits with errorCode 0.
+func TestAuthorizeAccess_GetWithWriteOnlyResourceSkipsCheck(t *testing.T) {
+	req := map[string]interface{}{
+		"action":        "get",
+		"authorization": "some-token",
+	}
+	errorCode, handle, gatingId := authorizeAccess(req, "Vehicle.Speed", 1) // maxValidation%10 == 1
+	if errorCode != 0 || handle != "" || gatingId != "" {
+		t.Fatalf("get-against-write-only: got (%d, %q, %q); want (0, \"\", \"\")", errorCode, handle, gatingId)
+	}
+}
+
+// TestAuthorizeAccess_NonStringAuthorizationFails covers the
+// type-assertion branch — when the authorization header is present
+// but not a string, the helper returns errorCode 1 without trying to
+// hit the ats goroutine.
+func TestAuthorizeAccess_NonStringAuthorizationFails(t *testing.T) {
+	req := map[string]interface{}{
+		"action":        "set", // forces the auth-check path
+		"authorization": 42,    // non-string
+	}
+	errorCode, handle, gatingId := authorizeAccess(req, "Vehicle.Speed", 1)
+	if errorCode != 1 || handle != "" || gatingId != "" {
+		t.Fatalf("non-string-auth: got (%d, %q, %q); want (1, \"\", \"\")", errorCode, handle, gatingId)
+	}
+}


### PR DESCRIPTION
Fifth in the refactor+test series after #124 (udsMgr+httpMgr), #125 (feederv4), #126 (wsMgr), and #127 (grpcMgr).

Unlike the previous PRs in the series, `vissv2server.go` core (`serveRequest` / `issueServiceRequest`) is **not** a for/select loop — so the extraction targets are different. This PR extracts five testable helpers plus does one piece of real deduplication.

### Extracted

| Helper | What it does |
|---|---|
| `isInternalAction(action) bool` | the `kill-subscriptions` / `cancel-subscription` predicate used at the top of `issueServiceRequest` |
| `isUnsubscribeRequest(action) bool` | the client-driven `unsubscribe` predicate used by `serveRequest` |
| `setErrorAndForward(req, tDChanIndex, errorIndex, description)` | the `SetErrorResponse → backendChan → return` pattern that appeared **inline six times** inside `issueServiceRequest` |
| `expandPathFilter(parameter, rootPath) ([]string, bool)` | single-path-vs-JSON-array path-filter expansion, lifted out of the filter loop |
| `authorizeAccess(req, paths, maxValidation) (errorCode, handle, gatingId)` | the token-verification dispatch — no-auth, non-set against write-only resource, non-string auth, otherwise delegate to `verifyToken` |

### Behaviour preservation

Straight extractions plus one piece of deduplication (`setErrorAndForward`). No logic changes.

### Tests added (`server/vissv2server/vissv2server_dispatch_test.go`)

- `TestIsInternalAction` — table of 8 actions including the defensive "must match exact action string, not a prefix" case
- `TestIsUnsubscribeRequest` — table of 5 actions
- `TestExpandPathFilter_SinglePath`
- `TestExpandPathFilter_PathArray`
- `TestExpandPathFilter_MalformedJsonReturnsFalse`
- `TestSetErrorAndForward` — `bad_request`, `invalid_data`, `unavailable_data`, `service_unavailable`, and an alt-description override case
- `TestAuthorizeAccess_NoAuthorizationHeader`
- `TestAuthorizeAccess_GetWithWriteOnlyResourceSkipsCheck`
- `TestAuthorizeAccess_NonStringAuthorizationFails`

All 13 test entries pass with `-race`.

The live `verifyToken` delegation path through `authorizeAccess` still requires the `atsChannel` goroutine, so it is not covered by these new tests — same situation as before the extraction.

### Out of scope for this PR

`initiateFileTransfer` is intentionally left alone here. Its two branches share an `ftChannel` handshake, but the surrounding helpers (`getFileDescriptorData`, `calculateHash`) are already extracted, and mocking the disk reads needed by the upload path was not worth the test plumbing for this PR.