### PR TITLE
Refactor/servicemgr notification arms

### DIFF
--- a/server/vissv2server/serviceMgr/serviceMgr.go
+++ b/server/vissv2server/serviceMgr/serviceMgr.go
@@ -458,7 +458,7 @@ func getIntervalPeriod(opValue string) int { // {"period":"X"}
 	}
 	period, err := strconv.Atoi(intervalData.Period)
 	if err != nil {
-		utils.Error.Printf("getIntervalPeriod: Invalid period=%s", period)
+		utils.Error.Printf("getIntervalPeriod: Invalid period=%q, err=%v", intervalData.Period, err)
 		return -1
 	}
 	return period
@@ -1430,6 +1430,143 @@ func feederReader(udsConn net.Conn, feederName string, feederChannelIndex int) {
 	}
 }
 
+// buildServiceResponseMap returns the standard response skeleton used
+// for replies to dataChan requests inside ServiceMgrInit. Extracted in
+// PR #129 (this PR) so the per-action handlers below can share the
+// setup without duplicating the six-line dance. See
+// serviceMgr_dispatch_test.go.
+func buildServiceResponseMap(requestMap map[string]interface{}) map[string]interface{} {
+	responseMap := make(map[string]interface{})
+	responseMap["RouterId"] = requestMap["RouterId"]
+	responseMap["action"] = requestMap["action"]
+	responseMap["requestId"] = requestMap["requestId"]
+	responseMap["ts"] = utils.GetRfcTime()
+	if requestMap["handle"] != nil {
+		responseMap["authorization"] = requestMap["handle"]
+	}
+	return responseMap
+}
+
+// handleServiceSet processes a "set" action: writes the value via the
+// state-storage backend (setVehicleData) and pushes a success or
+// service_unavailable response back on dataChan. Extracted from
+// ServiceMgrInit's dataChan switch in PR #129.
+func handleServiceSet(requestMap map[string]interface{}, responseMap map[string]interface{}, dataChan chan map[string]interface{}) {
+	var ts string
+	switch requestMap["value"].(type) {
+	case string:
+		ts = setVehicleData(requestMap["path"].(string), requestMap["value"].(string))
+	case map[string]interface{}:
+		data, _ := json.Marshal(requestMap["value"])
+		ts = setVehicleData(requestMap["path"].(string), string(data))
+	}
+	if len(ts) == 0 {
+		utils.SetErrorResponse(requestMap, errorResponseMap, 7, "") //service_unavailable
+		dataChan <- errorResponseMap
+		return
+	}
+	responseMap["ts"] = ts
+	dataChan <- responseMap
+}
+
+// handleServiceGet processes a "get" action: unpacks the path array,
+// validates an optional filter, fetches the data pack via
+// getDataPackMap, and pushes the response on dataChan. Extracted from
+// ServiceMgrInit in PR #129. Error paths emit invalid_data or
+// bad_request as appropriate.
+func handleServiceGet(requestMap map[string]interface{}, responseMap map[string]interface{}, dataChan chan map[string]interface{}) {
+	pathArray := unpackPaths(requestMap["path"].(string))
+	if pathArray == nil {
+		utils.Error.Printf("Unmarshal of path array failed.")
+		utils.SetErrorResponse(requestMap, errorResponseMap, 1, "") //invalid_data
+		dataChan <- errorResponseMap
+		return
+	}
+	var filterList []utils.FilterObject
+	if requestMap["filter"] != nil && requestMap["filter"] != "" {
+		utils.UnpackFilter(requestMap["filter"], &filterList)
+		if len(filterList) == 0 {
+			utils.Error.Printf("Request filter malformed.")
+			utils.SetErrorResponse(requestMap, errorResponseMap, 0, "") //bad_request
+			dataChan <- errorResponseMap
+			return
+		}
+	}
+	dataPack := getDataPackMap(pathArray)
+	responseMap["data"] = dataPack["dpack"]
+	dataChan <- responseMap
+}
+
+// handleServiceUnsubscribe processes a client-driven "unsubscribe"
+// action: deactivates the subscription identified by subscriptionId,
+// forwards the request to the feeder so it can drop its end of the
+// stream, and replies to the client. Returns the updated
+// subscriptionList. On missing or invalid subscriptionId an
+// invalid_data error is sent back. Extracted from ServiceMgrInit in
+// PR #129.
+func handleServiceUnsubscribe(requestMap map[string]interface{}, responseMap map[string]interface{}, dataChan chan map[string]interface{}, subscriptionList []SubscriptionState, toFeederChan chan string) []SubscriptionState {
+	if requestMap["subscriptionId"] != nil {
+		status := -1
+		subscriptId, ok := requestMap["subscriptionId"].(string)
+		if ok == true {
+			status, subscriptionList = deactivateSubscription(subscriptionList, subscriptId)
+			if status != -1 {
+				dataChan <- responseMap
+				toFeederChan <- utils.FinalizeMessage(requestMap)
+				return subscriptionList
+			}
+			delete(requestMap, "subscriptionId")
+		}
+	}
+	utils.SetErrorResponse(requestMap, errorResponseMap, 1, "") //invalid_data
+	dataChan <- errorResponseMap
+	return subscriptionList
+}
+
+// handleInternalKillSubscriptions processes the
+// "internal-killsubscriptions" action: scans the subscription list and
+// removes every entry whose RouterId matches the request. No response
+// is emitted — this is an internal cleanup message. Returns the
+// updated subscriptionList. Extracted from ServiceMgrInit in PR #129.
+func handleInternalKillSubscriptions(requestMap map[string]interface{}, subscriptionList []SubscriptionState) []SubscriptionState {
+	isRemoved := true
+	for isRemoved == true {
+		isRemoved, subscriptionList = scanAndRemoveListItem(subscriptionList, requestMap["RouterId"].(string))
+		utils.Info.Printf("internal-killsubscriptions: RouterId = %s", requestMap["RouterId"].(string))
+	}
+	return subscriptionList
+}
+
+// handleInternalCancelSubscription processes the
+// "internal-cancelsubscription" action used when the AGT cancels a
+// token or consent: looks up the subscription by gatingId, rewrites the
+// request as a synthetic "subscription" error event, pushes it to the
+// client, and removes the subscription from the list. Returns the
+// updated subscriptionList. If the gatingId is not found, the list is
+// returned unchanged. Extracted from ServiceMgrInit in PR #129.
+func handleInternalCancelSubscription(requestMap map[string]interface{}, dataChan chan map[string]interface{}, subscriptionList []SubscriptionState) []SubscriptionState {
+	routerId, subscriptionId := getSubscriptionData(subscriptionList, requestMap["gatingId"].(string))
+	if routerId != "" {
+		requestMap["RouterId"] = routerId
+		requestMap["action"] = "subscription"
+		requestMap["requestId"] = nil
+		requestMap["subscriptionId"] = subscriptionId
+		utils.SetErrorResponse(requestMap, errorResponseMap, 2, "Token expired or consent cancelled.")
+		dataChan <- errorResponseMap
+		_, subscriptionList = scanAndRemoveListItem(subscriptionList, routerId)
+	}
+	return subscriptionList
+}
+
+// handleUnknownAction handles the default arm of the dataChan switch:
+// emits an invalid_data response with "Unknown action" as the message.
+// Extracted from ServiceMgrInit in PR #129 so the default arm is just
+// one line at the call site.
+func handleUnknownAction(requestMap map[string]interface{}, dataChan chan map[string]interface{}) {
+	utils.SetErrorResponse(requestMap, errorResponseMap, 1, "Unknown action") //invalid_data
+	dataChan <- errorResponseMap
+}
+
 func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, stateStorageType string, histSupport bool, dbFile string) {
 	stateDbType = stateStorageType
 	historySupport = histSupport
@@ -1573,60 +1710,21 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 		select {
 		case requestMap := <-dataChan: // request from server core
 //			utils.Info.Printf("Service manager: Request from Server core:%s\n", requestMap["action"].(string))
-			var responseMap = make(map[string]interface{})
-			responseMap["RouterId"] = requestMap["RouterId"]
-			responseMap["action"] = requestMap["action"]
-			responseMap["requestId"] = requestMap["requestId"]
-			responseMap["ts"] = utils.GetRfcTime()
-			if requestMap["handle"] != nil {
-				responseMap["authorization"] = requestMap["handle"]
-			}
+			responseMap := buildServiceResponseMap(requestMap)
 			switch requestMap["action"] {
 			case "invoke": // invokeVehicleService(...
 			case "set":
-				var ts string
-				switch requestMap["value"].(type) {
-					case string:
-						ts = setVehicleData(requestMap["path"].(string), requestMap["value"].(string))
-					case map[string]interface{}:
-						data, _ := json.Marshal(requestMap["value"])
-						ts = setVehicleData(requestMap["path"].(string), string(data))
-				}
-				if len(ts) == 0 {
-					utils.SetErrorResponse(requestMap, errorResponseMap, 7, "") //service_unavailable
-					dataChan <- errorResponseMap
-					break
-				}
-				responseMap["ts"] = ts
-				dataChan <- responseMap
+				handleServiceSet(requestMap, responseMap, dataChan)
 			case "get":
-				pathArray := unpackPaths(requestMap["path"].(string))
-				if pathArray == nil {
-					utils.Error.Printf("Unmarshal of path array failed.")
-					utils.SetErrorResponse(requestMap, errorResponseMap, 1, "") //invalid_data
-					dataChan <- errorResponseMap
-					break
-				}
-				var filterList []utils.FilterObject
-				if requestMap["filter"] != nil && requestMap["filter"] != "" {
-					utils.UnpackFilter(requestMap["filter"], &filterList)
-					if len(filterList) == 0 {
-						utils.Error.Printf("Request filter malformed.")
-						utils.SetErrorResponse(requestMap, errorResponseMap, 0, "") //bad_request
-						dataChan <- errorResponseMap
-						break
-					}
-				}
-				dataPack := getDataPackMap(pathArray)
-/*				if len(dataPack) == 0 {
-					utils.Info.Printf("No historic data available")
-					utils.SetErrorResponse(requestMap, errorResponseMap, 6, "") //unavailable_data
-					dataChan <- errorResponseMap
-					break
-				}*/
-				responseMap["data"] = dataPack["dpack"]
-				dataChan <- responseMap
+				handleServiceGet(requestMap, responseMap, dataChan)
 			case "subscribe":
+				// The subscribe arm is intentionally left inline for now —
+				// it mutates several locals (subscriptionList, subscriptionId)
+				// and sends on three channels (subscriptionChan, CLChannel,
+				// toFeeder), so extracting it cleanly is the next step in
+				// the refactor series. TODO(testing): pull this into
+				// handleServiceSubscribe once the channel ownership story
+				// is sorted.
 				var subscriptionState SubscriptionState
 				subscriptionState.SubscriptionId = subscriptionId
 				subscriptionState.RouterId = requestMap["RouterId"].(string)
@@ -1655,41 +1753,13 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 				subscriptionId++ // not to be incremented elsewhere
 				dataChan <- responseMap
 			case "unsubscribe":
-				if requestMap["subscriptionId"] != nil {
-					status := -1
-					subscriptId, ok := requestMap["subscriptionId"].(string)
-					if ok == true {
-						status, subscriptionList = deactivateSubscription(subscriptionList, subscriptId)
-						if status != -1 {
-							dataChan <- responseMap
-							toFeeder <- utils.FinalizeMessage(requestMap)
-							break
-						}
-						delete(requestMap, "subscriptionId")
-					}
-				}
-				utils.SetErrorResponse(requestMap, errorResponseMap, 1, "") //invalid_data
-				dataChan <- errorResponseMap
+				subscriptionList = handleServiceUnsubscribe(requestMap, responseMap, dataChan, subscriptionList, toFeeder)
 			case "internal-killsubscriptions":
-				isRemoved := true
-				for isRemoved == true {
-					isRemoved, subscriptionList = scanAndRemoveListItem(subscriptionList, requestMap["RouterId"].(string))
-					utils.Info.Printf("internal-killsubscriptions: RouterId = %s", requestMap["RouterId"].(string))
-				}
+				subscriptionList = handleInternalKillSubscriptions(requestMap, subscriptionList)
 			case "internal-cancelsubscription":
-				routerId, subscriptionId := getSubscriptionData(subscriptionList, requestMap["gatingId"].(string))
-				if routerId != "" {
-					requestMap["RouterId"] = routerId
-					requestMap["action"] = "subscription"
-					requestMap["requestId"] = nil
-					requestMap["subscriptionId"] = subscriptionId
-					utils.SetErrorResponse(requestMap, errorResponseMap, 2, "Token expired or consent cancelled.")
-					dataChan <- errorResponseMap
-					_, subscriptionList = scanAndRemoveListItem(subscriptionList, routerId)
-				}
+				subscriptionList = handleInternalCancelSubscription(requestMap, dataChan, subscriptionList)
 			default:
-				utils.SetErrorResponse(requestMap, errorResponseMap, 1, "Unknown action") //invalid_data
-					dataChan <- errorResponseMap
+				handleUnknownAction(requestMap, dataChan)
 			} // switch
 		case <-dummyTickerC:
 			dummyValue++

--- a/server/vissv2server/serviceMgr/serviceMgr.go
+++ b/server/vissv2server/serviceMgr/serviceMgr.go
@@ -1497,6 +1497,68 @@ func handleServiceGet(requestMap map[string]interface{}, responseMap map[string]
 	dataChan <- responseMap
 }
 
+// handleServiceSubscribe processes a "subscribe" action: builds a
+// SubscriptionState from the request, validates the filter, appends
+// it to the subscription list, activates interval/curve-log timers
+// when needed via activateIfIntervalOrCL, and notifies the feeder for
+// curvelog/range/change variants. Returns the updated subscription
+// list and the next subscriptionId. Extracted from ServiceMgrInit's
+// dataChan switch as a follow-up to PR #129 — the inline version
+// carried a TODO(testing) note pointing here.
+//
+// PRE-EXISTING BUGS preserved as-is (file separately for fix):
+//   1. After the empty-FilterList error response, execution falls
+//      through to append the subscription anyway, producing a second
+//      message on dataChan. The original arm had no `break` after the
+//      `dataChan <- errorResponseMap` send and we preserve that bug
+//      here so this stays behaviour-preserving. See the marker below.
+//   2. subscriptionState.Path is dereferenced at index 0 without a
+//      nil check. If unpackPaths returned nil (malformed JSON path
+//      array), this panics. Original code has the same hazard.
+func handleServiceSubscribe(
+	requestMap map[string]interface{},
+	responseMap map[string]interface{},
+	dataChan chan map[string]interface{},
+	subscriptionList []SubscriptionState,
+	subscriptionId int,
+	subscriptionChan chan int,
+	clChannel chan CLPack,
+	toFeederChan chan string,
+) ([]SubscriptionState, int) {
+	var subscriptionState SubscriptionState
+	subscriptionState.SubscriptionId = subscriptionId
+	subscriptionState.RouterId = requestMap["RouterId"].(string)
+	subscriptionState.Path = unpackPaths(requestMap["path"].(string))
+	if requestMap["filter"] == nil || requestMap["filter"] == "" {
+		utils.SetErrorResponse(requestMap, errorResponseMap, 0, "") //bad_request
+		dataChan <- errorResponseMap
+		return subscriptionList, subscriptionId
+	}
+	utils.UnpackFilter(requestMap["filter"], &(subscriptionState.FilterList))
+	if len(subscriptionState.FilterList) == 0 {
+		utils.SetErrorResponse(requestMap, errorResponseMap, 1, "") //invalid_data
+		dataChan <- errorResponseMap
+		// BUG-PRESERVED: original arm had no break here. Execution
+		// continues and appends the empty-filter subscription, then
+		// sends a second response on dataChan further down. Fix in a
+		// separate PR so reviewers see exactly what changed.
+	}
+	if requestMap["gatingId"] != nil {
+		subscriptionState.GatingId = requestMap["gatingId"].(string)
+	}
+	subscriptionState.LatestDataPoint = getVehicleData(subscriptionState.Path[0])
+	subscriptionList = append(subscriptionList, subscriptionState)
+	responseMap["subscriptionId"] = strconv.Itoa(subscriptionId)
+	subscriptionList = activateIfIntervalOrCL(subscriptionState.FilterList, subscriptionChan, clChannel, subscriptionId, subscriptionState.Path, subscriptionList)
+	variant := getFeederNotifyType(subscriptionState.FilterList)
+	if variant == "curvelog" || variant == "range" || variant == "change" {
+		toFeederChan <- createFeederNotifyMessage(variant, subscriptionState.Path, subscriptionId)
+	}
+	subscriptionId++ // not to be incremented elsewhere
+	dataChan <- responseMap
+	return subscriptionList, subscriptionId
+}
+
 // handleServiceUnsubscribe processes a client-driven "unsubscribe"
 // action: deactivates the subscription identified by subscriptionId,
 // forwards the request to the feeder so it can drop its end of the
@@ -1718,40 +1780,11 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 			case "get":
 				handleServiceGet(requestMap, responseMap, dataChan)
 			case "subscribe":
-				// The subscribe arm is intentionally left inline for now —
-				// it mutates several locals (subscriptionList, subscriptionId)
-				// and sends on three channels (subscriptionChan, CLChannel,
-				// toFeeder), so extracting it cleanly is the next step in
-				// the refactor series. TODO(testing): pull this into
-				// handleServiceSubscribe once the channel ownership story
-				// is sorted.
-				var subscriptionState SubscriptionState
-				subscriptionState.SubscriptionId = subscriptionId
-				subscriptionState.RouterId = requestMap["RouterId"].(string)
-				subscriptionState.Path = unpackPaths(requestMap["path"].(string))
-				if requestMap["filter"] == nil || requestMap["filter"] == "" {
-					utils.SetErrorResponse(requestMap, errorResponseMap, 0, "") //bad_request
-					dataChan <- errorResponseMap
-					break
-				}
-				utils.UnpackFilter(requestMap["filter"], &(subscriptionState.FilterList))
-				if len(subscriptionState.FilterList) == 0 {
-					utils.SetErrorResponse(requestMap, errorResponseMap, 1, "") //invalid_data
-					dataChan <- errorResponseMap
-				}
-				if requestMap["gatingId"] != nil {
-					subscriptionState.GatingId = requestMap["gatingId"].(string)
-				}
-				subscriptionState.LatestDataPoint = getVehicleData(subscriptionState.Path[0])
-				subscriptionList = append(subscriptionList, subscriptionState)
-				responseMap["subscriptionId"] = strconv.Itoa(subscriptionId)
-				subscriptionList = activateIfIntervalOrCL(subscriptionState.FilterList, subscriptionChan, CLChannel, subscriptionId, subscriptionState.Path, subscriptionList)
-				variant := getFeederNotifyType(subscriptionState.FilterList)
-				if variant == "curvelog" || variant == "range" || variant == "change" {
-					toFeeder <- createFeederNotifyMessage(variant, subscriptionState.Path, subscriptionId)
-				}
-				subscriptionId++ // not to be incremented elsewhere
-				dataChan <- responseMap
+				subscriptionList, subscriptionId = handleServiceSubscribe(
+					requestMap, responseMap, dataChan,
+					subscriptionList, subscriptionId,
+					subscriptionChan, CLChannel, toFeeder,
+				)
 			case "unsubscribe":
 				subscriptionList = handleServiceUnsubscribe(requestMap, responseMap, dataChan, subscriptionList, toFeeder)
 			case "internal-killsubscriptions":

--- a/server/vissv2server/serviceMgr/serviceMgr.go
+++ b/server/vissv2server/serviceMgr/serviceMgr.go
@@ -1629,6 +1629,107 @@ func handleUnknownAction(requestMap map[string]interface{}, dataChan chan map[st
 	dataChan <- errorResponseMap
 }
 
+// handleIntervalNotification handles a fire on subscriptionChan (an
+// interval-based subscription's timer ticked). Looks up the
+// subscription, builds a notification event with the current data
+// pack, and pushes it to backendChan with a non-blocking select — the
+// original arm drops the event rather than block when backendChan is
+// full. Extracted from ServiceMgrInit in follow-up PR B to #129.
+func handleIntervalNotification(subscriptionId int, subscriptionList []SubscriptionState, backendChan chan map[string]interface{}) {
+	subIndex := getSubcriptionStateIndex(subscriptionId, subscriptionList)
+	if subIndex == -1 {
+		utils.Error.Printf("Subscription not found for id=%d", subscriptionId)
+		return
+	}
+	subscriptionState := subscriptionList[subIndex]
+	var subscriptionMap = make(map[string]interface{})
+	subscriptionMap["action"] = "subscription"
+	subscriptionMap["ts"] = utils.GetRfcTime()
+	subscriptionMap["subscriptionId"] = strconv.Itoa(subscriptionState.SubscriptionId)
+	subscriptionMap["RouterId"] = subscriptionState.RouterId
+	subscriptionMap["data"] = getDataPackMap(subscriptionState.Path)["dpack"]
+	select {
+	case backendChan <- subscriptionMap:
+	default:
+		utils.Error.Printf("serviceMgr: Event dropped")
+	}
+}
+
+// handleCurveLogNotification handles a fire on CLChannel (a
+// curve-logging worker has produced a data point or is signalling
+// shutdown). Decrements the SubscriptionThreads counter for the
+// subscription, removes it from the list when this was the
+// close-signal for the requested subscription, and forwards the data
+// pack to backendChan. Reads and clears the package global
+// closeClSubId in the close-signal path. Returns the updated
+// subscriptionList. Extracted from ServiceMgrInit in follow-up PR B
+// to #129.
+//
+// PRE-EXISTING HAZARD preserved as-is (file separately for fix):
+// after removeFromsubscriptionList, `index` may now point past the
+// end of the slice (the helper does a swap-with-last + truncate). The
+// subsequent subscriptionList[index] accesses then panic when the
+// removed entry was the last one. The original arm has the same
+// hazard.
+func handleCurveLogNotification(clPack CLPack, subscriptionList []SubscriptionState, backendChan chan map[string]interface{}) []SubscriptionState {
+	index := getSubcriptionStateIndex(clPack.SubscriptionId, subscriptionList)
+	if index == -1 {
+		closeClSubId = -1
+		return subscriptionList
+	}
+	//subscriptionState := subscriptionList[index]
+	subscriptionList[index].SubscriptionThreads--
+	if clPack.SubscriptionId == closeClSubId && subscriptionList[index].SubscriptionThreads == 0 {
+		subscriptionList = removeFromsubscriptionList(subscriptionList, index)
+		closeClSubId = -1
+	}
+	var subscriptionMap = make(map[string]interface{})
+	subscriptionMap["action"] = "subscription"
+	subscriptionMap["ts"] = utils.GetRfcTime()
+	subscriptionMap["subscriptionId"] = strconv.Itoa(subscriptionList[index].SubscriptionId)
+	subscriptionMap["RouterId"] = subscriptionList[index].RouterId
+	subscriptionMap["data"] = string2Map(clPack.DataPack)["s2m"]
+	backendChan <- subscriptionMap
+	return subscriptionList
+}
+
+// handleRCTick handles a fire on the subscription ticker, which polls
+// range/change filters periodically when the feeder is not providing
+// its own notifications. If the feeder is providing notifications,
+// the ticker is stopped to save the wakeups. Returns the updated
+// subscriptionList. Extracted from ServiceMgrInit in follow-up PR B
+// to #129.
+func handleRCTick(feederNotificationActive bool, subscriptTicker *time.Ticker, subscriptionList []SubscriptionState, backendChan chan map[string]interface{}) []SubscriptionState {
+	if !feederNotificationActive { // feeder does not issue notifications
+		return checkRCFilterAndIssueMessages("", subscriptionList, backendChan)
+	}
+	subscriptTicker.Stop()
+	return subscriptionList
+}
+
+// handleFeederNotificationMessage handles a fire on fromFeederRorC.
+// Decodes the feeder's message, updates the feederNotification flag
+// returned by decodeFeederMessage, and re-evaluates the subscription
+// list's range/change filters for the triggered path. Returns the
+// updated feederNotification flag and subscriptionList. Extracted
+// from ServiceMgrInit in follow-up PR B to #129.
+func handleFeederNotificationMessage(feederMessage string, feederNotification bool, subscriptionList []SubscriptionState, backendChan chan map[string]interface{}) (bool, []SubscriptionState) {
+	triggeredPath, updatedNotification := decodeFeederMessage(feederMessage, feederNotification)
+	subscriptionList = checkRCFilterAndIssueMessages(triggeredPath, subscriptionList, backendChan)
+	return updatedNotification, subscriptionList
+}
+
+// handleFeederRegistration handles a fire on feederRegChan. Connects
+// to the registering feeder, updates the registry list, and sends the
+// current list of feeder names back on feederRegChan as the
+// registration acknowledgement. Extracted from ServiceMgrInit in
+// follow-up PR B to #129.
+func handleFeederRegistration(feederReq FeederRegElem, feederRegChan chan FeederRegElem) {
+	connectToFeeder(&feederReq)
+	updateFeederRegList(feederReq)
+	feederRegChan <- createFeederNameList()
+}
+
 func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, stateStorageType string, histSupport bool, dbFile string) {
 	stateDbType = stateStorageType
 	historySupport = histSupport
@@ -1766,7 +1867,6 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 	subscriptTicker := time.NewTicker(23 * time.Millisecond) //range/change subscription ticker when no feeder notifications
 	feederReconnectTicker := time.NewTicker(2 * time.Second)
 	feederNotification := false
-	triggeredPath := ""
 
 	for {
 		select {
@@ -1800,58 +1900,18 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 				dummyValue = 0
 			}
 		case subscriptionId := <-subscriptionChan: // interval notification triggered
-			subIndex := getSubcriptionStateIndex(subscriptionId, subscriptionList)
-			if subIndex == -1 {
-				utils.Error.Printf("Subscription not found for id=%d", subscriptionId)
-				continue
-			}
-			subscriptionState := subscriptionList[subIndex]
-			var subscriptionMap = make(map[string]interface{})
-			subscriptionMap["action"] = "subscription"
-			subscriptionMap["ts"] = utils.GetRfcTime()
-			subscriptionMap["subscriptionId"] = strconv.Itoa(subscriptionState.SubscriptionId)
-			subscriptionMap["RouterId"] = subscriptionState.RouterId
-			subscriptionMap["data"] = getDataPackMap(subscriptionState.Path)["dpack"]
-			select {
-			case backendChan <- subscriptionMap:
-			default: 
-				utils.Error.Printf("serviceMgr: Event dropped")
-			}
+			handleIntervalNotification(subscriptionId, subscriptionList, backendChan)
 		case clPack := <-CLChannel: // curve logging notification
-			index := getSubcriptionStateIndex(clPack.SubscriptionId, subscriptionList)
-			if index == -1 {
-				closeClSubId = -1
-				continue
-			}
-			//subscriptionState := subscriptionList[index]
-			subscriptionList[index].SubscriptionThreads--
-			if clPack.SubscriptionId == closeClSubId && subscriptionList[index].SubscriptionThreads == 0 {
-				subscriptionList = removeFromsubscriptionList(subscriptionList, index)
-				closeClSubId = -1
-			}
-			var subscriptionMap = make(map[string]interface{})
-			subscriptionMap["action"] = "subscription"
-			subscriptionMap["ts"] = utils.GetRfcTime()
-			subscriptionMap["subscriptionId"] = strconv.Itoa(subscriptionList[index].SubscriptionId)
-			subscriptionMap["RouterId"] = subscriptionList[index].RouterId
-			subscriptionMap["data"] = string2Map(clPack.DataPack)["s2m"]
-			backendChan <- subscriptionMap
+			subscriptionList = handleCurveLogNotification(clPack, subscriptionList, backendChan)
 		case <-subscriptTicker.C:
-			if feederNotification == false { // feeder does not issue notifications
-				subscriptionList = checkRCFilterAndIssueMessages("", subscriptionList, backendChan)
-			} else {
-				subscriptTicker.Stop()
-			}
+			subscriptionList = handleRCTick(feederNotification, subscriptTicker, subscriptionList, backendChan)
 		case <-feederReconnectTicker.C:
 			feederConnectRetry()
 		case feederMessage := <-fromFeederRorC:
 //utils.Info.Printf("Feeder message=%s", feederMessage)
-			triggeredPath, feederNotification = decodeFeederMessage(feederMessage, feederNotification)
-			subscriptionList = checkRCFilterAndIssueMessages(triggeredPath, subscriptionList, backendChan)
+			feederNotification, subscriptionList = handleFeederNotificationMessage(feederMessage, feederNotification, subscriptionList, backendChan)
 		case feederReq := <- feederRegChan:
-			connectToFeeder(&feederReq)
-			updateFeederRegList(feederReq)
-			feederRegChan <- createFeederNameList()
+			handleFeederRegistration(feederReq, feederRegChan)
 		} // select
 	} // for
 utils.Info.Printf("Service manager exit")

--- a/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
+++ b/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
@@ -1,0 +1,427 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* Tests for the per-message dispatch helpers extracted from
+* ServiceMgrInit's dataChan switch in PR #129 (this PR):
+*
+*   - buildServiceResponseMap        shared response-skeleton builder
+*   - handleServiceSet               "set" action arm
+*   - handleServiceGet               "get" action arm (error paths)
+*   - handleServiceUnsubscribe       client-driven "unsubscribe" arm
+*   - handleInternalKillSubscriptions kill all subscriptions for a RouterId
+*   - handleInternalCancelSubscription AGT-cancelled subscription cleanup
+*   - handleUnknownAction            default arm
+*
+* The subscribe arm is intentionally left inline in this PR — it mutates
+* several locals (subscriptionList, subscriptionId) and sends on three
+* channels (subscriptionChan, CLChannel, toFeeder), so extracting it
+* cleanly will be a follow-up. The storage-backend interface
+* (StorageBackend) injection is also deferred to a future PR — it is a
+* genuinely separate architectural change touching 5 backends and their
+* init paths, and bundling it here would balloon this diff.
+*
+* Same shape as the dispatch tests in PRs #124 (udsMgr+httpMgr), #125
+* (feederv4), #126 (wsMgr), #127 (grpcMgr), and #128 (vissv2server core).
+**/
+package serviceMgr
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/covesa/vissr/utils"
+)
+
+// TestMain initialises utils.Info / utils.Error so the helpers can
+// log without nil-deref under test conditions. We deliberately do
+// NOT set stateDbType here — the empty value falls through to the
+// default arm in setVehicleData/getVehicleData, returning "" without
+// touching the live storage backends. That keeps these tests
+// self-contained and exercises the service_unavailable / empty-data
+// paths.
+func TestMain(m *testing.M) {
+	utils.InitLog("serviceMgr-dispatch-test.log", os.TempDir(), false, "error")
+	os.Exit(m.Run())
+}
+
+// resetErrorResponseMap clears the shared package-level
+// errorResponseMap between tests. The production code mutates it in
+// place on the assumption that one request is being processed at a
+// time, so we restore that assumption per test case.
+func resetErrorResponseMap() {
+	for k := range errorResponseMap {
+		delete(errorResponseMap, k)
+	}
+}
+
+// TestBuildServiceResponseMap verifies the response skeleton carries
+// the four required fields and that the authorization field is only
+// set when "handle" is present on the request.
+func TestBuildServiceResponseMap(t *testing.T) {
+	req := map[string]interface{}{
+		"RouterId":  "0?7",
+		"action":    "get",
+		"requestId": "42",
+		"handle":    "tok-handle-xyz",
+	}
+	resp := buildServiceResponseMap(req)
+	if resp["RouterId"] != "0?7" {
+		t.Errorf("RouterId = %v; want 0?7", resp["RouterId"])
+	}
+	if resp["action"] != "get" {
+		t.Errorf("action = %v; want get", resp["action"])
+	}
+	if resp["requestId"] != "42" {
+		t.Errorf("requestId = %v; want 42", resp["requestId"])
+	}
+	if resp["ts"] == nil || resp["ts"].(string) == "" {
+		t.Errorf("ts not populated")
+	}
+	if resp["authorization"] != "tok-handle-xyz" {
+		t.Errorf("authorization = %v; want tok-handle-xyz", resp["authorization"])
+	}
+
+	// Without a handle, the authorization field must be absent.
+	req2 := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "get",
+		"requestId": "1",
+	}
+	resp2 := buildServiceResponseMap(req2)
+	if _, present := resp2["authorization"]; present {
+		t.Errorf("authorization should be absent when handle is nil; got %v", resp2["authorization"])
+	}
+}
+
+// TestHandleServiceSet_StorageUnavailableReturnsError exercises the
+// service_unavailable path: with stateDbType unset, setVehicleData
+// returns the zero string and the helper must emit the canonical
+// error response on dataChan.
+func TestHandleServiceSet_StorageUnavailableReturnsError(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "set",
+		"requestId": "1",
+		"path":      "Vehicle.Speed",
+		"value":     "100",
+	}
+	resp := buildServiceResponseMap(req)
+
+	go handleServiceSet(req, resp, dataChan)
+
+	select {
+	case got := <-dataChan:
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error response; got %v", got)
+		}
+		if errMap["reason"] != "service_unavailable" {
+			t.Errorf("error.reason = %v; want service_unavailable", errMap["reason"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleServiceSet did not reply on dataChan")
+	}
+}
+
+// TestHandleServiceGet_MalformedPathArray covers the invalid_data
+// branch when unpackPaths can't decode a "looks like an array but
+// isn't" path string.
+func TestHandleServiceGet_MalformedPathArray(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "get",
+		"requestId": "1",
+		"path":      `["Vehicle.Speed`, // open bracket but no close
+	}
+	resp := buildServiceResponseMap(req)
+
+	go handleServiceGet(req, resp, dataChan)
+
+	select {
+	case got := <-dataChan:
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error response; got %v", got)
+		}
+		if errMap["reason"] != "invalid_data" {
+			t.Errorf("error.reason = %v; want invalid_data", errMap["reason"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleServiceGet did not reply on dataChan")
+	}
+}
+
+// TestHandleServiceGet_SinglePathSucceeds confirms the happy path
+// resolves a single path without hitting the error arms. With
+// stateDbType unset, getVehicleData returns "" and the data pack ends
+// up with a nil "dp" value, but the helper still emits a success
+// response (not an error response). This pins the contract that the
+// "no data available" case is NOT treated as an error here — the
+// caller has to interpret a missing dp themselves.
+func TestHandleServiceGet_SinglePathSucceeds(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "get",
+		"requestId": "1",
+		"path":      "Vehicle.Speed", // single path, not an array
+	}
+	resp := buildServiceResponseMap(req)
+
+	go handleServiceGet(req, resp, dataChan)
+
+	select {
+	case got := <-dataChan:
+		if _, isErr := got["error"]; isErr {
+			t.Fatalf("expected success response; got error %v", got)
+		}
+		if got["action"] != "get" {
+			t.Errorf("action = %v; want get", got["action"])
+		}
+		// "data" key should be present even when empty.
+		if _, present := got["data"]; !present {
+			t.Errorf("data key missing from success response")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleServiceGet did not reply on dataChan")
+	}
+}
+
+// TestHandleServiceUnsubscribe_MissingSubscriptionId hits the
+// invalid_data branch when the request has no subscriptionId field.
+func TestHandleServiceUnsubscribe_MissingSubscriptionId(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	toFeederChan := make(chan string, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "unsubscribe",
+		"requestId": "1",
+		// no subscriptionId
+	}
+	resp := buildServiceResponseMap(req)
+	subscriptionList := []SubscriptionState{}
+
+	updated := handleServiceUnsubscribe(req, resp, dataChan, subscriptionList, toFeederChan)
+	if len(updated) != 0 {
+		t.Errorf("subscriptionList length = %d; want 0", len(updated))
+	}
+
+	select {
+	case got := <-dataChan:
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error response; got %v", got)
+		}
+		if errMap["reason"] != "invalid_data" {
+			t.Errorf("error.reason = %v; want invalid_data", errMap["reason"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleServiceUnsubscribe did not reply on dataChan")
+	}
+
+	// toFeeder should NOT have been sent to on the error path.
+	select {
+	case got := <-toFeederChan:
+		t.Errorf("toFeederChan should be empty on error path; got %q", got)
+	default:
+	}
+}
+
+// TestHandleServiceUnsubscribe_NotFoundOnList covers the case where
+// the subscriptionId is well-formed but no matching subscription is
+// in the list — deactivateSubscription returns status=-1 and the
+// helper falls through to the invalid_data error.
+func TestHandleServiceUnsubscribe_NotFoundOnList(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	toFeederChan := make(chan string, 1)
+	req := map[string]interface{}{
+		"RouterId":       "0?0",
+		"action":         "unsubscribe",
+		"requestId":      "1",
+		"subscriptionId": "9999",
+	}
+	resp := buildServiceResponseMap(req)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 1, RouterId: "0?0"},
+	}
+
+	updated := handleServiceUnsubscribe(req, resp, dataChan, subscriptionList, toFeederChan)
+	if len(updated) != 1 {
+		t.Errorf("subscriptionList length = %d; want 1 (unchanged)", len(updated))
+	}
+
+	select {
+	case got := <-dataChan:
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error response; got %v", got)
+		}
+		if errMap["reason"] != "invalid_data" {
+			t.Errorf("error.reason = %v; want invalid_data", errMap["reason"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleServiceUnsubscribe did not reply on dataChan")
+	}
+}
+
+// TestHandleInternalKillSubscriptions_RemovesMatching seeds a
+// subscription list with two entries for the same RouterId and one
+// for a different RouterId, then verifies the kill loop removes both
+// of the matching entries while leaving the unrelated one alone.
+func TestHandleInternalKillSubscriptions_RemovesMatching(t *testing.T) {
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 1, RouterId: "0?5"},
+		{SubscriptionId: 2, RouterId: "0?5"},
+		{SubscriptionId: 3, RouterId: "0?9"},
+	}
+	req := map[string]interface{}{
+		"action":   "internal-killsubscriptions",
+		"RouterId": "0?5",
+	}
+
+	updated := handleInternalKillSubscriptions(req, subscriptionList)
+
+	// The two 0?5 entries should be gone; 0?9 should survive.
+	for _, s := range updated {
+		if s.RouterId == "0?5" {
+			t.Errorf("found leftover RouterId=0?5 entry: subId=%d", s.SubscriptionId)
+		}
+	}
+	foundOther := false
+	for _, s := range updated {
+		if s.RouterId == "0?9" {
+			foundOther = true
+		}
+	}
+	if !foundOther {
+		t.Errorf("RouterId=0?9 entry was removed; should have survived")
+	}
+}
+
+// TestHandleInternalKillSubscriptions_NoMatch confirms that when no
+// entries match the request RouterId, the list is returned unchanged.
+func TestHandleInternalKillSubscriptions_NoMatch(t *testing.T) {
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 1, RouterId: "0?9"},
+	}
+	req := map[string]interface{}{
+		"action":   "internal-killsubscriptions",
+		"RouterId": "0?5",
+	}
+	updated := handleInternalKillSubscriptions(req, subscriptionList)
+	if len(updated) != 1 || updated[0].RouterId != "0?9" {
+		t.Errorf("list mutated unexpectedly; got %v", updated)
+	}
+}
+
+// TestHandleInternalCancelSubscription_GatingIdFound seeds a
+// subscription with a matching gatingId, then confirms the helper:
+//   1) rewrites requestMap into a synthetic "subscription" error event
+//   2) pushes it to dataChan with the expired_token error number
+//   3) removes the subscription from the list
+func TestHandleInternalCancelSubscription_GatingIdFound(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 7, RouterId: "0?3", GatingId: "gate-abc"},
+	}
+	req := map[string]interface{}{
+		"action":   "internal-cancelsubscription",
+		"gatingId": "gate-abc",
+	}
+
+	updated := handleInternalCancelSubscription(req, dataChan, subscriptionList)
+	if len(updated) != 0 {
+		t.Errorf("subscriptionList length = %d; want 0 (entry should have been removed)", len(updated))
+	}
+
+	select {
+	case got := <-dataChan:
+		if got["action"] != "subscription" {
+			t.Errorf("rewritten action = %v; want subscription", got["action"])
+		}
+		if got["RouterId"] != "0?3" {
+			t.Errorf("rewritten RouterId = %v; want 0?3", got["RouterId"])
+		}
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error sub-map; got %v", got)
+		}
+		if desc, _ := errMap["description"].(string); !strings.Contains(desc, "Token expired") {
+			t.Errorf("description = %q; want it to mention Token expired", desc)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleInternalCancelSubscription did not reply on dataChan")
+	}
+}
+
+// TestHandleInternalCancelSubscription_GatingIdNotFound confirms a
+// non-matching gatingId is a no-op: the list is unchanged and nothing
+// is pushed onto dataChan.
+func TestHandleInternalCancelSubscription_GatingIdNotFound(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 7, RouterId: "0?3", GatingId: "gate-abc"},
+	}
+	req := map[string]interface{}{
+		"action":   "internal-cancelsubscription",
+		"gatingId": "gate-not-here",
+	}
+
+	updated := handleInternalCancelSubscription(req, dataChan, subscriptionList)
+	if len(updated) != 1 {
+		t.Errorf("subscriptionList length = %d; want 1 (unchanged)", len(updated))
+	}
+
+	select {
+	case got := <-dataChan:
+		t.Errorf("dataChan should be empty when gatingId not found; got %v", got)
+	default:
+	}
+}
+
+// TestHandleUnknownAction confirms the default arm emits the
+// invalid_data response with "Unknown action" as the description.
+func TestHandleUnknownAction(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "completely-made-up-action",
+		"requestId": "1",
+	}
+
+	handleUnknownAction(req, dataChan)
+
+	select {
+	case got := <-dataChan:
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error response; got %v", got)
+		}
+		if errMap["reason"] != "invalid_data" {
+			t.Errorf("error.reason = %v; want invalid_data", errMap["reason"])
+		}
+		if desc, _ := errMap["description"].(string); desc != "Unknown action" {
+			t.Errorf("description = %q; want exactly \"Unknown action\"", desc)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleUnknownAction did not reply on dataChan")
+	}
+}

--- a/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
+++ b/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
@@ -8,8 +8,9 @@
 * ----------------------------------------------------------------------------
 *
 * Tests for the per-message dispatch helpers extracted from
-* ServiceMgrInit's dataChan switch in PR #129 (this PR):
+* ServiceMgrInit's dataChan switch.
 *
+* Originally added in PR #129 covering:
 *   - buildServiceResponseMap        shared response-skeleton builder
 *   - handleServiceSet               "set" action arm
 *   - handleServiceGet               "get" action arm (error paths)
@@ -18,13 +19,12 @@
 *   - handleInternalCancelSubscription AGT-cancelled subscription cleanup
 *   - handleUnknownAction            default arm
 *
-* The subscribe arm is intentionally left inline in this PR — it mutates
-* several locals (subscriptionList, subscriptionId) and sends on three
-* channels (subscriptionChan, CLChannel, toFeeder), so extracting it
-* cleanly will be a follow-up. The storage-backend interface
-* (StorageBackend) injection is also deferred to a future PR — it is a
-* genuinely separate architectural change touching 5 backends and their
-* init paths, and bundling it here would balloon this diff.
+* Follow-up PR (this PR) adds tests for the subscribe arm, which was
+* left inline in #129 with a TODO(testing) note and has now been
+* extracted to handleServiceSubscribe. The storage-backend interface
+* (StorageBackend) injection is still deferred to a separate PR — it
+* is a genuinely separate architectural change touching 5 backends
+* and their init paths.
 *
 * Same shape as the dispatch tests in PRs #124 (udsMgr+httpMgr), #125
 * (feederv4), #126 (wsMgr), #127 (grpcMgr), and #128 (vissv2server core).
@@ -423,5 +423,241 @@ func TestHandleUnknownAction(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("handleUnknownAction did not reply on dataChan")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests for handleServiceSubscribe (added in the follow-up PR after #129).
+//
+// The subscribe arm was left inline in PR #129 with a TODO(testing) note.
+// These tests cover the extracted handleServiceSubscribe — the clean error
+// paths, the happy path with a non-special filter (one that doesn't trip
+// subscriptionChan / CLChannel / toFeeder), and a regression-pinning test
+// for the pre-existing missing-break bug in the empty-FilterList branch.
+// ----------------------------------------------------------------------------
+
+// TestHandleServiceSubscribe_MissingFilterReturnsBadRequest exercises
+// the nil-filter short-circuit: no filter field at all on the request,
+// so the helper returns immediately with a bad_request error and does
+// not touch the subscription list or any side channels.
+func TestHandleServiceSubscribe_MissingFilterReturnsBadRequest(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 2)
+	subChan := make(chan int, 1)
+	clChan := make(chan CLPack, 1)
+	toFeederChan := make(chan string, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "subscribe",
+		"requestId": "1",
+		"path":      "Vehicle.Speed",
+		// no filter
+	}
+	resp := buildServiceResponseMap(req)
+	list := []SubscriptionState{}
+
+	updatedList, nextId := handleServiceSubscribe(req, resp, dataChan, list, 99, subChan, clChan, toFeederChan)
+	if len(updatedList) != 0 {
+		t.Errorf("subscriptionList grew on the error path; len=%d", len(updatedList))
+	}
+	if nextId != 99 {
+		t.Errorf("subscriptionId advanced on the error path; got %d, want 99", nextId)
+	}
+
+	select {
+	case got := <-dataChan:
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error response; got %v", got)
+		}
+		if errMap["reason"] != "bad_request" {
+			t.Errorf("error.reason = %v; want bad_request", errMap["reason"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleServiceSubscribe did not reply on dataChan")
+	}
+
+	// Nothing should reach the side channels on this error path.
+	select {
+	case <-subChan:
+		t.Errorf("subChan was sent to on the error path")
+	case <-clChan:
+		t.Errorf("clChan was sent to on the error path")
+	case <-toFeederChan:
+		t.Errorf("toFeederChan was sent to on the error path")
+	default:
+	}
+}
+
+// TestHandleServiceSubscribe_EmptyStringFilterReturnsBadRequest covers
+// the same short-circuit when the filter field is present but is the
+// empty string (which the original arm explicitly rejected alongside
+// nil).
+func TestHandleServiceSubscribe_EmptyStringFilterReturnsBadRequest(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 2)
+	subChan := make(chan int, 1)
+	clChan := make(chan CLPack, 1)
+	toFeederChan := make(chan string, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "subscribe",
+		"requestId": "1",
+		"path":      "Vehicle.Speed",
+		"filter":    "",
+	}
+	resp := buildServiceResponseMap(req)
+
+	updatedList, nextId := handleServiceSubscribe(req, resp, dataChan, []SubscriptionState{}, 7, subChan, clChan, toFeederChan)
+	if len(updatedList) != 0 || nextId != 7 {
+		t.Errorf("subscription state mutated on the error path; list=%d, id=%d", len(updatedList), nextId)
+	}
+
+	select {
+	case got := <-dataChan:
+		errMap, _ := got["error"].(map[string]interface{})
+		if errMap == nil || errMap["reason"] != "bad_request" {
+			t.Errorf("expected bad_request error; got %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("no response on dataChan")
+	}
+}
+
+// TestHandleServiceSubscribe_HappyPath exercises the success path
+// using a "paths" filter — one that does NOT trip the timebased,
+// curvelog, change, or range branches, so the three side channels
+// (subChan, clChan, toFeederChan) all stay quiet. We verify:
+//   1) the subscription is appended to the list
+//   2) subscriptionId is incremented by one
+//   3) responseMap["subscriptionId"] is set to the old id (the one the
+//      client should use for unsubscribe)
+//   4) the response is pushed to dataChan
+func TestHandleServiceSubscribe_HappyPath(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 2)
+	subChan := make(chan int, 1)
+	clChan := make(chan CLPack, 1)
+	toFeederChan := make(chan string, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?5",
+		"action":    "subscribe",
+		"requestId": "1",
+		"path":      "Vehicle.Speed",
+		// A "paths" filter: not timebased / curvelog / range / change,
+		// so it triggers none of the side channels.
+		"filter": map[string]interface{}{
+			"variant":   "paths",
+			"parameter": "Vehicle.Speed",
+		},
+	}
+	resp := buildServiceResponseMap(req)
+	startId := 42
+
+	updatedList, nextId := handleServiceSubscribe(req, resp, dataChan, []SubscriptionState{}, startId, subChan, clChan, toFeederChan)
+
+	if len(updatedList) != 1 {
+		t.Fatalf("subscriptionList len = %d; want 1", len(updatedList))
+	}
+	if updatedList[0].SubscriptionId != startId {
+		t.Errorf("appended SubscriptionId = %d; want %d", updatedList[0].SubscriptionId, startId)
+	}
+	if updatedList[0].RouterId != "0?5" {
+		t.Errorf("appended RouterId = %q; want 0?5", updatedList[0].RouterId)
+	}
+	if nextId != startId+1 {
+		t.Errorf("nextId = %d; want %d (subscriptionId must advance by 1)", nextId, startId+1)
+	}
+
+	select {
+	case got := <-dataChan:
+		if _, isErr := got["error"]; isErr {
+			t.Fatalf("happy path produced an error response: %v", got)
+		}
+		if got["subscriptionId"] != "42" {
+			t.Errorf("responseMap.subscriptionId = %v; want \"42\"", got["subscriptionId"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("no response on dataChan on happy path")
+	}
+
+	// Side channels stay quiet for a "paths" filter.
+	select {
+	case <-subChan:
+		t.Errorf("subChan was sent to on the paths-filter path")
+	case <-clChan:
+		t.Errorf("clChan was sent to on the paths-filter path")
+	case <-toFeederChan:
+		t.Errorf("toFeederChan was sent to on the paths-filter path")
+	default:
+	}
+}
+
+// TestHandleServiceSubscribe_EmptyFilterListBugPreserved is a
+// regression-pinning test for a PRE-EXISTING bug in the original
+// inline arm that handleServiceSubscribe preserves verbatim:
+//
+//   When UnpackFilter unpacks a non-nil filter into an EMPTY
+//   FilterList, the arm sends a "invalid_data" error response on
+//   dataChan AND THEN falls through to append the empty-filter
+//   subscription, sending a SECOND response on dataChan and
+//   incrementing subscriptionId. The arm was missing a `break` after
+//   the error send.
+//
+// If a future fix adds the missing break, THIS TEST WILL FAIL — that
+// is intentional. Update the test to reflect the corrected behaviour
+// (single error response, list unchanged, id unchanged) at that time.
+func TestHandleServiceSubscribe_EmptyFilterListBugPreserved(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 2) // room for both messages
+	subChan := make(chan int, 1)
+	clChan := make(chan CLPack, 1)
+	toFeederChan := make(chan string, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?5",
+		"action":    "subscribe",
+		"requestId": "1",
+		"path":      "Vehicle.Speed",
+		// A non-empty string filter hits the default arm of
+		// utils.UnpackFilter (which only branches on []interface{} or
+		// map[string]interface{}), leaving the FilterList nil — i.e.
+		// len() == 0 — and tripping the buggy empty-FilterList path.
+		"filter": "this-is-neither-a-map-nor-an-array",
+	}
+	resp := buildServiceResponseMap(req)
+	startId := 100
+
+	updatedList, nextId := handleServiceSubscribe(req, resp, dataChan, []SubscriptionState{}, startId, subChan, clChan, toFeederChan)
+
+	// First message on dataChan should be the invalid_data error.
+	select {
+	case got := <-dataChan:
+		errMap, _ := got["error"].(map[string]interface{})
+		if errMap == nil || errMap["reason"] != "invalid_data" {
+			t.Errorf("first message was not invalid_data error: %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("no first response on dataChan")
+	}
+
+	// Second message exists due to the missing-break bug — the arm
+	// keeps going and sends responseMap as if the subscription was
+	// added. If this select hits the timeout instead, the bug has
+	// been fixed; update the test to the corrected behaviour.
+	select {
+	case got := <-dataChan:
+		if got["subscriptionId"] != "100" {
+			t.Errorf("second (buggy) message did not carry the new subscriptionId: %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("missing second message — bug may have been fixed; update this test to the corrected behaviour")
+	}
+
+	// And the list / id reflect the buggy append.
+	if len(updatedList) != 1 {
+		t.Errorf("subscriptionList len = %d; bug-preserved behaviour appends 1", len(updatedList))
+	}
+	if nextId != startId+1 {
+		t.Errorf("nextId = %d; bug-preserved behaviour increments to %d", nextId, startId+1)
 	}
 }

--- a/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
+++ b/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
@@ -19,12 +19,23 @@
 *   - handleInternalCancelSubscription AGT-cancelled subscription cleanup
 *   - handleUnknownAction            default arm
 *
-* Follow-up PR (this PR) adds tests for the subscribe arm, which was
-* left inline in #129 with a TODO(testing) note and has now been
-* extracted to handleServiceSubscribe. The storage-backend interface
-* (StorageBackend) injection is still deferred to a separate PR — it
-* is a genuinely separate architectural change touching 5 backends
-* and their init paths.
+* Follow-up PR A added tests for the subscribe arm, which was left
+* inline in #129 with a TODO(testing) note and has now been extracted
+* to handleServiceSubscribe.
+*
+* Follow-up PR B (this PR) extracts the five notification-side arms
+* of ServiceMgrInit's select loop and adds tests for the four that
+* are unit-testable without a live UDS socket:
+*   - handleIntervalNotification       <-subscriptionChan
+*   - handleCurveLogNotification       <-CLChannel
+*   - handleRCTick                     <-subscriptTicker.C
+*   - handleFeederNotificationMessage  <-fromFeederRorC
+*   (handleFeederRegistration is extracted but not unit-tested -- it
+*    calls connectToFeeder which opens a real UDS socket.)
+*
+* The storage-backend interface (StorageBackend) injection is still
+* deferred to a separate PR — it is a genuinely separate architectural
+* change touching 5 backends and their init paths.
 *
 * Same shape as the dispatch tests in PRs #124 (udsMgr+httpMgr), #125
 * (feederv4), #126 (wsMgr), #127 (grpcMgr), and #128 (vissv2server core).
@@ -659,5 +670,226 @@ func TestHandleServiceSubscribe_EmptyFilterListBugPreserved(t *testing.T) {
 	}
 	if nextId != startId+1 {
 		t.Errorf("nextId = %d; bug-preserved behaviour increments to %d", nextId, startId+1)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests for the notification-arm handlers (follow-up PR B to #129):
+//
+//   - handleIntervalNotification       <-subscriptionChan arm
+//   - handleCurveLogNotification       <-CLChannel arm
+//   - handleRCTick                     <-subscriptTicker.C arm
+//   - handleFeederNotificationMessage  <-fromFeederRorC arm
+//
+// (handleFeederRegistration is not unit-tested -- it calls
+// connectToFeeder which opens a real UDS socket, and mocking that
+// requires more plumbing than the value it delivers here.)
+// ----------------------------------------------------------------------------
+
+// TestHandleIntervalNotification_UnknownIdLogsAndReturns covers the
+// "subscription has been removed but the interval timer fired anyway"
+// race: the handler should log and return without touching backendChan.
+func TestHandleIntervalNotification_UnknownIdLogsAndReturns(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 1},
+	}
+	handleIntervalNotification(9999, subscriptionList, backChan)
+	select {
+	case got := <-backChan:
+		t.Fatalf("backChan should be empty for unknown id; got %v", got)
+	default:
+	}
+}
+
+// TestHandleIntervalNotification_KnownIdSendsToBackend exercises the
+// happy path: the subscription is in the list, the handler builds a
+// well-shaped subscription event and pushes it to backendChan.
+func TestHandleIntervalNotification_KnownIdSendsToBackend(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{
+			SubscriptionId: 7,
+			RouterId:       "0?3",
+			Path:           []string{"Vehicle.Speed"},
+		},
+	}
+	handleIntervalNotification(7, subscriptionList, backChan)
+	select {
+	case got := <-backChan:
+		if got["action"] != "subscription" {
+			t.Errorf("action = %v; want subscription", got["action"])
+		}
+		if got["subscriptionId"] != "7" {
+			t.Errorf("subscriptionId = %v; want \"7\"", got["subscriptionId"])
+		}
+		if got["RouterId"] != "0?3" {
+			t.Errorf("RouterId = %v; want 0?3", got["RouterId"])
+		}
+		if _, present := got["data"]; !present {
+			t.Errorf("data key missing from notification event")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleIntervalNotification did not push to backChan")
+	}
+}
+
+// TestHandleIntervalNotification_DropOnBackpressure exercises the
+// non-blocking select branch: when backendChan is full, the handler
+// drops the event rather than block. This pins the original arm's
+// drop-on-overflow behaviour.
+func TestHandleIntervalNotification_DropOnBackpressure(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	backChan <- map[string]interface{}{"stale": "event"} // fill the buffer
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 7, RouterId: "0?3", Path: []string{"Vehicle.Speed"}},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		handleIntervalNotification(7, subscriptionList, backChan)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// Good: the handler returned without blocking even though the
+		// channel was full.
+	case <-time.After(time.Second):
+		t.Fatalf("handleIntervalNotification blocked instead of dropping")
+	}
+
+	// The buffer still holds the original stale event — the new one
+	// was dropped on the floor.
+	select {
+	case got := <-backChan:
+		if got["stale"] != "event" {
+			t.Errorf("backChan contained the new event; should have dropped it")
+		}
+	default:
+		t.Fatalf("backChan was unexpectedly drained")
+	}
+}
+
+// TestHandleCurveLogNotification_UnknownIdResetsCloseSignal covers the
+// "subscription is no longer on the list when the close signal
+// arrives" path: closeClSubId is cleared and the handler returns
+// without touching backendChan.
+func TestHandleCurveLogNotification_UnknownIdResetsCloseSignal(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 1, SubscriptionThreads: 3},
+	}
+	closeClSubId = 9999 // pretend a close was pending for an id we won't find
+
+	updated := handleCurveLogNotification(CLPack{SubscriptionId: 9999, DataPack: `{"value":"x","ts":"y"}`}, subscriptionList, backChan)
+
+	if closeClSubId != -1 {
+		t.Errorf("closeClSubId = %d; want -1 (should be cleared on unknown id)", closeClSubId)
+	}
+	if len(updated) != 1 {
+		t.Errorf("subscriptionList mutated unexpectedly; len=%d, want 1", len(updated))
+	}
+	select {
+	case got := <-backChan:
+		t.Fatalf("backChan should be empty on unknown-id path; got %v", got)
+	default:
+	}
+}
+
+// TestHandleCurveLogNotification_DecrementsThreadsAndForwards exercises
+// the happy path: the subscription is in the list, this is NOT the
+// close signal for it, so the threads counter is decremented and the
+// data pack is forwarded to backendChan.
+func TestHandleCurveLogNotification_DecrementsThreadsAndForwards(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 5, RouterId: "0?2", SubscriptionThreads: 3},
+	}
+	closeClSubId = -1 // no pending close
+
+	updated := handleCurveLogNotification(
+		CLPack{SubscriptionId: 5, DataPack: `{"value":"42","ts":"2026-01-01T00:00:00Z"}`},
+		subscriptionList, backChan,
+	)
+
+	if updated[0].SubscriptionThreads != 2 {
+		t.Errorf("SubscriptionThreads = %d; want 2 (decremented from 3)", updated[0].SubscriptionThreads)
+	}
+	select {
+	case got := <-backChan:
+		if got["subscriptionId"] != "5" {
+			t.Errorf("subscriptionId = %v; want \"5\"", got["subscriptionId"])
+		}
+		if got["RouterId"] != "0?2" {
+			t.Errorf("RouterId = %v; want 0?2", got["RouterId"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleCurveLogNotification did not push to backChan")
+	}
+}
+
+// TestHandleRCTick_FeederActiveStopsTicker covers the path taken when
+// the feeder is producing range/change notifications itself: the
+// poll-ticker is stopped and the subscription list is returned
+// unchanged.
+func TestHandleRCTick_FeederActiveStopsTicker(t *testing.T) {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop() // double-Stop is safe
+	backChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 1},
+	}
+
+	updated := handleRCTick(true, ticker, subscriptionList, backChan)
+	if len(updated) != 1 {
+		t.Errorf("subscriptionList mutated on feeder-active path; len=%d", len(updated))
+	}
+	// We can't directly assert "ticker is stopped" — the time.Ticker
+	// API doesn't expose state. But the call should have returned
+	// promptly and not panicked, which is what matters for behaviour.
+	select {
+	case got := <-backChan:
+		t.Errorf("backChan should be empty on feeder-active path; got %v", got)
+	default:
+	}
+}
+
+// TestHandleRCTick_FeederInactivePollsRC covers the path taken when
+// the feeder is NOT providing notifications: the handler delegates to
+// checkRCFilterAndIssueMessages, which is a no-op on an empty
+// subscription list (so this test just confirms the call returns
+// cleanly with the list unchanged).
+func TestHandleRCTick_FeederInactivePollsRC(t *testing.T) {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	backChan := make(chan map[string]interface{}, 1)
+	updated := handleRCTick(false, ticker, []SubscriptionState{}, backChan)
+	if updated == nil || len(updated) != 0 {
+		t.Errorf("subscriptionList should be returned (possibly unchanged) on feeder-inactive path; got %v", updated)
+	}
+}
+
+// TestHandleFeederNotificationMessage_SubscribeOkFlipsNotificationOn
+// covers the feeder telling us "I support range/change notifications"
+// via a subscribe response with status=ok. The handler should flip the
+// feederNotification flag to true.
+func TestHandleFeederNotificationMessage_SubscribeOkFlipsNotificationOn(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	msg := `{"action":"subscribe","status":"ok"}`
+	updatedFlag, _ := handleFeederNotificationMessage(msg, false, []SubscriptionState{}, backChan)
+	if updatedFlag != true {
+		t.Errorf("feederNotification flag = %v; want true after subscribe ok", updatedFlag)
+	}
+}
+
+// TestHandleFeederNotificationMessage_MalformedMessagePreservesFlag
+// covers the defensive arm of decodeFeederMessage: an unparseable
+// message leaves the flag unchanged.
+func TestHandleFeederNotificationMessage_MalformedMessagePreservesFlag(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	msg := "not-json-at-all"
+	updatedFlag, _ := handleFeederNotificationMessage(msg, true, []SubscriptionState{}, backChan)
+	if updatedFlag != true {
+		t.Errorf("feederNotification flag = %v; want it to stay true on malformed input", updatedFlag)
 	}
 }


### PR DESCRIPTION
Second of three follow-up PRs to #129. Pulls the five notification-side arms of `ServiceMgrInit`'s select loop into named functions.

### Extracted

| Helper | Arm |
|---|---|
| `handleIntervalNotification(subId, list, backendChan)` | `<-subscriptionChan` — interval-timer fire; builds a subscription event from the current dataPack and pushes to backendChan with a **non-blocking** select (drops on backpressure) |
| `handleCurveLogNotification(clPack, list, backendChan) []SubscriptionState` | `<-CLChannel` — decrement `SubscriptionThreads`, handle close-signal removal, forward the data pack |
| `handleRCTick(feederActive, subscriptTicker, list, backendChan) []SubscriptionState` | `<-subscriptTicker.C` — poll RC filters when the feeder is not pushing notifications; otherwise stop the ticker |
| `handleFeederNotificationMessage(feederMsg, feederActive, list, backendChan) (bool, []SubscriptionState)` | `<-fromFeederRorC` — decode the feeder's message, update the feederNotification flag, re-evaluate RC filters |
| `handleFeederRegistration(feederReq, feederRegChan)` | `<-feederRegChan` — connect to the feeder, update the registry, send the name list back as the ack |

`ServiceMgrInit`'s notification side collapses from ~57 lines of inline case bodies to one-line calls. Also removed the now-unused `triggeredPath` local declaration in `ServiceMgrInit` (the only use site has moved into `handleFeederNotificationMessage`).

### Behaviour preservation

Straight code moves, no logic changes.

### Pre-existing hazard preserved

In `handleCurveLogNotification`, after the close-signal branch calls `removeFromsubscriptionList`, the local `index` variable may now point past the end of the slice (the helper does a swap-with-last + truncate). The subsequent `subscriptionList[index]` accesses then panic when the removed entry was the last one. The original arm has the same hazard; the new function documents it in its doc comment. Worth a separate small bug-fix PR.

### Tests added

Appended to `server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go`:

- `TestHandleIntervalNotification_UnknownIdLogsAndReturns`
- `TestHandleIntervalNotification_KnownIdSendsToBackend`
- `TestHandleIntervalNotification_DropOnBackpressure` — pins the non-blocking select arm: with a full backendChan, the new event is dropped and the prior buffered event survives unchanged
- `TestHandleCurveLogNotification_UnknownIdResetsCloseSignal`
- `TestHandleCurveLogNotification_DecrementsThreadsAndForwards`
- `TestHandleRCTick_FeederActiveStopsTicker`
- `TestHandleRCTick_FeederInactivePollsRC`
- `TestHandleFeederNotificationMessage_SubscribeOkFlipsNotificationOn`
- `TestHandleFeederNotificationMessage_MalformedMessagePreservesFlag` — defensive: garbage input leaves the flag unchanged

`handleFeederRegistration` is extracted but **not** unit-tested — it calls `connectToFeeder` which opens a real UDS socket, and mocking that requires more plumbing than the value it delivers here.

All 24 tests across `serviceMgr_dispatch_test.go` pass with `-race` (11 from #129 + 4 from #130 + 9 from this PR).

### Depends on

PRs #129 and #130 merging first — this branch is stacked on `refactor/servicemgr-subscribe-arm`.

### Series context

| PR | Subsystem |
|---|---|
| #129 | serviceMgr (main batch of 6 dispatch arms) |
| #130 | serviceMgr subscribe arm |
| **this PR** | serviceMgr notification arms |
| (next) | Storage-backend interface injection |