### PR TITLE
Fix/servicemgr tier1 bugs

### DIFF
--- a/server/vissv2server/serviceMgr/serviceMgr.go
+++ b/server/vissv2server/serviceMgr/serviceMgr.go
@@ -1395,23 +1395,23 @@ func handleServiceGet(requestMap map[string]interface{}, responseMap map[string]
 }
 
 // handleServiceSubscribe processes a "subscribe" action: builds a
-// SubscriptionState from the request, validates the filter, appends
-// it to the subscription list, activates interval/curve-log timers
-// when needed via activateIfIntervalOrCL, and notifies the feeder for
-// curvelog/range/change variants. Returns the updated subscription
-// list and the next subscriptionId. Extracted from ServiceMgrInit's
-// dataChan switch as a follow-up to PR #129 — the inline version
-// carried a TODO(testing) note pointing here.
+// SubscriptionState from the request, validates the path and filter,
+// appends it to the subscription list, activates interval/curve-log
+// timers when needed via activateIfIntervalOrCL, and notifies the
+// feeder for curvelog/range/change variants. Returns the updated
+// subscription list and the next subscriptionId. Extracted from
+// ServiceMgrInit's dataChan switch as a follow-up to PR #129.
 //
-// PRE-EXISTING BUGS preserved as-is (file separately for fix):
-//   1. After the empty-FilterList error response, execution falls
-//      through to append the subscription anyway, producing a second
-//      message on dataChan. The original arm had no `break` after the
-//      `dataChan <- errorResponseMap` send and we preserve that bug
-//      here so this stays behaviour-preserving. See the marker below.
-//   2. subscriptionState.Path is dereferenced at index 0 without a
-//      nil check. If unpackPaths returned nil (malformed JSON path
-//      array), this panics. Original code has the same hazard.
+// This is the post-fix version: the two pre-existing bugs documented
+// when the function was extracted are now fixed.
+//   1. The empty-FilterList error path now `return`s instead of
+//      falling through to append the empty-filter subscription. The
+//      original (and prior extracted) code sent the invalid_data
+//      error then kept going, producing a second message on dataChan
+//      and growing the subscription list with garbage.
+//   2. subscriptionState.Path is now nil-checked after unpackPaths
+//      before any Path[0] access. A malformed JSON path array
+//      (`["Vehicle.Speed`) would previously panic here.
 func handleServiceSubscribe(
 	requestMap map[string]interface{},
 	responseMap map[string]interface{},
@@ -1426,6 +1426,11 @@ func handleServiceSubscribe(
 	subscriptionState.SubscriptionId = subscriptionId
 	subscriptionState.RouterId = requestMap["RouterId"].(string)
 	subscriptionState.Path = unpackPaths(requestMap["path"].(string))
+	if len(subscriptionState.Path) == 0 { // Fix bug 2: unpackPaths returned nil for malformed JSON
+		utils.SetErrorResponse(requestMap, errorResponseMap, 0, "") //bad_request
+		dataChan <- errorResponseMap
+		return subscriptionList, subscriptionId
+	}
 	if requestMap["filter"] == nil || requestMap["filter"] == "" {
 		utils.SetErrorResponse(requestMap, errorResponseMap, 0, "") //bad_request
 		dataChan <- errorResponseMap
@@ -1435,10 +1440,7 @@ func handleServiceSubscribe(
 	if len(subscriptionState.FilterList) == 0 {
 		utils.SetErrorResponse(requestMap, errorResponseMap, 1, "") //invalid_data
 		dataChan <- errorResponseMap
-		// BUG-PRESERVED: original arm had no break here. Execution
-		// continues and appends the empty-filter subscription, then
-		// sends a second response on dataChan further down. Fix in a
-		// separate PR so reviewers see exactly what changed.
+		return subscriptionList, subscriptionId // Fix bug 1: return instead of falling through
 	}
 	if requestMap["gatingId"] != nil {
 		subscriptionState.GatingId = requestMap["gatingId"].(string)
@@ -1558,28 +1560,45 @@ func handleIntervalNotification(subscriptionId int, subscriptionList []Subscript
 // subscription, removes it from the list when this was the
 // close-signal for the requested subscription, and forwards the data
 // pack to backendChan. Reads and clears the package global
-// closeClSubId in the close-signal path. Returns the updated
-// subscriptionList. Extracted from ServiceMgrInit in follow-up PR B
-// to #129.
+// closeClSubId under mcloseClSubId so the close-signal observation is
+// race-safe relative to deactivateSubscription. Returns the updated
+// subscriptionList.
 //
-// PRE-EXISTING HAZARD preserved as-is (file separately for fix):
-// after removeFromsubscriptionList, `index` may now point past the
-// end of the slice (the helper does a swap-with-last + truncate). The
-// subsequent subscriptionList[index] accesses then panic when the
-// removed entry was the last one. The original arm has the same
-// hazard.
+// This is the post-fix version: two pre-existing bugs documented when
+// the function was extracted are now fixed.
+//   3. After removeFromsubscriptionList, `index` may point past the
+//      end of the slice (the helper does a swap-with-last + truncate).
+//      The post-remove code path now returns early instead of touching
+//      subscriptionList[index] again. There is no notification to
+//      forward for a subscription that just got removed.
+//   4. closeClSubId is read and written here without holding
+//      mcloseClSubId, while deactivateSubscription writes it under the
+//      mutex. We now lock around the entire read-modify-write so
+//      observation and clearing happen atomically with deactivate.
 func handleCurveLogNotification(clPack CLPack, subscriptionList []SubscriptionState, backendChan chan map[string]interface{}) []SubscriptionState {
 	index := getSubcriptionStateIndex(clPack.SubscriptionId, subscriptionList)
 	if index == -1 {
+		mcloseClSubId.Lock()
 		closeClSubId = -1
+		mcloseClSubId.Unlock()
 		return subscriptionList
 	}
-	//subscriptionState := subscriptionList[index]
 	subscriptionList[index].SubscriptionThreads--
-	if clPack.SubscriptionId == closeClSubId && subscriptionList[index].SubscriptionThreads == 0 {
-		subscriptionList = removeFromsubscriptionList(subscriptionList, index)
+
+	mcloseClSubId.Lock()
+	shouldRemove := clPack.SubscriptionId == closeClSubId && subscriptionList[index].SubscriptionThreads == 0
+	if shouldRemove {
 		closeClSubId = -1
 	}
+	mcloseClSubId.Unlock()
+
+	if shouldRemove {
+		// Fix bug 3: do not attempt to index into the slice after the
+		// remove. The subscription is gone; there is no notification
+		// event to forward for it.
+		return removeFromsubscriptionList(subscriptionList, index)
+	}
+
 	var subscriptionMap = make(map[string]interface{})
 	subscriptionMap["action"] = "subscription"
 	subscriptionMap["ts"] = utils.GetRfcTime()

--- a/server/vissv2server/serviceMgr/serviceMgr.go
+++ b/server/vissv2server/serviceMgr/serviceMgr.go
@@ -458,7 +458,7 @@ func getIntervalPeriod(opValue string) int { // {"period":"X"}
 	}
 	period, err := strconv.Atoi(intervalData.Period)
 	if err != nil {
-		utils.Error.Printf("getIntervalPeriod: Invalid period=%s", period)
+		utils.Error.Printf("getIntervalPeriod: Invalid period=%q, err=%v", intervalData.Period, err)
 		return -1
 	}
 	return period
@@ -1430,6 +1430,143 @@ func feederReader(udsConn net.Conn, feederName string, feederChannelIndex int) {
 	}
 }
 
+// buildServiceResponseMap returns the standard response skeleton used
+// for replies to dataChan requests inside ServiceMgrInit. Extracted in
+// PR #129 (this PR) so the per-action handlers below can share the
+// setup without duplicating the six-line dance. See
+// serviceMgr_dispatch_test.go.
+func buildServiceResponseMap(requestMap map[string]interface{}) map[string]interface{} {
+	responseMap := make(map[string]interface{})
+	responseMap["RouterId"] = requestMap["RouterId"]
+	responseMap["action"] = requestMap["action"]
+	responseMap["requestId"] = requestMap["requestId"]
+	responseMap["ts"] = utils.GetRfcTime()
+	if requestMap["handle"] != nil {
+		responseMap["authorization"] = requestMap["handle"]
+	}
+	return responseMap
+}
+
+// handleServiceSet processes a "set" action: writes the value via the
+// state-storage backend (setVehicleData) and pushes a success or
+// service_unavailable response back on dataChan. Extracted from
+// ServiceMgrInit's dataChan switch in PR #129.
+func handleServiceSet(requestMap map[string]interface{}, responseMap map[string]interface{}, dataChan chan map[string]interface{}) {
+	var ts string
+	switch requestMap["value"].(type) {
+	case string:
+		ts = setVehicleData(requestMap["path"].(string), requestMap["value"].(string))
+	case map[string]interface{}:
+		data, _ := json.Marshal(requestMap["value"])
+		ts = setVehicleData(requestMap["path"].(string), string(data))
+	}
+	if len(ts) == 0 {
+		utils.SetErrorResponse(requestMap, errorResponseMap, 7, "") //service_unavailable
+		dataChan <- errorResponseMap
+		return
+	}
+	responseMap["ts"] = ts
+	dataChan <- responseMap
+}
+
+// handleServiceGet processes a "get" action: unpacks the path array,
+// validates an optional filter, fetches the data pack via
+// getDataPackMap, and pushes the response on dataChan. Extracted from
+// ServiceMgrInit in PR #129. Error paths emit invalid_data or
+// bad_request as appropriate.
+func handleServiceGet(requestMap map[string]interface{}, responseMap map[string]interface{}, dataChan chan map[string]interface{}) {
+	pathArray := unpackPaths(requestMap["path"].(string))
+	if pathArray == nil {
+		utils.Error.Printf("Unmarshal of path array failed.")
+		utils.SetErrorResponse(requestMap, errorResponseMap, 1, "") //invalid_data
+		dataChan <- errorResponseMap
+		return
+	}
+	var filterList []utils.FilterObject
+	if requestMap["filter"] != nil && requestMap["filter"] != "" {
+		utils.UnpackFilter(requestMap["filter"], &filterList)
+		if len(filterList) == 0 {
+			utils.Error.Printf("Request filter malformed.")
+			utils.SetErrorResponse(requestMap, errorResponseMap, 0, "") //bad_request
+			dataChan <- errorResponseMap
+			return
+		}
+	}
+	dataPack := getDataPackMap(pathArray)
+	responseMap["data"] = dataPack["dpack"]
+	dataChan <- responseMap
+}
+
+// handleServiceUnsubscribe processes a client-driven "unsubscribe"
+// action: deactivates the subscription identified by subscriptionId,
+// forwards the request to the feeder so it can drop its end of the
+// stream, and replies to the client. Returns the updated
+// subscriptionList. On missing or invalid subscriptionId an
+// invalid_data error is sent back. Extracted from ServiceMgrInit in
+// PR #129.
+func handleServiceUnsubscribe(requestMap map[string]interface{}, responseMap map[string]interface{}, dataChan chan map[string]interface{}, subscriptionList []SubscriptionState, toFeederChan chan string) []SubscriptionState {
+	if requestMap["subscriptionId"] != nil {
+		status := -1
+		subscriptId, ok := requestMap["subscriptionId"].(string)
+		if ok == true {
+			status, subscriptionList = deactivateSubscription(subscriptionList, subscriptId)
+			if status != -1 {
+				dataChan <- responseMap
+				toFeederChan <- utils.FinalizeMessage(requestMap)
+				return subscriptionList
+			}
+			delete(requestMap, "subscriptionId")
+		}
+	}
+	utils.SetErrorResponse(requestMap, errorResponseMap, 1, "") //invalid_data
+	dataChan <- errorResponseMap
+	return subscriptionList
+}
+
+// handleInternalKillSubscriptions processes the
+// "internal-killsubscriptions" action: scans the subscription list and
+// removes every entry whose RouterId matches the request. No response
+// is emitted — this is an internal cleanup message. Returns the
+// updated subscriptionList. Extracted from ServiceMgrInit in PR #129.
+func handleInternalKillSubscriptions(requestMap map[string]interface{}, subscriptionList []SubscriptionState) []SubscriptionState {
+	isRemoved := true
+	for isRemoved == true {
+		isRemoved, subscriptionList = scanAndRemoveListItem(subscriptionList, requestMap["RouterId"].(string))
+		utils.Info.Printf("internal-killsubscriptions: RouterId = %s", requestMap["RouterId"].(string))
+	}
+	return subscriptionList
+}
+
+// handleInternalCancelSubscription processes the
+// "internal-cancelsubscription" action used when the AGT cancels a
+// token or consent: looks up the subscription by gatingId, rewrites the
+// request as a synthetic "subscription" error event, pushes it to the
+// client, and removes the subscription from the list. Returns the
+// updated subscriptionList. If the gatingId is not found, the list is
+// returned unchanged. Extracted from ServiceMgrInit in PR #129.
+func handleInternalCancelSubscription(requestMap map[string]interface{}, dataChan chan map[string]interface{}, subscriptionList []SubscriptionState) []SubscriptionState {
+	routerId, subscriptionId := getSubscriptionData(subscriptionList, requestMap["gatingId"].(string))
+	if routerId != "" {
+		requestMap["RouterId"] = routerId
+		requestMap["action"] = "subscription"
+		requestMap["requestId"] = nil
+		requestMap["subscriptionId"] = subscriptionId
+		utils.SetErrorResponse(requestMap, errorResponseMap, 2, "Token expired or consent cancelled.")
+		dataChan <- errorResponseMap
+		_, subscriptionList = scanAndRemoveListItem(subscriptionList, routerId)
+	}
+	return subscriptionList
+}
+
+// handleUnknownAction handles the default arm of the dataChan switch:
+// emits an invalid_data response with "Unknown action" as the message.
+// Extracted from ServiceMgrInit in PR #129 so the default arm is just
+// one line at the call site.
+func handleUnknownAction(requestMap map[string]interface{}, dataChan chan map[string]interface{}) {
+	utils.SetErrorResponse(requestMap, errorResponseMap, 1, "Unknown action") //invalid_data
+	dataChan <- errorResponseMap
+}
+
 func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, stateStorageType string, histSupport bool, dbFile string) {
 	stateDbType = stateStorageType
 	historySupport = histSupport
@@ -1573,60 +1710,21 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 		select {
 		case requestMap := <-dataChan: // request from server core
 //			utils.Info.Printf("Service manager: Request from Server core:%s\n", requestMap["action"].(string))
-			var responseMap = make(map[string]interface{})
-			responseMap["RouterId"] = requestMap["RouterId"]
-			responseMap["action"] = requestMap["action"]
-			responseMap["requestId"] = requestMap["requestId"]
-			responseMap["ts"] = utils.GetRfcTime()
-			if requestMap["handle"] != nil {
-				responseMap["authorization"] = requestMap["handle"]
-			}
+			responseMap := buildServiceResponseMap(requestMap)
 			switch requestMap["action"] {
 			case "invoke": // invokeVehicleService(...
 			case "set":
-				var ts string
-				switch requestMap["value"].(type) {
-					case string:
-						ts = setVehicleData(requestMap["path"].(string), requestMap["value"].(string))
-					case map[string]interface{}:
-						data, _ := json.Marshal(requestMap["value"])
-						ts = setVehicleData(requestMap["path"].(string), string(data))
-				}
-				if len(ts) == 0 {
-					utils.SetErrorResponse(requestMap, errorResponseMap, 7, "") //service_unavailable
-					dataChan <- errorResponseMap
-					break
-				}
-				responseMap["ts"] = ts
-				dataChan <- responseMap
+				handleServiceSet(requestMap, responseMap, dataChan)
 			case "get":
-				pathArray := unpackPaths(requestMap["path"].(string))
-				if pathArray == nil {
-					utils.Error.Printf("Unmarshal of path array failed.")
-					utils.SetErrorResponse(requestMap, errorResponseMap, 1, "") //invalid_data
-					dataChan <- errorResponseMap
-					break
-				}
-				var filterList []utils.FilterObject
-				if requestMap["filter"] != nil && requestMap["filter"] != "" {
-					utils.UnpackFilter(requestMap["filter"], &filterList)
-					if len(filterList) == 0 {
-						utils.Error.Printf("Request filter malformed.")
-						utils.SetErrorResponse(requestMap, errorResponseMap, 0, "") //bad_request
-						dataChan <- errorResponseMap
-						break
-					}
-				}
-				dataPack := getDataPackMap(pathArray)
-/*				if len(dataPack) == 0 {
-					utils.Info.Printf("No historic data available")
-					utils.SetErrorResponse(requestMap, errorResponseMap, 6, "") //unavailable_data
-					dataChan <- errorResponseMap
-					break
-				}*/
-				responseMap["data"] = dataPack["dpack"]
-				dataChan <- responseMap
+				handleServiceGet(requestMap, responseMap, dataChan)
 			case "subscribe":
+				// The subscribe arm is intentionally left inline for now —
+				// it mutates several locals (subscriptionList, subscriptionId)
+				// and sends on three channels (subscriptionChan, CLChannel,
+				// toFeeder), so extracting it cleanly is the next step in
+				// the refactor series. TODO(testing): pull this into
+				// handleServiceSubscribe once the channel ownership story
+				// is sorted.
 				var subscriptionState SubscriptionState
 				subscriptionState.SubscriptionId = subscriptionId
 				subscriptionState.RouterId = requestMap["RouterId"].(string)
@@ -1655,41 +1753,13 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 				subscriptionId++ // not to be incremented elsewhere
 				dataChan <- responseMap
 			case "unsubscribe":
-				if requestMap["subscriptionId"] != nil {
-					status := -1
-					subscriptId, ok := requestMap["subscriptionId"].(string)
-					if ok == true {
-						status, subscriptionList = deactivateSubscription(subscriptionList, subscriptId)
-						if status != -1 {
-							dataChan <- responseMap
-							toFeeder <- utils.FinalizeMessage(requestMap)
-							break
-						}
-						delete(requestMap, "subscriptionId")
-					}
-				}
-				utils.SetErrorResponse(requestMap, errorResponseMap, 1, "") //invalid_data
-				dataChan <- errorResponseMap
+				subscriptionList = handleServiceUnsubscribe(requestMap, responseMap, dataChan, subscriptionList, toFeeder)
 			case "internal-killsubscriptions":
-				isRemoved := true
-				for isRemoved == true {
-					isRemoved, subscriptionList = scanAndRemoveListItem(subscriptionList, requestMap["RouterId"].(string))
-					utils.Info.Printf("internal-killsubscriptions: RouterId = %s", requestMap["RouterId"].(string))
-				}
+				subscriptionList = handleInternalKillSubscriptions(requestMap, subscriptionList)
 			case "internal-cancelsubscription":
-				routerId, subscriptionId := getSubscriptionData(subscriptionList, requestMap["gatingId"].(string))
-				if routerId != "" {
-					requestMap["RouterId"] = routerId
-					requestMap["action"] = "subscription"
-					requestMap["requestId"] = nil
-					requestMap["subscriptionId"] = subscriptionId
-					utils.SetErrorResponse(requestMap, errorResponseMap, 2, "Token expired or consent cancelled.")
-					dataChan <- errorResponseMap
-					_, subscriptionList = scanAndRemoveListItem(subscriptionList, routerId)
-				}
+				subscriptionList = handleInternalCancelSubscription(requestMap, dataChan, subscriptionList)
 			default:
-				utils.SetErrorResponse(requestMap, errorResponseMap, 1, "Unknown action") //invalid_data
-					dataChan <- errorResponseMap
+				handleUnknownAction(requestMap, dataChan)
 			} // switch
 		case <-dummyTickerC:
 			dummyValue++

--- a/server/vissv2server/serviceMgr/serviceMgr.go
+++ b/server/vissv2server/serviceMgr/serviceMgr.go
@@ -1497,6 +1497,68 @@ func handleServiceGet(requestMap map[string]interface{}, responseMap map[string]
 	dataChan <- responseMap
 }
 
+// handleServiceSubscribe processes a "subscribe" action: builds a
+// SubscriptionState from the request, validates the filter, appends
+// it to the subscription list, activates interval/curve-log timers
+// when needed via activateIfIntervalOrCL, and notifies the feeder for
+// curvelog/range/change variants. Returns the updated subscription
+// list and the next subscriptionId. Extracted from ServiceMgrInit's
+// dataChan switch as a follow-up to PR #129 — the inline version
+// carried a TODO(testing) note pointing here.
+//
+// PRE-EXISTING BUGS preserved as-is (file separately for fix):
+//   1. After the empty-FilterList error response, execution falls
+//      through to append the subscription anyway, producing a second
+//      message on dataChan. The original arm had no `break` after the
+//      `dataChan <- errorResponseMap` send and we preserve that bug
+//      here so this stays behaviour-preserving. See the marker below.
+//   2. subscriptionState.Path is dereferenced at index 0 without a
+//      nil check. If unpackPaths returned nil (malformed JSON path
+//      array), this panics. Original code has the same hazard.
+func handleServiceSubscribe(
+	requestMap map[string]interface{},
+	responseMap map[string]interface{},
+	dataChan chan map[string]interface{},
+	subscriptionList []SubscriptionState,
+	subscriptionId int,
+	subscriptionChan chan int,
+	clChannel chan CLPack,
+	toFeederChan chan string,
+) ([]SubscriptionState, int) {
+	var subscriptionState SubscriptionState
+	subscriptionState.SubscriptionId = subscriptionId
+	subscriptionState.RouterId = requestMap["RouterId"].(string)
+	subscriptionState.Path = unpackPaths(requestMap["path"].(string))
+	if requestMap["filter"] == nil || requestMap["filter"] == "" {
+		utils.SetErrorResponse(requestMap, errorResponseMap, 0, "") //bad_request
+		dataChan <- errorResponseMap
+		return subscriptionList, subscriptionId
+	}
+	utils.UnpackFilter(requestMap["filter"], &(subscriptionState.FilterList))
+	if len(subscriptionState.FilterList) == 0 {
+		utils.SetErrorResponse(requestMap, errorResponseMap, 1, "") //invalid_data
+		dataChan <- errorResponseMap
+		// BUG-PRESERVED: original arm had no break here. Execution
+		// continues and appends the empty-filter subscription, then
+		// sends a second response on dataChan further down. Fix in a
+		// separate PR so reviewers see exactly what changed.
+	}
+	if requestMap["gatingId"] != nil {
+		subscriptionState.GatingId = requestMap["gatingId"].(string)
+	}
+	subscriptionState.LatestDataPoint = getVehicleData(subscriptionState.Path[0])
+	subscriptionList = append(subscriptionList, subscriptionState)
+	responseMap["subscriptionId"] = strconv.Itoa(subscriptionId)
+	subscriptionList = activateIfIntervalOrCL(subscriptionState.FilterList, subscriptionChan, clChannel, subscriptionId, subscriptionState.Path, subscriptionList)
+	variant := getFeederNotifyType(subscriptionState.FilterList)
+	if variant == "curvelog" || variant == "range" || variant == "change" {
+		toFeederChan <- createFeederNotifyMessage(variant, subscriptionState.Path, subscriptionId)
+	}
+	subscriptionId++ // not to be incremented elsewhere
+	dataChan <- responseMap
+	return subscriptionList, subscriptionId
+}
+
 // handleServiceUnsubscribe processes a client-driven "unsubscribe"
 // action: deactivates the subscription identified by subscriptionId,
 // forwards the request to the feeder so it can drop its end of the
@@ -1718,40 +1780,11 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 			case "get":
 				handleServiceGet(requestMap, responseMap, dataChan)
 			case "subscribe":
-				// The subscribe arm is intentionally left inline for now —
-				// it mutates several locals (subscriptionList, subscriptionId)
-				// and sends on three channels (subscriptionChan, CLChannel,
-				// toFeeder), so extracting it cleanly is the next step in
-				// the refactor series. TODO(testing): pull this into
-				// handleServiceSubscribe once the channel ownership story
-				// is sorted.
-				var subscriptionState SubscriptionState
-				subscriptionState.SubscriptionId = subscriptionId
-				subscriptionState.RouterId = requestMap["RouterId"].(string)
-				subscriptionState.Path = unpackPaths(requestMap["path"].(string))
-				if requestMap["filter"] == nil || requestMap["filter"] == "" {
-					utils.SetErrorResponse(requestMap, errorResponseMap, 0, "") //bad_request
-					dataChan <- errorResponseMap
-					break
-				}
-				utils.UnpackFilter(requestMap["filter"], &(subscriptionState.FilterList))
-				if len(subscriptionState.FilterList) == 0 {
-					utils.SetErrorResponse(requestMap, errorResponseMap, 1, "") //invalid_data
-					dataChan <- errorResponseMap
-				}
-				if requestMap["gatingId"] != nil {
-					subscriptionState.GatingId = requestMap["gatingId"].(string)
-				}
-				subscriptionState.LatestDataPoint = getVehicleData(subscriptionState.Path[0])
-				subscriptionList = append(subscriptionList, subscriptionState)
-				responseMap["subscriptionId"] = strconv.Itoa(subscriptionId)
-				subscriptionList = activateIfIntervalOrCL(subscriptionState.FilterList, subscriptionChan, CLChannel, subscriptionId, subscriptionState.Path, subscriptionList)
-				variant := getFeederNotifyType(subscriptionState.FilterList)
-				if variant == "curvelog" || variant == "range" || variant == "change" {
-					toFeeder <- createFeederNotifyMessage(variant, subscriptionState.Path, subscriptionId)
-				}
-				subscriptionId++ // not to be incremented elsewhere
-				dataChan <- responseMap
+				subscriptionList, subscriptionId = handleServiceSubscribe(
+					requestMap, responseMap, dataChan,
+					subscriptionList, subscriptionId,
+					subscriptionChan, CLChannel, toFeeder,
+				)
 			case "unsubscribe":
 				subscriptionList = handleServiceUnsubscribe(requestMap, responseMap, dataChan, subscriptionList, toFeeder)
 			case "internal-killsubscriptions":

--- a/server/vissv2server/serviceMgr/serviceMgr.go
+++ b/server/vissv2server/serviceMgr/serviceMgr.go
@@ -15,7 +15,6 @@ package serviceMgr
 import (
 	"database/sql"
 	"encoding/json"
-	"fmt"
 	"github.com/apache/iotdb-client-go/client"
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/covesa/vissr/utils"
@@ -98,15 +97,19 @@ const FEEDER_REG_SOCKFILE = FEEDER_REG_DIR + "feederReg.sock"
 
 var errorResponseMap = map[string]interface{}{}
 
-var dbHandle *sql.DB
-var dbErr error
-var redisClient *redis.Client
-var memcacheClient *memcache.Client
+// stateBackend is the storage adapter wired up by ServiceMgrInit.
+// It defaults to noneBackend{} so that any getVehicleData /
+// setVehicleData call before ServiceMgrInit finishes (e.g. inside
+// tests that exercise the dispatch helpers directly) does not
+// nil-deref. Replaced at init time with the adapter matching
+// stateDbType. See storage_backend.go for the interface contract and
+// the five adapter implementations.
+var stateBackend StorageBackend = &noneBackend{}
+
 var stateDbType string
 var historySupport bool
 
 // Apache IoTDB
-var IoTDBsession client.Session
 var IoTDBClientConfig = &client.Config{
 	Host:     "127.0.0.1",
 	Port:     "6667",
@@ -526,127 +529,21 @@ func activateIfIntervalOrCL(filterList []utils.FilterObject, subscriptionChan ch
 	return subscriptionList
 }
 
+// getVehicleData reads the data point at path through the configured
+// state-storage backend and returns the canonical
+// {"value":"...","ts":"..."} JSON string. The long backend-specific
+// switch that used to live here has been moved into the adapter
+// implementations in storage_backend.go.
 func getVehicleData(path string) string { // returns {"value":"Y", "ts":"Z"}
-	switch stateDbType {
-	case "sqlite":
-
-		rows, err := dbHandle.Query("SELECT `c_value`, `c_ts` FROM VSS_MAP WHERE `path`=?", path)
-		if err != nil {
-			return `{"value":"Data-error", "ts":"` + utils.GetRfcTime() + `"}`
-		}
-		defer rows.Close()
-		value := ""
-		timestamp := ""
-
-		rows.Next()
-		err = rows.Scan(&value, &timestamp)
-		if err != nil {
-			utils.Warning.Printf("Data not found: %s for path=%s", err, path)
-			return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
-		}
-		return `{"value":"` + value + `", "ts":"` + timestamp + `"}`
-	case "redis":
-//		utils.Info.Printf(path)
-		dp, err := redisClient.Get(path).Result()
-		if err != nil {
-			if err.Error() != "redis: nil" {
-				utils.Error.Printf("Job failed. Error()=%s", err.Error())
-				return `{"value":"Database-error", "ts":"` + utils.GetRfcTime() + `"}`
-			} else {
-//				utils.Warning.Printf("Data not found.")
-				return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
-			}
-		} else {
-			return dp
-		}
-	case "apache-iotdb":
-		var (
-			// Back-quote the VSS node for the DB query, e.g. `Vehicle.CurrentLocation.Longitude`
-			selectLastSQL = fmt.Sprintf("select last `%v` from %v", path, IoTDBConfig.PrefixPath)
-			value         = ""
-			ts            = ""
-		)
-		//		utils.Info.Printf("IoTDB: query using: %v", selectLastSQL)
-		sessionDataSet, err := IoTDBsession.ExecuteQueryStatement(selectLastSQL, &IoTDBConfig.Timeout)
-		if err == nil {
-			var success bool
-			success, err = sessionDataSet.Next()
-			if err == nil && success {
-				value = sessionDataSet.GetText("Value")
-				ts = sessionDataSet.GetText(client.TimestampColumnName)
-				//				utils.Info.Printf("IoTDB: get returned: ts=%v, Value=%v", ts, value)
-				//				resultStr := `{"value":"` + value + `", "ts":"` + ts + `"}`
-				//				utils.Info.Printf("IoTDB: returning get result=%v", resultStr)
-			}
-			sessionDataSet.Close()
-		} else {
-			utils.Error.Printf("IoTDB: Query failed with error=%s", err)
-			return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
-		}
-		return `{"value":"` + value + `", "ts":"` + ts + `"}`
-	case "memcache":
-		mcItem, err := memcacheClient.Get(path)
-		if err != nil {
-			if err.Error() != "memcache: cache miss" {
-				utils.Error.Printf("Job failed. Error()=%s", err.Error())
-				return `{"value":"Database-error", "ts":"` + utils.GetRfcTime() + `"}`
-			} else {
-				utils.Warning.Printf("Data not found.")
-				return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
-			}
-		} else {
-			return string(mcItem.Value)
-		}
-	case "none":
-		return `{"value":"` + strconv.Itoa(dummyValue) + `", "ts":"` + utils.GetRfcTime() + `"}`
-	}
-	return ""
+	return stateBackend.Get(path)
 }
 
+// setVehicleData writes value at path through the configured
+// state-storage backend and returns the timestamp used for the write
+// (or "" on failure). The backend-specific switch is now in the
+// adapter implementations -- see storage_backend.go.
 func setVehicleData(path string, value string) string {
-	ts := utils.GetRfcTime()
-	switch stateDbType {
-	case "sqlite":
-		stmt, err := dbHandle.Prepare("UPDATE VSS_MAP SET d_value=?, d_ts=? WHERE `path`=?")
-		if err != nil {
-			utils.Error.Printf("Could not prepare for statestorage updating, err = %s", err)
-			return ""
-		}
-		defer stmt.Close()
-
-		_, err = stmt.Exec(value, ts, path[1:len(path)-1]) // remove quotes surrounding path
-		if err != nil {
-			utils.Error.Printf("Could not update statestorage, err = %s", err)
-			return ""
-		}
-		return ts
-	case "memcache":
-		fallthrough
-	case "redis":
-		message := `{"action": "set", "data": {"path":"` + path + `", "dp":{"value":"` + value + `", "ts":"` + ts + `"}}}`
-		toFeeder <- message
-		return ts
-	case "apache-iotdb":
-		vssKey := []string{"`" + path + "`"} // Back-quote the VSS node for the DB insert, e.g. `Vehicle.CurrentLocation.Longitude`
-		vssValue := []string{value}
-		IoTDBts := time.Now().UTC().UnixNano() / 1000000
-
-		// IoTDB will automatically convert the value string to the native data type in the timeseries schema for basic types
-		//		utils.Info.Printf("IoTDB: DB insert with prefixPath: %v vssKey: %v, vssValue: %v, ts: %v", IoTDBConfig.PrefixPath, vssKey, vssValue, IoTDBts)
-		if status, err := IoTDBsession.InsertStringRecord(IoTDBConfig.PrefixPath, vssKey, vssValue, IoTDBts); err != nil {
-			utils.Error.Printf("IoTDB: DB insert using InsertStringRecord failed with: %v", err)
-			return ""
-		} else {
-			if status != nil {
-				if err = client.VerifySuccess(status); err != nil {
-					utils.Error.Printf("IoTDB: DB insert Verify failed with: %v", err)
-					return ""
-				}
-			}
-		}
-		return ts
-	}
-	return ""
+	return stateBackend.Set(path, value)
 }
 
 func unpackPaths(paths string) []string {
@@ -1736,16 +1633,21 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 
 	utils.ReadUdsRegistrations("uds-registration.json")
 
+	// toFeeder is created here (moved up from its old slot further
+	// below) so the redis and memcache adapters can capture it at
+	// construction time rather than referencing a package global.
+	toFeeder = make(chan string)
+
 	switch stateDbType {
 	case "sqlite":
 		if utils.FileExists(dbFile) {
-			dbHandle, dbErr = sql.Open("sqlite3", dbFile)
-			if dbErr != nil {
-				utils.Error.Printf("Could not open state storage file = %s, err = %s", dbFile, dbErr)
+			db, openErr := sql.Open("sqlite3", dbFile)
+			if openErr != nil {
+				utils.Error.Printf("Could not open state storage file = %s, err = %s", dbFile, openErr)
 				os.Exit(1)
-			} else {
-				utils.Info.Printf("SQLite state storage initialised.")
 			}
+			stateBackend = newSqliteBackend(db)
+			utils.Info.Printf("SQLite state storage initialised.")
 		} else {
 			utils.Error.Printf("Could not find state storage file = %s", dbFile)
 		}
@@ -1757,28 +1659,27 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 			return
 		}
 		utils.Info.Printf(addr)
-		redisClient = redis.NewClient(&redis.Options{
+		redisCli := redis.NewClient(&redis.Options{
 			Network:  "unix",
 			Addr:     addr,
 			Password: "",
 			DB:       1,
 		})
-		err := redisClient.Ping().Err()
-		if err != nil {
+		if err := redisCli.Ping().Err(); err != nil {
 			utils.Info.Printf("Redis-server not started. Trying to start it.")
 			if utils.FileExists("redis.log") {
 				os.Remove("redis.log")
 			}
 			cmd := exec.Command("/usr/bin/bash", "redisNativeInit.sh")
-			err := cmd.Run()
-			if err != nil {
-				utils.Error.Printf("redis-server startup failed, err=%s", err)
+			if runErr := cmd.Run(); runErr != nil {
+				utils.Error.Printf("redis-server startup failed, err=%s", runErr)
 				// os.Exit(1) should terminate the process
 				return
 			}
 		} else {
 			utils.Info.Printf("Redis state ping is ok")
 		}
+		stateBackend = newRedisBackend(redisCli, toFeeder)
 		utils.Info.Printf("Redis state storage initialised.")
 	case "apache-iotdb":
 		// Read configuration from file if present else use defaults
@@ -1806,12 +1707,13 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 
 		// Create new client session with IoTDB server
 		utils.Info.Printf("IoTDB: Creating new session with client config = %+v", *IoTDBClientConfig)
-		IoTDBsession = client.NewSession(IoTDBClientConfig)
-		if err := IoTDBsession.Open(false, 0); err != nil {
+		session := client.NewSession(IoTDBClientConfig)
+		if err := session.Open(false, 0); err != nil {
 			utils.Error.Printf("IoTDB: Failed to open server session with error=%s", err)
 			os.Exit(1)
 		}
-		defer IoTDBsession.Close()
+		defer session.Close()
+		stateBackend = newIoTDBBackend(session, IoTDBConfig)
 	case "memcache":
 		addr := utils.GetUdsPath("Vehicle", "memcache")
 		if len(addr) == 0 {
@@ -1819,19 +1721,24 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 			// os.Exit(1) should terminate the process
 			return
 		}
-		memcacheClient = memcache.New(addr)
-		err := memcacheClient.Ping()
-		if err != nil {
+		mcCli := memcache.New(addr)
+		if err := mcCli.Ping(); err != nil {
 			utils.Info.Printf("Memcache daemon not alive. Trying to start it")
 			cmd := exec.Command("/usr/bin/bash", "memcacheNativeInit.sh")
-			err := cmd.Run()
-			if err != nil {
-				utils.Error.Printf("Memcache daemon startup failed, err=%s", err)
+			if runErr := cmd.Run(); runErr != nil {
+				utils.Error.Printf("Memcache daemon startup failed, err=%s", runErr)
 				// os.Exit(1) should terminate the process
 				return
 			}
 		}
+		stateBackend = newMemcacheBackend(mcCli, toFeeder)
 		utils.Info.Printf("Memcache daemon alive.")
+	case "none":
+		// noneBackend is also the package-level default for
+		// stateBackend, so this case is a no-op (kept explicit so the
+		// init log lines line up with the documented set of backends).
+		stateBackend = newNoneBackend()
+		utils.Info.Printf("State storage type = none (dummyValue counter backend).")
 	default:
 		utils.Error.Printf("Unknown state storage type = %s", stateDbType)
 	}
@@ -1853,7 +1760,8 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 	go initDataServer(serviceMgrChan, dataChan, backendChan)
 	feederRegChan := make(chan FeederRegElem)
 	go initFeederRegServer(feederRegChan)
-	toFeeder = make(chan string)
+	// toFeeder was moved up to before the storage init switch so the
+	// redis/memcache adapters can capture it at construction time.
 	fromFeederRorC = make(chan string)
 	fromFeederCl = make(chan string)
 	go feederFrontend(toFeeder, fromFeederRorC, fromFeederCl)

--- a/server/vissv2server/serviceMgr/serviceMgr.go
+++ b/server/vissv2server/serviceMgr/serviceMgr.go
@@ -1629,6 +1629,107 @@ func handleUnknownAction(requestMap map[string]interface{}, dataChan chan map[st
 	dataChan <- errorResponseMap
 }
 
+// handleIntervalNotification handles a fire on subscriptionChan (an
+// interval-based subscription's timer ticked). Looks up the
+// subscription, builds a notification event with the current data
+// pack, and pushes it to backendChan with a non-blocking select — the
+// original arm drops the event rather than block when backendChan is
+// full. Extracted from ServiceMgrInit in follow-up PR B to #129.
+func handleIntervalNotification(subscriptionId int, subscriptionList []SubscriptionState, backendChan chan map[string]interface{}) {
+	subIndex := getSubcriptionStateIndex(subscriptionId, subscriptionList)
+	if subIndex == -1 {
+		utils.Error.Printf("Subscription not found for id=%d", subscriptionId)
+		return
+	}
+	subscriptionState := subscriptionList[subIndex]
+	var subscriptionMap = make(map[string]interface{})
+	subscriptionMap["action"] = "subscription"
+	subscriptionMap["ts"] = utils.GetRfcTime()
+	subscriptionMap["subscriptionId"] = strconv.Itoa(subscriptionState.SubscriptionId)
+	subscriptionMap["RouterId"] = subscriptionState.RouterId
+	subscriptionMap["data"] = getDataPackMap(subscriptionState.Path)["dpack"]
+	select {
+	case backendChan <- subscriptionMap:
+	default:
+		utils.Error.Printf("serviceMgr: Event dropped")
+	}
+}
+
+// handleCurveLogNotification handles a fire on CLChannel (a
+// curve-logging worker has produced a data point or is signalling
+// shutdown). Decrements the SubscriptionThreads counter for the
+// subscription, removes it from the list when this was the
+// close-signal for the requested subscription, and forwards the data
+// pack to backendChan. Reads and clears the package global
+// closeClSubId in the close-signal path. Returns the updated
+// subscriptionList. Extracted from ServiceMgrInit in follow-up PR B
+// to #129.
+//
+// PRE-EXISTING HAZARD preserved as-is (file separately for fix):
+// after removeFromsubscriptionList, `index` may now point past the
+// end of the slice (the helper does a swap-with-last + truncate). The
+// subsequent subscriptionList[index] accesses then panic when the
+// removed entry was the last one. The original arm has the same
+// hazard.
+func handleCurveLogNotification(clPack CLPack, subscriptionList []SubscriptionState, backendChan chan map[string]interface{}) []SubscriptionState {
+	index := getSubcriptionStateIndex(clPack.SubscriptionId, subscriptionList)
+	if index == -1 {
+		closeClSubId = -1
+		return subscriptionList
+	}
+	//subscriptionState := subscriptionList[index]
+	subscriptionList[index].SubscriptionThreads--
+	if clPack.SubscriptionId == closeClSubId && subscriptionList[index].SubscriptionThreads == 0 {
+		subscriptionList = removeFromsubscriptionList(subscriptionList, index)
+		closeClSubId = -1
+	}
+	var subscriptionMap = make(map[string]interface{})
+	subscriptionMap["action"] = "subscription"
+	subscriptionMap["ts"] = utils.GetRfcTime()
+	subscriptionMap["subscriptionId"] = strconv.Itoa(subscriptionList[index].SubscriptionId)
+	subscriptionMap["RouterId"] = subscriptionList[index].RouterId
+	subscriptionMap["data"] = string2Map(clPack.DataPack)["s2m"]
+	backendChan <- subscriptionMap
+	return subscriptionList
+}
+
+// handleRCTick handles a fire on the subscription ticker, which polls
+// range/change filters periodically when the feeder is not providing
+// its own notifications. If the feeder is providing notifications,
+// the ticker is stopped to save the wakeups. Returns the updated
+// subscriptionList. Extracted from ServiceMgrInit in follow-up PR B
+// to #129.
+func handleRCTick(feederNotificationActive bool, subscriptTicker *time.Ticker, subscriptionList []SubscriptionState, backendChan chan map[string]interface{}) []SubscriptionState {
+	if !feederNotificationActive { // feeder does not issue notifications
+		return checkRCFilterAndIssueMessages("", subscriptionList, backendChan)
+	}
+	subscriptTicker.Stop()
+	return subscriptionList
+}
+
+// handleFeederNotificationMessage handles a fire on fromFeederRorC.
+// Decodes the feeder's message, updates the feederNotification flag
+// returned by decodeFeederMessage, and re-evaluates the subscription
+// list's range/change filters for the triggered path. Returns the
+// updated feederNotification flag and subscriptionList. Extracted
+// from ServiceMgrInit in follow-up PR B to #129.
+func handleFeederNotificationMessage(feederMessage string, feederNotification bool, subscriptionList []SubscriptionState, backendChan chan map[string]interface{}) (bool, []SubscriptionState) {
+	triggeredPath, updatedNotification := decodeFeederMessage(feederMessage, feederNotification)
+	subscriptionList = checkRCFilterAndIssueMessages(triggeredPath, subscriptionList, backendChan)
+	return updatedNotification, subscriptionList
+}
+
+// handleFeederRegistration handles a fire on feederRegChan. Connects
+// to the registering feeder, updates the registry list, and sends the
+// current list of feeder names back on feederRegChan as the
+// registration acknowledgement. Extracted from ServiceMgrInit in
+// follow-up PR B to #129.
+func handleFeederRegistration(feederReq FeederRegElem, feederRegChan chan FeederRegElem) {
+	connectToFeeder(&feederReq)
+	updateFeederRegList(feederReq)
+	feederRegChan <- createFeederNameList()
+}
+
 func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, stateStorageType string, histSupport bool, dbFile string) {
 	stateDbType = stateStorageType
 	historySupport = histSupport
@@ -1766,7 +1867,6 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 	subscriptTicker := time.NewTicker(23 * time.Millisecond) //range/change subscription ticker when no feeder notifications
 	feederReconnectTicker := time.NewTicker(2 * time.Second)
 	feederNotification := false
-	triggeredPath := ""
 
 	for {
 		select {
@@ -1800,58 +1900,18 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 				dummyValue = 0
 			}
 		case subscriptionId := <-subscriptionChan: // interval notification triggered
-			subIndex := getSubcriptionStateIndex(subscriptionId, subscriptionList)
-			if subIndex == -1 {
-				utils.Error.Printf("Subscription not found for id=%d", subscriptionId)
-				continue
-			}
-			subscriptionState := subscriptionList[subIndex]
-			var subscriptionMap = make(map[string]interface{})
-			subscriptionMap["action"] = "subscription"
-			subscriptionMap["ts"] = utils.GetRfcTime()
-			subscriptionMap["subscriptionId"] = strconv.Itoa(subscriptionState.SubscriptionId)
-			subscriptionMap["RouterId"] = subscriptionState.RouterId
-			subscriptionMap["data"] = getDataPackMap(subscriptionState.Path)["dpack"]
-			select {
-			case backendChan <- subscriptionMap:
-			default: 
-				utils.Error.Printf("serviceMgr: Event dropped")
-			}
+			handleIntervalNotification(subscriptionId, subscriptionList, backendChan)
 		case clPack := <-CLChannel: // curve logging notification
-			index := getSubcriptionStateIndex(clPack.SubscriptionId, subscriptionList)
-			if index == -1 {
-				closeClSubId = -1
-				continue
-			}
-			//subscriptionState := subscriptionList[index]
-			subscriptionList[index].SubscriptionThreads--
-			if clPack.SubscriptionId == closeClSubId && subscriptionList[index].SubscriptionThreads == 0 {
-				subscriptionList = removeFromsubscriptionList(subscriptionList, index)
-				closeClSubId = -1
-			}
-			var subscriptionMap = make(map[string]interface{})
-			subscriptionMap["action"] = "subscription"
-			subscriptionMap["ts"] = utils.GetRfcTime()
-			subscriptionMap["subscriptionId"] = strconv.Itoa(subscriptionList[index].SubscriptionId)
-			subscriptionMap["RouterId"] = subscriptionList[index].RouterId
-			subscriptionMap["data"] = string2Map(clPack.DataPack)["s2m"]
-			backendChan <- subscriptionMap
+			subscriptionList = handleCurveLogNotification(clPack, subscriptionList, backendChan)
 		case <-subscriptTicker.C:
-			if feederNotification == false { // feeder does not issue notifications
-				subscriptionList = checkRCFilterAndIssueMessages("", subscriptionList, backendChan)
-			} else {
-				subscriptTicker.Stop()
-			}
+			subscriptionList = handleRCTick(feederNotification, subscriptTicker, subscriptionList, backendChan)
 		case <-feederReconnectTicker.C:
 			feederConnectRetry()
 		case feederMessage := <-fromFeederRorC:
 //utils.Info.Printf("Feeder message=%s", feederMessage)
-			triggeredPath, feederNotification = decodeFeederMessage(feederMessage, feederNotification)
-			subscriptionList = checkRCFilterAndIssueMessages(triggeredPath, subscriptionList, backendChan)
+			feederNotification, subscriptionList = handleFeederNotificationMessage(feederMessage, feederNotification, subscriptionList, backendChan)
 		case feederReq := <- feederRegChan:
-			connectToFeeder(&feederReq)
-			updateFeederRegList(feederReq)
-			feederRegChan <- createFeederNameList()
+			handleFeederRegistration(feederReq, feederRegChan)
 		} // select
 	} // for
 utils.Info.Printf("Service manager exit")

--- a/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
+++ b/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
@@ -1,0 +1,427 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* Tests for the per-message dispatch helpers extracted from
+* ServiceMgrInit's dataChan switch in PR #129 (this PR):
+*
+*   - buildServiceResponseMap        shared response-skeleton builder
+*   - handleServiceSet               "set" action arm
+*   - handleServiceGet               "get" action arm (error paths)
+*   - handleServiceUnsubscribe       client-driven "unsubscribe" arm
+*   - handleInternalKillSubscriptions kill all subscriptions for a RouterId
+*   - handleInternalCancelSubscription AGT-cancelled subscription cleanup
+*   - handleUnknownAction            default arm
+*
+* The subscribe arm is intentionally left inline in this PR — it mutates
+* several locals (subscriptionList, subscriptionId) and sends on three
+* channels (subscriptionChan, CLChannel, toFeeder), so extracting it
+* cleanly will be a follow-up. The storage-backend interface
+* (StorageBackend) injection is also deferred to a future PR — it is a
+* genuinely separate architectural change touching 5 backends and their
+* init paths, and bundling it here would balloon this diff.
+*
+* Same shape as the dispatch tests in PRs #124 (udsMgr+httpMgr), #125
+* (feederv4), #126 (wsMgr), #127 (grpcMgr), and #128 (vissv2server core).
+**/
+package serviceMgr
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/covesa/vissr/utils"
+)
+
+// TestMain initialises utils.Info / utils.Error so the helpers can
+// log without nil-deref under test conditions. We deliberately do
+// NOT set stateDbType here — the empty value falls through to the
+// default arm in setVehicleData/getVehicleData, returning "" without
+// touching the live storage backends. That keeps these tests
+// self-contained and exercises the service_unavailable / empty-data
+// paths.
+func TestMain(m *testing.M) {
+	utils.InitLog("serviceMgr-dispatch-test.log", os.TempDir(), false, "error")
+	os.Exit(m.Run())
+}
+
+// resetErrorResponseMap clears the shared package-level
+// errorResponseMap between tests. The production code mutates it in
+// place on the assumption that one request is being processed at a
+// time, so we restore that assumption per test case.
+func resetErrorResponseMap() {
+	for k := range errorResponseMap {
+		delete(errorResponseMap, k)
+	}
+}
+
+// TestBuildServiceResponseMap verifies the response skeleton carries
+// the four required fields and that the authorization field is only
+// set when "handle" is present on the request.
+func TestBuildServiceResponseMap(t *testing.T) {
+	req := map[string]interface{}{
+		"RouterId":  "0?7",
+		"action":    "get",
+		"requestId": "42",
+		"handle":    "tok-handle-xyz",
+	}
+	resp := buildServiceResponseMap(req)
+	if resp["RouterId"] != "0?7" {
+		t.Errorf("RouterId = %v; want 0?7", resp["RouterId"])
+	}
+	if resp["action"] != "get" {
+		t.Errorf("action = %v; want get", resp["action"])
+	}
+	if resp["requestId"] != "42" {
+		t.Errorf("requestId = %v; want 42", resp["requestId"])
+	}
+	if resp["ts"] == nil || resp["ts"].(string) == "" {
+		t.Errorf("ts not populated")
+	}
+	if resp["authorization"] != "tok-handle-xyz" {
+		t.Errorf("authorization = %v; want tok-handle-xyz", resp["authorization"])
+	}
+
+	// Without a handle, the authorization field must be absent.
+	req2 := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "get",
+		"requestId": "1",
+	}
+	resp2 := buildServiceResponseMap(req2)
+	if _, present := resp2["authorization"]; present {
+		t.Errorf("authorization should be absent when handle is nil; got %v", resp2["authorization"])
+	}
+}
+
+// TestHandleServiceSet_StorageUnavailableReturnsError exercises the
+// service_unavailable path: with stateDbType unset, setVehicleData
+// returns the zero string and the helper must emit the canonical
+// error response on dataChan.
+func TestHandleServiceSet_StorageUnavailableReturnsError(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "set",
+		"requestId": "1",
+		"path":      "Vehicle.Speed",
+		"value":     "100",
+	}
+	resp := buildServiceResponseMap(req)
+
+	go handleServiceSet(req, resp, dataChan)
+
+	select {
+	case got := <-dataChan:
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error response; got %v", got)
+		}
+		if errMap["reason"] != "service_unavailable" {
+			t.Errorf("error.reason = %v; want service_unavailable", errMap["reason"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleServiceSet did not reply on dataChan")
+	}
+}
+
+// TestHandleServiceGet_MalformedPathArray covers the invalid_data
+// branch when unpackPaths can't decode a "looks like an array but
+// isn't" path string.
+func TestHandleServiceGet_MalformedPathArray(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "get",
+		"requestId": "1",
+		"path":      `["Vehicle.Speed`, // open bracket but no close
+	}
+	resp := buildServiceResponseMap(req)
+
+	go handleServiceGet(req, resp, dataChan)
+
+	select {
+	case got := <-dataChan:
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error response; got %v", got)
+		}
+		if errMap["reason"] != "invalid_data" {
+			t.Errorf("error.reason = %v; want invalid_data", errMap["reason"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleServiceGet did not reply on dataChan")
+	}
+}
+
+// TestHandleServiceGet_SinglePathSucceeds confirms the happy path
+// resolves a single path without hitting the error arms. With
+// stateDbType unset, getVehicleData returns "" and the data pack ends
+// up with a nil "dp" value, but the helper still emits a success
+// response (not an error response). This pins the contract that the
+// "no data available" case is NOT treated as an error here — the
+// caller has to interpret a missing dp themselves.
+func TestHandleServiceGet_SinglePathSucceeds(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "get",
+		"requestId": "1",
+		"path":      "Vehicle.Speed", // single path, not an array
+	}
+	resp := buildServiceResponseMap(req)
+
+	go handleServiceGet(req, resp, dataChan)
+
+	select {
+	case got := <-dataChan:
+		if _, isErr := got["error"]; isErr {
+			t.Fatalf("expected success response; got error %v", got)
+		}
+		if got["action"] != "get" {
+			t.Errorf("action = %v; want get", got["action"])
+		}
+		// "data" key should be present even when empty.
+		if _, present := got["data"]; !present {
+			t.Errorf("data key missing from success response")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleServiceGet did not reply on dataChan")
+	}
+}
+
+// TestHandleServiceUnsubscribe_MissingSubscriptionId hits the
+// invalid_data branch when the request has no subscriptionId field.
+func TestHandleServiceUnsubscribe_MissingSubscriptionId(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	toFeederChan := make(chan string, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "unsubscribe",
+		"requestId": "1",
+		// no subscriptionId
+	}
+	resp := buildServiceResponseMap(req)
+	subscriptionList := []SubscriptionState{}
+
+	updated := handleServiceUnsubscribe(req, resp, dataChan, subscriptionList, toFeederChan)
+	if len(updated) != 0 {
+		t.Errorf("subscriptionList length = %d; want 0", len(updated))
+	}
+
+	select {
+	case got := <-dataChan:
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error response; got %v", got)
+		}
+		if errMap["reason"] != "invalid_data" {
+			t.Errorf("error.reason = %v; want invalid_data", errMap["reason"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleServiceUnsubscribe did not reply on dataChan")
+	}
+
+	// toFeeder should NOT have been sent to on the error path.
+	select {
+	case got := <-toFeederChan:
+		t.Errorf("toFeederChan should be empty on error path; got %q", got)
+	default:
+	}
+}
+
+// TestHandleServiceUnsubscribe_NotFoundOnList covers the case where
+// the subscriptionId is well-formed but no matching subscription is
+// in the list — deactivateSubscription returns status=-1 and the
+// helper falls through to the invalid_data error.
+func TestHandleServiceUnsubscribe_NotFoundOnList(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	toFeederChan := make(chan string, 1)
+	req := map[string]interface{}{
+		"RouterId":       "0?0",
+		"action":         "unsubscribe",
+		"requestId":      "1",
+		"subscriptionId": "9999",
+	}
+	resp := buildServiceResponseMap(req)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 1, RouterId: "0?0"},
+	}
+
+	updated := handleServiceUnsubscribe(req, resp, dataChan, subscriptionList, toFeederChan)
+	if len(updated) != 1 {
+		t.Errorf("subscriptionList length = %d; want 1 (unchanged)", len(updated))
+	}
+
+	select {
+	case got := <-dataChan:
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error response; got %v", got)
+		}
+		if errMap["reason"] != "invalid_data" {
+			t.Errorf("error.reason = %v; want invalid_data", errMap["reason"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleServiceUnsubscribe did not reply on dataChan")
+	}
+}
+
+// TestHandleInternalKillSubscriptions_RemovesMatching seeds a
+// subscription list with two entries for the same RouterId and one
+// for a different RouterId, then verifies the kill loop removes both
+// of the matching entries while leaving the unrelated one alone.
+func TestHandleInternalKillSubscriptions_RemovesMatching(t *testing.T) {
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 1, RouterId: "0?5"},
+		{SubscriptionId: 2, RouterId: "0?5"},
+		{SubscriptionId: 3, RouterId: "0?9"},
+	}
+	req := map[string]interface{}{
+		"action":   "internal-killsubscriptions",
+		"RouterId": "0?5",
+	}
+
+	updated := handleInternalKillSubscriptions(req, subscriptionList)
+
+	// The two 0?5 entries should be gone; 0?9 should survive.
+	for _, s := range updated {
+		if s.RouterId == "0?5" {
+			t.Errorf("found leftover RouterId=0?5 entry: subId=%d", s.SubscriptionId)
+		}
+	}
+	foundOther := false
+	for _, s := range updated {
+		if s.RouterId == "0?9" {
+			foundOther = true
+		}
+	}
+	if !foundOther {
+		t.Errorf("RouterId=0?9 entry was removed; should have survived")
+	}
+}
+
+// TestHandleInternalKillSubscriptions_NoMatch confirms that when no
+// entries match the request RouterId, the list is returned unchanged.
+func TestHandleInternalKillSubscriptions_NoMatch(t *testing.T) {
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 1, RouterId: "0?9"},
+	}
+	req := map[string]interface{}{
+		"action":   "internal-killsubscriptions",
+		"RouterId": "0?5",
+	}
+	updated := handleInternalKillSubscriptions(req, subscriptionList)
+	if len(updated) != 1 || updated[0].RouterId != "0?9" {
+		t.Errorf("list mutated unexpectedly; got %v", updated)
+	}
+}
+
+// TestHandleInternalCancelSubscription_GatingIdFound seeds a
+// subscription with a matching gatingId, then confirms the helper:
+//   1) rewrites requestMap into a synthetic "subscription" error event
+//   2) pushes it to dataChan with the expired_token error number
+//   3) removes the subscription from the list
+func TestHandleInternalCancelSubscription_GatingIdFound(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 7, RouterId: "0?3", GatingId: "gate-abc"},
+	}
+	req := map[string]interface{}{
+		"action":   "internal-cancelsubscription",
+		"gatingId": "gate-abc",
+	}
+
+	updated := handleInternalCancelSubscription(req, dataChan, subscriptionList)
+	if len(updated) != 0 {
+		t.Errorf("subscriptionList length = %d; want 0 (entry should have been removed)", len(updated))
+	}
+
+	select {
+	case got := <-dataChan:
+		if got["action"] != "subscription" {
+			t.Errorf("rewritten action = %v; want subscription", got["action"])
+		}
+		if got["RouterId"] != "0?3" {
+			t.Errorf("rewritten RouterId = %v; want 0?3", got["RouterId"])
+		}
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error sub-map; got %v", got)
+		}
+		if desc, _ := errMap["description"].(string); !strings.Contains(desc, "Token expired") {
+			t.Errorf("description = %q; want it to mention Token expired", desc)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleInternalCancelSubscription did not reply on dataChan")
+	}
+}
+
+// TestHandleInternalCancelSubscription_GatingIdNotFound confirms a
+// non-matching gatingId is a no-op: the list is unchanged and nothing
+// is pushed onto dataChan.
+func TestHandleInternalCancelSubscription_GatingIdNotFound(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 7, RouterId: "0?3", GatingId: "gate-abc"},
+	}
+	req := map[string]interface{}{
+		"action":   "internal-cancelsubscription",
+		"gatingId": "gate-not-here",
+	}
+
+	updated := handleInternalCancelSubscription(req, dataChan, subscriptionList)
+	if len(updated) != 1 {
+		t.Errorf("subscriptionList length = %d; want 1 (unchanged)", len(updated))
+	}
+
+	select {
+	case got := <-dataChan:
+		t.Errorf("dataChan should be empty when gatingId not found; got %v", got)
+	default:
+	}
+}
+
+// TestHandleUnknownAction confirms the default arm emits the
+// invalid_data response with "Unknown action" as the description.
+func TestHandleUnknownAction(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "completely-made-up-action",
+		"requestId": "1",
+	}
+
+	handleUnknownAction(req, dataChan)
+
+	select {
+	case got := <-dataChan:
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error response; got %v", got)
+		}
+		if errMap["reason"] != "invalid_data" {
+			t.Errorf("error.reason = %v; want invalid_data", errMap["reason"])
+		}
+		if desc, _ := errMap["description"].(string); desc != "Unknown action" {
+			t.Errorf("description = %q; want exactly \"Unknown action\"", desc)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleUnknownAction did not reply on dataChan")
+	}
+}

--- a/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
+++ b/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
@@ -8,8 +8,9 @@
 * ----------------------------------------------------------------------------
 *
 * Tests for the per-message dispatch helpers extracted from
-* ServiceMgrInit's dataChan switch in PR #129 (this PR):
+* ServiceMgrInit's dataChan switch.
 *
+* Originally added in PR #129 covering:
 *   - buildServiceResponseMap        shared response-skeleton builder
 *   - handleServiceSet               "set" action arm
 *   - handleServiceGet               "get" action arm (error paths)
@@ -18,13 +19,12 @@
 *   - handleInternalCancelSubscription AGT-cancelled subscription cleanup
 *   - handleUnknownAction            default arm
 *
-* The subscribe arm is intentionally left inline in this PR — it mutates
-* several locals (subscriptionList, subscriptionId) and sends on three
-* channels (subscriptionChan, CLChannel, toFeeder), so extracting it
-* cleanly will be a follow-up. The storage-backend interface
-* (StorageBackend) injection is also deferred to a future PR — it is a
-* genuinely separate architectural change touching 5 backends and their
-* init paths, and bundling it here would balloon this diff.
+* Follow-up PR (this PR) adds tests for the subscribe arm, which was
+* left inline in #129 with a TODO(testing) note and has now been
+* extracted to handleServiceSubscribe. The storage-backend interface
+* (StorageBackend) injection is still deferred to a separate PR — it
+* is a genuinely separate architectural change touching 5 backends
+* and their init paths.
 *
 * Same shape as the dispatch tests in PRs #124 (udsMgr+httpMgr), #125
 * (feederv4), #126 (wsMgr), #127 (grpcMgr), and #128 (vissv2server core).
@@ -423,5 +423,241 @@ func TestHandleUnknownAction(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("handleUnknownAction did not reply on dataChan")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests for handleServiceSubscribe (added in the follow-up PR after #129).
+//
+// The subscribe arm was left inline in PR #129 with a TODO(testing) note.
+// These tests cover the extracted handleServiceSubscribe — the clean error
+// paths, the happy path with a non-special filter (one that doesn't trip
+// subscriptionChan / CLChannel / toFeeder), and a regression-pinning test
+// for the pre-existing missing-break bug in the empty-FilterList branch.
+// ----------------------------------------------------------------------------
+
+// TestHandleServiceSubscribe_MissingFilterReturnsBadRequest exercises
+// the nil-filter short-circuit: no filter field at all on the request,
+// so the helper returns immediately with a bad_request error and does
+// not touch the subscription list or any side channels.
+func TestHandleServiceSubscribe_MissingFilterReturnsBadRequest(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 2)
+	subChan := make(chan int, 1)
+	clChan := make(chan CLPack, 1)
+	toFeederChan := make(chan string, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "subscribe",
+		"requestId": "1",
+		"path":      "Vehicle.Speed",
+		// no filter
+	}
+	resp := buildServiceResponseMap(req)
+	list := []SubscriptionState{}
+
+	updatedList, nextId := handleServiceSubscribe(req, resp, dataChan, list, 99, subChan, clChan, toFeederChan)
+	if len(updatedList) != 0 {
+		t.Errorf("subscriptionList grew on the error path; len=%d", len(updatedList))
+	}
+	if nextId != 99 {
+		t.Errorf("subscriptionId advanced on the error path; got %d, want 99", nextId)
+	}
+
+	select {
+	case got := <-dataChan:
+		errMap, ok := got["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected error response; got %v", got)
+		}
+		if errMap["reason"] != "bad_request" {
+			t.Errorf("error.reason = %v; want bad_request", errMap["reason"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleServiceSubscribe did not reply on dataChan")
+	}
+
+	// Nothing should reach the side channels on this error path.
+	select {
+	case <-subChan:
+		t.Errorf("subChan was sent to on the error path")
+	case <-clChan:
+		t.Errorf("clChan was sent to on the error path")
+	case <-toFeederChan:
+		t.Errorf("toFeederChan was sent to on the error path")
+	default:
+	}
+}
+
+// TestHandleServiceSubscribe_EmptyStringFilterReturnsBadRequest covers
+// the same short-circuit when the filter field is present but is the
+// empty string (which the original arm explicitly rejected alongside
+// nil).
+func TestHandleServiceSubscribe_EmptyStringFilterReturnsBadRequest(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 2)
+	subChan := make(chan int, 1)
+	clChan := make(chan CLPack, 1)
+	toFeederChan := make(chan string, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?0",
+		"action":    "subscribe",
+		"requestId": "1",
+		"path":      "Vehicle.Speed",
+		"filter":    "",
+	}
+	resp := buildServiceResponseMap(req)
+
+	updatedList, nextId := handleServiceSubscribe(req, resp, dataChan, []SubscriptionState{}, 7, subChan, clChan, toFeederChan)
+	if len(updatedList) != 0 || nextId != 7 {
+		t.Errorf("subscription state mutated on the error path; list=%d, id=%d", len(updatedList), nextId)
+	}
+
+	select {
+	case got := <-dataChan:
+		errMap, _ := got["error"].(map[string]interface{})
+		if errMap == nil || errMap["reason"] != "bad_request" {
+			t.Errorf("expected bad_request error; got %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("no response on dataChan")
+	}
+}
+
+// TestHandleServiceSubscribe_HappyPath exercises the success path
+// using a "paths" filter — one that does NOT trip the timebased,
+// curvelog, change, or range branches, so the three side channels
+// (subChan, clChan, toFeederChan) all stay quiet. We verify:
+//   1) the subscription is appended to the list
+//   2) subscriptionId is incremented by one
+//   3) responseMap["subscriptionId"] is set to the old id (the one the
+//      client should use for unsubscribe)
+//   4) the response is pushed to dataChan
+func TestHandleServiceSubscribe_HappyPath(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 2)
+	subChan := make(chan int, 1)
+	clChan := make(chan CLPack, 1)
+	toFeederChan := make(chan string, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?5",
+		"action":    "subscribe",
+		"requestId": "1",
+		"path":      "Vehicle.Speed",
+		// A "paths" filter: not timebased / curvelog / range / change,
+		// so it triggers none of the side channels.
+		"filter": map[string]interface{}{
+			"variant":   "paths",
+			"parameter": "Vehicle.Speed",
+		},
+	}
+	resp := buildServiceResponseMap(req)
+	startId := 42
+
+	updatedList, nextId := handleServiceSubscribe(req, resp, dataChan, []SubscriptionState{}, startId, subChan, clChan, toFeederChan)
+
+	if len(updatedList) != 1 {
+		t.Fatalf("subscriptionList len = %d; want 1", len(updatedList))
+	}
+	if updatedList[0].SubscriptionId != startId {
+		t.Errorf("appended SubscriptionId = %d; want %d", updatedList[0].SubscriptionId, startId)
+	}
+	if updatedList[0].RouterId != "0?5" {
+		t.Errorf("appended RouterId = %q; want 0?5", updatedList[0].RouterId)
+	}
+	if nextId != startId+1 {
+		t.Errorf("nextId = %d; want %d (subscriptionId must advance by 1)", nextId, startId+1)
+	}
+
+	select {
+	case got := <-dataChan:
+		if _, isErr := got["error"]; isErr {
+			t.Fatalf("happy path produced an error response: %v", got)
+		}
+		if got["subscriptionId"] != "42" {
+			t.Errorf("responseMap.subscriptionId = %v; want \"42\"", got["subscriptionId"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("no response on dataChan on happy path")
+	}
+
+	// Side channels stay quiet for a "paths" filter.
+	select {
+	case <-subChan:
+		t.Errorf("subChan was sent to on the paths-filter path")
+	case <-clChan:
+		t.Errorf("clChan was sent to on the paths-filter path")
+	case <-toFeederChan:
+		t.Errorf("toFeederChan was sent to on the paths-filter path")
+	default:
+	}
+}
+
+// TestHandleServiceSubscribe_EmptyFilterListBugPreserved is a
+// regression-pinning test for a PRE-EXISTING bug in the original
+// inline arm that handleServiceSubscribe preserves verbatim:
+//
+//   When UnpackFilter unpacks a non-nil filter into an EMPTY
+//   FilterList, the arm sends a "invalid_data" error response on
+//   dataChan AND THEN falls through to append the empty-filter
+//   subscription, sending a SECOND response on dataChan and
+//   incrementing subscriptionId. The arm was missing a `break` after
+//   the error send.
+//
+// If a future fix adds the missing break, THIS TEST WILL FAIL — that
+// is intentional. Update the test to reflect the corrected behaviour
+// (single error response, list unchanged, id unchanged) at that time.
+func TestHandleServiceSubscribe_EmptyFilterListBugPreserved(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 2) // room for both messages
+	subChan := make(chan int, 1)
+	clChan := make(chan CLPack, 1)
+	toFeederChan := make(chan string, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?5",
+		"action":    "subscribe",
+		"requestId": "1",
+		"path":      "Vehicle.Speed",
+		// A non-empty string filter hits the default arm of
+		// utils.UnpackFilter (which only branches on []interface{} or
+		// map[string]interface{}), leaving the FilterList nil — i.e.
+		// len() == 0 — and tripping the buggy empty-FilterList path.
+		"filter": "this-is-neither-a-map-nor-an-array",
+	}
+	resp := buildServiceResponseMap(req)
+	startId := 100
+
+	updatedList, nextId := handleServiceSubscribe(req, resp, dataChan, []SubscriptionState{}, startId, subChan, clChan, toFeederChan)
+
+	// First message on dataChan should be the invalid_data error.
+	select {
+	case got := <-dataChan:
+		errMap, _ := got["error"].(map[string]interface{})
+		if errMap == nil || errMap["reason"] != "invalid_data" {
+			t.Errorf("first message was not invalid_data error: %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("no first response on dataChan")
+	}
+
+	// Second message exists due to the missing-break bug — the arm
+	// keeps going and sends responseMap as if the subscription was
+	// added. If this select hits the timeout instead, the bug has
+	// been fixed; update the test to the corrected behaviour.
+	select {
+	case got := <-dataChan:
+		if got["subscriptionId"] != "100" {
+			t.Errorf("second (buggy) message did not carry the new subscriptionId: %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("missing second message — bug may have been fixed; update this test to the corrected behaviour")
+	}
+
+	// And the list / id reflect the buggy append.
+	if len(updatedList) != 1 {
+		t.Errorf("subscriptionList len = %d; bug-preserved behaviour appends 1", len(updatedList))
+	}
+	if nextId != startId+1 {
+		t.Errorf("nextId = %d; bug-preserved behaviour increments to %d", nextId, startId+1)
 	}
 }

--- a/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
+++ b/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
@@ -19,12 +19,23 @@
 *   - handleInternalCancelSubscription AGT-cancelled subscription cleanup
 *   - handleUnknownAction            default arm
 *
-* Follow-up PR (this PR) adds tests for the subscribe arm, which was
-* left inline in #129 with a TODO(testing) note and has now been
-* extracted to handleServiceSubscribe. The storage-backend interface
-* (StorageBackend) injection is still deferred to a separate PR — it
-* is a genuinely separate architectural change touching 5 backends
-* and their init paths.
+* Follow-up PR A added tests for the subscribe arm, which was left
+* inline in #129 with a TODO(testing) note and has now been extracted
+* to handleServiceSubscribe.
+*
+* Follow-up PR B (this PR) extracts the five notification-side arms
+* of ServiceMgrInit's select loop and adds tests for the four that
+* are unit-testable without a live UDS socket:
+*   - handleIntervalNotification       <-subscriptionChan
+*   - handleCurveLogNotification       <-CLChannel
+*   - handleRCTick                     <-subscriptTicker.C
+*   - handleFeederNotificationMessage  <-fromFeederRorC
+*   (handleFeederRegistration is extracted but not unit-tested -- it
+*    calls connectToFeeder which opens a real UDS socket.)
+*
+* The storage-backend interface (StorageBackend) injection is still
+* deferred to a separate PR — it is a genuinely separate architectural
+* change touching 5 backends and their init paths.
 *
 * Same shape as the dispatch tests in PRs #124 (udsMgr+httpMgr), #125
 * (feederv4), #126 (wsMgr), #127 (grpcMgr), and #128 (vissv2server core).
@@ -659,5 +670,226 @@ func TestHandleServiceSubscribe_EmptyFilterListBugPreserved(t *testing.T) {
 	}
 	if nextId != startId+1 {
 		t.Errorf("nextId = %d; bug-preserved behaviour increments to %d", nextId, startId+1)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Tests for the notification-arm handlers (follow-up PR B to #129):
+//
+//   - handleIntervalNotification       <-subscriptionChan arm
+//   - handleCurveLogNotification       <-CLChannel arm
+//   - handleRCTick                     <-subscriptTicker.C arm
+//   - handleFeederNotificationMessage  <-fromFeederRorC arm
+//
+// (handleFeederRegistration is not unit-tested -- it calls
+// connectToFeeder which opens a real UDS socket, and mocking that
+// requires more plumbing than the value it delivers here.)
+// ----------------------------------------------------------------------------
+
+// TestHandleIntervalNotification_UnknownIdLogsAndReturns covers the
+// "subscription has been removed but the interval timer fired anyway"
+// race: the handler should log and return without touching backendChan.
+func TestHandleIntervalNotification_UnknownIdLogsAndReturns(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 1},
+	}
+	handleIntervalNotification(9999, subscriptionList, backChan)
+	select {
+	case got := <-backChan:
+		t.Fatalf("backChan should be empty for unknown id; got %v", got)
+	default:
+	}
+}
+
+// TestHandleIntervalNotification_KnownIdSendsToBackend exercises the
+// happy path: the subscription is in the list, the handler builds a
+// well-shaped subscription event and pushes it to backendChan.
+func TestHandleIntervalNotification_KnownIdSendsToBackend(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{
+			SubscriptionId: 7,
+			RouterId:       "0?3",
+			Path:           []string{"Vehicle.Speed"},
+		},
+	}
+	handleIntervalNotification(7, subscriptionList, backChan)
+	select {
+	case got := <-backChan:
+		if got["action"] != "subscription" {
+			t.Errorf("action = %v; want subscription", got["action"])
+		}
+		if got["subscriptionId"] != "7" {
+			t.Errorf("subscriptionId = %v; want \"7\"", got["subscriptionId"])
+		}
+		if got["RouterId"] != "0?3" {
+			t.Errorf("RouterId = %v; want 0?3", got["RouterId"])
+		}
+		if _, present := got["data"]; !present {
+			t.Errorf("data key missing from notification event")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleIntervalNotification did not push to backChan")
+	}
+}
+
+// TestHandleIntervalNotification_DropOnBackpressure exercises the
+// non-blocking select branch: when backendChan is full, the handler
+// drops the event rather than block. This pins the original arm's
+// drop-on-overflow behaviour.
+func TestHandleIntervalNotification_DropOnBackpressure(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	backChan <- map[string]interface{}{"stale": "event"} // fill the buffer
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 7, RouterId: "0?3", Path: []string{"Vehicle.Speed"}},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		handleIntervalNotification(7, subscriptionList, backChan)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// Good: the handler returned without blocking even though the
+		// channel was full.
+	case <-time.After(time.Second):
+		t.Fatalf("handleIntervalNotification blocked instead of dropping")
+	}
+
+	// The buffer still holds the original stale event — the new one
+	// was dropped on the floor.
+	select {
+	case got := <-backChan:
+		if got["stale"] != "event" {
+			t.Errorf("backChan contained the new event; should have dropped it")
+		}
+	default:
+		t.Fatalf("backChan was unexpectedly drained")
+	}
+}
+
+// TestHandleCurveLogNotification_UnknownIdResetsCloseSignal covers the
+// "subscription is no longer on the list when the close signal
+// arrives" path: closeClSubId is cleared and the handler returns
+// without touching backendChan.
+func TestHandleCurveLogNotification_UnknownIdResetsCloseSignal(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 1, SubscriptionThreads: 3},
+	}
+	closeClSubId = 9999 // pretend a close was pending for an id we won't find
+
+	updated := handleCurveLogNotification(CLPack{SubscriptionId: 9999, DataPack: `{"value":"x","ts":"y"}`}, subscriptionList, backChan)
+
+	if closeClSubId != -1 {
+		t.Errorf("closeClSubId = %d; want -1 (should be cleared on unknown id)", closeClSubId)
+	}
+	if len(updated) != 1 {
+		t.Errorf("subscriptionList mutated unexpectedly; len=%d, want 1", len(updated))
+	}
+	select {
+	case got := <-backChan:
+		t.Fatalf("backChan should be empty on unknown-id path; got %v", got)
+	default:
+	}
+}
+
+// TestHandleCurveLogNotification_DecrementsThreadsAndForwards exercises
+// the happy path: the subscription is in the list, this is NOT the
+// close signal for it, so the threads counter is decremented and the
+// data pack is forwarded to backendChan.
+func TestHandleCurveLogNotification_DecrementsThreadsAndForwards(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 5, RouterId: "0?2", SubscriptionThreads: 3},
+	}
+	closeClSubId = -1 // no pending close
+
+	updated := handleCurveLogNotification(
+		CLPack{SubscriptionId: 5, DataPack: `{"value":"42","ts":"2026-01-01T00:00:00Z"}`},
+		subscriptionList, backChan,
+	)
+
+	if updated[0].SubscriptionThreads != 2 {
+		t.Errorf("SubscriptionThreads = %d; want 2 (decremented from 3)", updated[0].SubscriptionThreads)
+	}
+	select {
+	case got := <-backChan:
+		if got["subscriptionId"] != "5" {
+			t.Errorf("subscriptionId = %v; want \"5\"", got["subscriptionId"])
+		}
+		if got["RouterId"] != "0?2" {
+			t.Errorf("RouterId = %v; want 0?2", got["RouterId"])
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleCurveLogNotification did not push to backChan")
+	}
+}
+
+// TestHandleRCTick_FeederActiveStopsTicker covers the path taken when
+// the feeder is producing range/change notifications itself: the
+// poll-ticker is stopped and the subscription list is returned
+// unchanged.
+func TestHandleRCTick_FeederActiveStopsTicker(t *testing.T) {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop() // double-Stop is safe
+	backChan := make(chan map[string]interface{}, 1)
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 1},
+	}
+
+	updated := handleRCTick(true, ticker, subscriptionList, backChan)
+	if len(updated) != 1 {
+		t.Errorf("subscriptionList mutated on feeder-active path; len=%d", len(updated))
+	}
+	// We can't directly assert "ticker is stopped" — the time.Ticker
+	// API doesn't expose state. But the call should have returned
+	// promptly and not panicked, which is what matters for behaviour.
+	select {
+	case got := <-backChan:
+		t.Errorf("backChan should be empty on feeder-active path; got %v", got)
+	default:
+	}
+}
+
+// TestHandleRCTick_FeederInactivePollsRC covers the path taken when
+// the feeder is NOT providing notifications: the handler delegates to
+// checkRCFilterAndIssueMessages, which is a no-op on an empty
+// subscription list (so this test just confirms the call returns
+// cleanly with the list unchanged).
+func TestHandleRCTick_FeederInactivePollsRC(t *testing.T) {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	backChan := make(chan map[string]interface{}, 1)
+	updated := handleRCTick(false, ticker, []SubscriptionState{}, backChan)
+	if updated == nil || len(updated) != 0 {
+		t.Errorf("subscriptionList should be returned (possibly unchanged) on feeder-inactive path; got %v", updated)
+	}
+}
+
+// TestHandleFeederNotificationMessage_SubscribeOkFlipsNotificationOn
+// covers the feeder telling us "I support range/change notifications"
+// via a subscribe response with status=ok. The handler should flip the
+// feederNotification flag to true.
+func TestHandleFeederNotificationMessage_SubscribeOkFlipsNotificationOn(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	msg := `{"action":"subscribe","status":"ok"}`
+	updatedFlag, _ := handleFeederNotificationMessage(msg, false, []SubscriptionState{}, backChan)
+	if updatedFlag != true {
+		t.Errorf("feederNotification flag = %v; want true after subscribe ok", updatedFlag)
+	}
+}
+
+// TestHandleFeederNotificationMessage_MalformedMessagePreservesFlag
+// covers the defensive arm of decodeFeederMessage: an unparseable
+// message leaves the flag unchanged.
+func TestHandleFeederNotificationMessage_MalformedMessagePreservesFlag(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	msg := "not-json-at-all"
+	updatedFlag, _ := handleFeederNotificationMessage(msg, true, []SubscriptionState{}, backChan)
+	if updatedFlag != true {
+		t.Errorf("feederNotification flag = %v; want it to stay true on malformed input", updatedFlag)
 	}
 }

--- a/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
+++ b/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
@@ -23,8 +23,21 @@
 * inline in #129 with a TODO(testing) note and has now been extracted
 * to handleServiceSubscribe.
 *
-* Follow-up PR B (this PR) extracts the five notification-side arms
-* of ServiceMgrInit's select loop and adds tests for the four that
+* The Tier-1 bug-fix PR (most recent) closes out four pre-existing
+* bugs documented as PRESERVED in #130 / #131:
+*   - bug 1: subscribe arm missing break after empty-FilterList
+*            error  (test renamed from _BugPreserved to _ReturnsError,
+*                    assertions flipped)
+*   - bug 2: subscribe arm panicked on malformed JSON path arrays
+*            (new TestHandleServiceSubscribe_MalformedPathReturnsError)
+*   - bug 3: handleCurveLogNotification indexed past the slice end
+*            after remove (new
+*            TestHandleCurveLogNotification_CloseSignalRemovesEntryAndReturns)
+*   - bug 4: closeClSubId accessed without mcloseClSubId mutex
+*            (locking added; -race verifies)
+*
+* Follow-up PR B extracted the five notification-side arms of
+* ServiceMgrInit's select loop and added tests for the four that
 * are unit-testable without a live UDS socket:
 *   - handleIntervalNotification       <-subscriptionChan
 *   - handleCurveLogNotification       <-CLChannel
@@ -604,23 +617,18 @@ func TestHandleServiceSubscribe_HappyPath(t *testing.T) {
 	}
 }
 
-// TestHandleServiceSubscribe_EmptyFilterListBugPreserved is a
-// regression-pinning test for a PRE-EXISTING bug in the original
-// inline arm that handleServiceSubscribe preserves verbatim:
+// TestHandleServiceSubscribe_EmptyFilterListReturnsError verifies the
+// corrected behaviour after fixing bug 1 (the missing `break` /
+// `return` after the empty-FilterList error response). The function
+// must now send exactly one invalid_data error to dataChan and leave
+// the subscription list and subscriptionId untouched.
 //
-//   When UnpackFilter unpacks a non-nil filter into an EMPTY
-//   FilterList, the arm sends a "invalid_data" error response on
-//   dataChan AND THEN falls through to append the empty-filter
-//   subscription, sending a SECOND response on dataChan and
-//   incrementing subscriptionId. The arm was missing a `break` after
-//   the error send.
-//
-// If a future fix adds the missing break, THIS TEST WILL FAIL — that
-// is intentional. Update the test to reflect the corrected behaviour
-// (single error response, list unchanged, id unchanged) at that time.
-func TestHandleServiceSubscribe_EmptyFilterListBugPreserved(t *testing.T) {
+// This test previously pinned the BUG-PRESERVED behaviour where the
+// arm fell through and sent a second message. See the Tier-1 bug-fix
+// PR for the fix.
+func TestHandleServiceSubscribe_EmptyFilterListReturnsError(t *testing.T) {
 	resetErrorResponseMap()
-	dataChan := make(chan map[string]interface{}, 2) // room for both messages
+	dataChan := make(chan map[string]interface{}, 2) // size 2 catches any erroneous second message
 	subChan := make(chan int, 1)
 	clChan := make(chan CLPack, 1)
 	toFeederChan := make(chan string, 1)
@@ -631,8 +639,7 @@ func TestHandleServiceSubscribe_EmptyFilterListBugPreserved(t *testing.T) {
 		"path":      "Vehicle.Speed",
 		// A non-empty string filter hits the default arm of
 		// utils.UnpackFilter (which only branches on []interface{} or
-		// map[string]interface{}), leaving the FilterList nil — i.e.
-		// len() == 0 — and tripping the buggy empty-FilterList path.
+		// map[string]interface{}), leaving the FilterList empty.
 		"filter": "this-is-neither-a-map-nor-an-array",
 	}
 	resp := buildServiceResponseMap(req)
@@ -640,7 +647,7 @@ func TestHandleServiceSubscribe_EmptyFilterListBugPreserved(t *testing.T) {
 
 	updatedList, nextId := handleServiceSubscribe(req, resp, dataChan, []SubscriptionState{}, startId, subChan, clChan, toFeederChan)
 
-	// First message on dataChan should be the invalid_data error.
+	// Exactly one message — the invalid_data error.
 	select {
 	case got := <-dataChan:
 		errMap, _ := got["error"].(map[string]interface{})
@@ -648,28 +655,68 @@ func TestHandleServiceSubscribe_EmptyFilterListBugPreserved(t *testing.T) {
 			t.Errorf("first message was not invalid_data error: %v", got)
 		}
 	case <-time.After(time.Second):
-		t.Fatalf("no first response on dataChan")
+		t.Fatalf("no response on dataChan")
 	}
 
-	// Second message exists due to the missing-break bug — the arm
-	// keeps going and sends responseMap as if the subscription was
-	// added. If this select hits the timeout instead, the bug has
-	// been fixed; update the test to the corrected behaviour.
+	// No second message: the bug-preserving fall-through is gone.
 	select {
 	case got := <-dataChan:
-		if got["subscriptionId"] != "100" {
-			t.Errorf("second (buggy) message did not carry the new subscriptionId: %v", got)
-		}
-	case <-time.After(time.Second):
-		t.Fatalf("missing second message — bug may have been fixed; update this test to the corrected behaviour")
+		t.Errorf("a second message was sent on dataChan; fix has regressed: %v", got)
+	default:
 	}
 
-	// And the list / id reflect the buggy append.
-	if len(updatedList) != 1 {
-		t.Errorf("subscriptionList len = %d; bug-preserved behaviour appends 1", len(updatedList))
+	// List and id must be unchanged.
+	if len(updatedList) != 0 {
+		t.Errorf("subscriptionList len = %d; want 0 (no append after error)", len(updatedList))
 	}
-	if nextId != startId+1 {
-		t.Errorf("nextId = %d; bug-preserved behaviour increments to %d", nextId, startId+1)
+	if nextId != startId {
+		t.Errorf("nextId = %d; want %d (no increment after error)", nextId, startId)
+	}
+}
+
+// TestHandleServiceSubscribe_MalformedPathReturnsError exercises the
+// bug-2 fix: a path string that looks like a JSON array but isn't
+// valid JSON would previously make subscriptionState.Path = nil and
+// then panic at Path[0]. Now the helper short-circuits with a
+// bad_request response before any Path[0] access.
+func TestHandleServiceSubscribe_MalformedPathReturnsError(t *testing.T) {
+	resetErrorResponseMap()
+	dataChan := make(chan map[string]interface{}, 2)
+	subChan := make(chan int, 1)
+	clChan := make(chan CLPack, 1)
+	toFeederChan := make(chan string, 1)
+	req := map[string]interface{}{
+		"RouterId":  "0?5",
+		"action":    "subscribe",
+		"requestId": "1",
+		"path":      `["Vehicle.Speed`, // opens an array but never closes it
+		"filter": map[string]interface{}{
+			"variant":   "paths",
+			"parameter": "Vehicle.Speed",
+		},
+	}
+	resp := buildServiceResponseMap(req)
+	startId := 7
+
+	// Must not panic. The previous code dereferenced Path[0] on a nil
+	// slice immediately after unpackPaths.
+	updatedList, nextId := handleServiceSubscribe(req, resp, dataChan, []SubscriptionState{}, startId, subChan, clChan, toFeederChan)
+
+	select {
+	case got := <-dataChan:
+		errMap, _ := got["error"].(map[string]interface{})
+		if errMap == nil || errMap["reason"] != "bad_request" {
+			t.Errorf("expected bad_request error; got %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("no response on dataChan")
+	}
+
+	if len(updatedList) != 0 {
+		t.Errorf("subscriptionList grew on malformed-path error path; len=%d", len(updatedList))
+	}
+	if nextId != startId {
+		t.Errorf("nextId advanced on the error path; got %d, want %d", nextId, startId)
 	}
 }
 
@@ -825,6 +872,51 @@ func TestHandleCurveLogNotification_DecrementsThreadsAndForwards(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("handleCurveLogNotification did not push to backChan")
+	}
+}
+
+// TestHandleCurveLogNotification_CloseSignalRemovesEntryAndReturns
+// exercises the bug-3 / bug-4 fix path: when closeClSubId matches and
+// SubscriptionThreads decrements to 0, the helper must remove the
+// entry AND return without further indexing into the slice (the old
+// code accessed subscriptionList[index] after the remove, which
+// panics when the removed entry was the last one). Also confirms
+// closeClSubId is cleared and that the post-fix run does not send a
+// stray notification for the just-removed subscription.
+//
+// Run with -race to verify the mcloseClSubId mutex pairing for bug 4.
+func TestHandleCurveLogNotification_CloseSignalRemovesEntryAndReturns(t *testing.T) {
+	backChan := make(chan map[string]interface{}, 1)
+	// Two subs in the list. The one at index 1 (last) is the close
+	// target — that is the index position where the old swap-with-last
+	// + truncate would leave `index` past the end.
+	subscriptionList := []SubscriptionState{
+		{SubscriptionId: 1, RouterId: "0?1", SubscriptionThreads: 2},
+		{SubscriptionId: 5, RouterId: "0?2", SubscriptionThreads: 1},
+	}
+	closeClSubId = 5 // pending close for subscriptionId 5
+
+	updated := handleCurveLogNotification(
+		CLPack{SubscriptionId: 5, DataPack: `{"value":"42","ts":"2026-01-01T00:00:00Z"}`},
+		subscriptionList, backChan,
+	)
+
+	// The matching subscription should be gone.
+	if len(updated) != 1 {
+		t.Fatalf("subscriptionList len = %d; want 1 after remove", len(updated))
+	}
+	if updated[0].SubscriptionId == 5 {
+		t.Errorf("subscriptionId 5 still present after close signal")
+	}
+	// closeClSubId should be cleared.
+	if closeClSubId != -1 {
+		t.Errorf("closeClSubId = %d; want -1 after close-signal handling", closeClSubId)
+	}
+	// No notification event for the just-removed entry.
+	select {
+	case got := <-backChan:
+		t.Errorf("backChan should be empty after removing the subscription; got %v", got)
+	default:
 	}
 }
 

--- a/server/vissv2server/serviceMgr/storage_backend.go
+++ b/server/vissv2server/serviceMgr/storage_backend.go
@@ -1,0 +1,240 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* StorageBackend interface + per-backend adapters used by serviceMgr.
+*
+* This file is the third follow-up to PR #129 and the deferred work
+* noted in #131's description. Previously, getVehicleData and
+* setVehicleData each carried a long switch statement on the
+* stateDbType string, with the database client (dbHandle, redisClient,
+* memcacheClient, IoTDBsession) held in package globals. The interface
+* makes each backend a self-contained unit, the adapters own their
+* dependencies, and tests can substitute a mock implementation without
+* poking package globals.
+**/
+package serviceMgr
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/apache/iotdb-client-go/client"
+	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/covesa/vissr/utils"
+	"github.com/go-redis/redis"
+	"strconv"
+)
+
+// StorageBackend abstracts the vehicle-state storage system used by
+// serviceMgr. Implementations exist for sqlite, redis, memcache,
+// apache-iotdb, and a "none" backend that emits the dummyValue
+// counter on Get and always fails Set.
+type StorageBackend interface {
+	// Get returns the canonical {"value":"...", "ts":"..."} JSON
+	// string for the data point at path. On error or missing data,
+	// returns the same sentinel-value JSON the original inline
+	// switches emitted (e.g. {"value":"visserr:Data-not-available",
+	// "ts":"..."}). Callers (getDataPackMap and subscribe LatestDataPoint
+	// capture) pass the result through to clients as-is.
+	Get(path string) string
+
+	// Set writes value at path. Returns the timestamp used for the
+	// write, or "" on failure -- handleServiceSet relies on the
+	// empty return to emit the service_unavailable response.
+	Set(path, value string) string
+}
+
+// sqliteBackend writes/reads vehicle state through a *sql.DB handle
+// against the VSS_MAP table. The original schema was
+//
+//	CREATE TABLE VSS_MAP (path TEXT, c_value TEXT, c_ts TEXT, d_value TEXT, d_ts TEXT)
+//
+// (c_* are the current value/ts, d_* are the desired). Get reads
+// c_value+c_ts, Set updates d_value+d_ts -- preserving the original
+// inline arms exactly.
+type sqliteBackend struct {
+	db *sql.DB
+}
+
+func newSqliteBackend(db *sql.DB) *sqliteBackend {
+	return &sqliteBackend{db: db}
+}
+
+func (s *sqliteBackend) Get(path string) string {
+	rows, err := s.db.Query("SELECT `c_value`, `c_ts` FROM VSS_MAP WHERE `path`=?", path)
+	if err != nil {
+		return `{"value":"Data-error", "ts":"` + utils.GetRfcTime() + `"}`
+	}
+	defer rows.Close()
+	value := ""
+	timestamp := ""
+	rows.Next()
+	err = rows.Scan(&value, &timestamp)
+	if err != nil {
+		utils.Warning.Printf("Data not found: %s for path=%s", err, path)
+		return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
+	}
+	return `{"value":"` + value + `", "ts":"` + timestamp + `"}`
+}
+
+func (s *sqliteBackend) Set(path, value string) string {
+	ts := utils.GetRfcTime()
+	stmt, err := s.db.Prepare("UPDATE VSS_MAP SET d_value=?, d_ts=? WHERE `path`=?")
+	if err != nil {
+		utils.Error.Printf("Could not prepare for statestorage updating, err = %s", err)
+		return ""
+	}
+	defer stmt.Close()
+	_, err = stmt.Exec(value, ts, path[1:len(path)-1]) // remove quotes surrounding path
+	if err != nil {
+		utils.Error.Printf("Could not update statestorage, err = %s", err)
+		return ""
+	}
+	return ts
+}
+
+// redisBackend reads from a redis client directly and writes by
+// pushing a JSON set message to the feeder via toFeeder (the original
+// arm did the same -- redis writes go through the feeder so it can
+// fan them out to subscribers).
+type redisBackend struct {
+	client   *redis.Client
+	toFeeder chan string
+}
+
+func newRedisBackend(c *redis.Client, toFeeder chan string) *redisBackend {
+	return &redisBackend{client: c, toFeeder: toFeeder}
+}
+
+func (r *redisBackend) Get(path string) string {
+	dp, err := r.client.Get(path).Result()
+	if err != nil {
+		if err.Error() != "redis: nil" {
+			utils.Error.Printf("Job failed. Error()=%s", err.Error())
+			return `{"value":"Database-error", "ts":"` + utils.GetRfcTime() + `"}`
+		}
+		return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
+	}
+	return dp
+}
+
+func (r *redisBackend) Set(path, value string) string {
+	ts := utils.GetRfcTime()
+	message := `{"action": "set", "data": {"path":"` + path + `", "dp":{"value":"` + value + `", "ts":"` + ts + `"}}}`
+	r.toFeeder <- message
+	return ts
+}
+
+// memcacheBackend has the same shape as redisBackend -- reads
+// directly through the client, writes through the feeder. The
+// original arms shared a fallthrough; we make the duplication
+// explicit by giving memcache its own struct.
+type memcacheBackend struct {
+	client   *memcache.Client
+	toFeeder chan string
+}
+
+func newMemcacheBackend(c *memcache.Client, toFeeder chan string) *memcacheBackend {
+	return &memcacheBackend{client: c, toFeeder: toFeeder}
+}
+
+func (m *memcacheBackend) Get(path string) string {
+	mcItem, err := m.client.Get(path)
+	if err != nil {
+		if err.Error() != "memcache: cache miss" {
+			utils.Error.Printf("Job failed. Error()=%s", err.Error())
+			return `{"value":"Database-error", "ts":"` + utils.GetRfcTime() + `"}`
+		}
+		utils.Warning.Printf("Data not found.")
+		return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
+	}
+	return string(mcItem.Value)
+}
+
+func (m *memcacheBackend) Set(path, value string) string {
+	ts := utils.GetRfcTime()
+	message := `{"action": "set", "data": {"path":"` + path + `", "dp":{"value":"` + value + `", "ts":"` + ts + `"}}}`
+	m.toFeeder <- message
+	return ts
+}
+
+// iotdbBackend talks to an Apache IoTDB session. The config struct
+// (host/port/prefix/timeout) is held alongside the session so the
+// PrefixPath and Timeout are available for query construction.
+type iotdbBackend struct {
+	session client.Session
+	config  IoTDBConfiguration
+}
+
+func newIoTDBBackend(session client.Session, config IoTDBConfiguration) *iotdbBackend {
+	return &iotdbBackend{session: session, config: config}
+}
+
+func (i *iotdbBackend) Get(path string) string {
+	// Back-quote the VSS node for the DB query, e.g. `Vehicle.CurrentLocation.Longitude`
+	selectLastSQL := fmt.Sprintf("select last `%v` from %v", path, i.config.PrefixPath)
+	value := ""
+	ts := ""
+	sessionDataSet, err := i.session.ExecuteQueryStatement(selectLastSQL, &i.config.Timeout)
+	if err != nil {
+		utils.Error.Printf("IoTDB: Query failed with error=%s", err)
+		return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
+	}
+	success, nextErr := sessionDataSet.Next()
+	if nextErr == nil && success {
+		value = sessionDataSet.GetText("Value")
+		ts = sessionDataSet.GetText(client.TimestampColumnName)
+	}
+	sessionDataSet.Close()
+	return `{"value":"` + value + `", "ts":"` + ts + `"}`
+}
+
+func (i *iotdbBackend) Set(path, value string) string {
+	ts := utils.GetRfcTime()
+	vssKey := []string{"`" + path + "`"} // Back-quote the VSS node for the DB insert
+	vssValue := []string{value}
+	IoTDBts := time.Now().UTC().UnixNano() / 1000000
+
+	status, err := i.session.InsertStringRecord(i.config.PrefixPath, vssKey, vssValue, IoTDBts)
+	if err != nil {
+		utils.Error.Printf("IoTDB: DB insert using InsertStringRecord failed with: %v", err)
+		return ""
+	}
+	if status != nil {
+		if err = client.VerifySuccess(status); err != nil {
+			utils.Error.Printf("IoTDB: DB insert Verify failed with: %v", err)
+			return ""
+		}
+	}
+	return ts
+}
+
+// noneBackend is the zero-dependency backend used when serviceMgr is
+// run without real state storage. Get returns the dummyValue counter
+// the package maintains as a sanity heartbeat; Set always returns ""
+// (failure) -- matching the original setVehicleData which had no
+// "none" case and fell through to the empty-string return.
+//
+// noneBackend is also the package-level default for stateBackend, so
+// getVehicleData / setVehicleData never nil-deref before
+// ServiceMgrInit runs (e.g. in tests).
+type noneBackend struct{}
+
+func newNoneBackend() *noneBackend {
+	return &noneBackend{}
+}
+
+func (n *noneBackend) Get(path string) string {
+	return `{"value":"` + strconv.Itoa(dummyValue) + `", "ts":"` + utils.GetRfcTime() + `"}`
+}
+
+func (n *noneBackend) Set(path, value string) string {
+	return "" // signals service_unavailable to handleServiceSet
+}

--- a/server/vissv2server/serviceMgr/storage_backend_test.go
+++ b/server/vissv2server/serviceMgr/storage_backend_test.go
@@ -1,0 +1,246 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* Tests for the StorageBackend interface + adapter implementations
+* introduced as the third follow-up to PR #129. Covers:
+*
+*   - noneBackend                        Get + Set
+*   - redisBackend / memcacheBackend     Set (pushes to toFeeder)
+*   - getVehicleData / setVehicleData    dispatch through stateBackend
+*   - handleServiceSet with a successful backend
+*     (the PR #129 test only covered the failure path because there
+*     was no way to inject a working backend without spinning up a
+*     real database)
+*
+* The Get arms of redisBackend, memcacheBackend, sqliteBackend, and
+* iotdbBackend all require real database connections to test
+* meaningfully, so those are left for integration testing rather than
+* unit testing here.
+**/
+package serviceMgr
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeBackend is a test double implementing StorageBackend. Use it
+// to verify that getVehicleData / setVehicleData dispatch correctly
+// through the injected backend, and to give handleServiceSet a
+// successful Set path that the production-default noneBackend can't
+// provide.
+type fakeBackend struct {
+	getPath        string         // last path passed to Get
+	getReturn      string         // what Get should return
+	setPath        string         // last path passed to Set
+	setValue       string         // last value passed to Set
+	setReturn      string         // what Set should return ("" means failure)
+}
+
+func (f *fakeBackend) Get(path string) string {
+	f.getPath = path
+	return f.getReturn
+}
+
+func (f *fakeBackend) Set(path, value string) string {
+	f.setPath = path
+	f.setValue = value
+	return f.setReturn
+}
+
+// withBackend swaps stateBackend in for the duration of fn and
+// restores the prior value on return — important because the
+// stateBackend global is process-wide and we run inside `go test`
+// alongside the PR-#129 / #130 / #131 dispatch tests.
+func withBackend(b StorageBackend, fn func()) {
+	prev := stateBackend
+	stateBackend = b
+	defer func() { stateBackend = prev }()
+	fn()
+}
+
+// TestNoneBackend_GetReturnsDummyValue exercises noneBackend.Get and
+// confirms it returns the canonical {"value":"<N>","ts":"..."} shape
+// using the dummyValue counter.
+func TestNoneBackend_GetReturnsDummyValue(t *testing.T) {
+	dummyValue = 42
+	b := newNoneBackend()
+	got := b.Get("Vehicle.Speed")
+	if !strings.Contains(got, `"value":"42"`) {
+		t.Errorf("noneBackend.Get = %q; want it to embed dummyValue=42", got)
+	}
+	if !strings.Contains(got, `"ts":"`) {
+		t.Errorf("noneBackend.Get = %q; want it to embed a ts field", got)
+	}
+}
+
+// TestNoneBackend_SetReturnsEmpty confirms the documented contract:
+// Set is always a no-op-failure (returns "") for the none backend.
+// handleServiceSet relies on this empty return to emit the
+// service_unavailable response.
+func TestNoneBackend_SetReturnsEmpty(t *testing.T) {
+	b := newNoneBackend()
+	if got := b.Set("Vehicle.Speed", "100"); got != "" {
+		t.Errorf("noneBackend.Set = %q; want \"\"", got)
+	}
+}
+
+// TestRedisBackend_SetPushesMessageToFeeder confirms the redis Set
+// arm encodes the path+value into a JSON set message and pushes it
+// onto the toFeeder channel (which is how redis writes get fanned
+// out — see the original arm comment).
+func TestRedisBackend_SetPushesMessageToFeeder(t *testing.T) {
+	feeder := make(chan string, 1)
+	b := newRedisBackend(nil, feeder) // client unused for Set path
+	ts := b.Set("Vehicle.Speed", "100")
+	if ts == "" {
+		t.Fatalf("redisBackend.Set returned empty timestamp on success path")
+	}
+	select {
+	case msg := <-feeder:
+		if !strings.Contains(msg, `"path":"Vehicle.Speed"`) {
+			t.Errorf("feeder message missing path: %q", msg)
+		}
+		if !strings.Contains(msg, `"value":"100"`) {
+			t.Errorf("feeder message missing value: %q", msg)
+		}
+		if !strings.Contains(msg, `"action": "set"`) {
+			t.Errorf("feeder message missing action=set: %q", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("redisBackend.Set did not push to feeder")
+	}
+}
+
+// TestMemcacheBackend_SetPushesMessageToFeeder — same as the redis
+// case. The two backends share the Set protocol exactly; the original
+// arms in setVehicleData even used `fallthrough` to share the body.
+// This test pins that the duplication remains intentional.
+func TestMemcacheBackend_SetPushesMessageToFeeder(t *testing.T) {
+	feeder := make(chan string, 1)
+	b := newMemcacheBackend(nil, feeder)
+	ts := b.Set("Vehicle.Speed", "100")
+	if ts == "" {
+		t.Fatalf("memcacheBackend.Set returned empty timestamp on success path")
+	}
+	select {
+	case msg := <-feeder:
+		if !strings.Contains(msg, `"path":"Vehicle.Speed"`) || !strings.Contains(msg, `"value":"100"`) {
+			t.Errorf("feeder message malformed: %q", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("memcacheBackend.Set did not push to feeder")
+	}
+}
+
+// TestGetVehicleData_DispatchesToStateBackend confirms the thunk-form
+// getVehicleData routes through the currently-installed stateBackend
+// — the whole point of the refactor.
+func TestGetVehicleData_DispatchesToStateBackend(t *testing.T) {
+	fake := &fakeBackend{getReturn: `{"value":"sentinel","ts":"2026-01-01T00:00:00Z"}`}
+	withBackend(fake, func() {
+		got := getVehicleData("Vehicle.Speed")
+		if got != fake.getReturn {
+			t.Errorf("getVehicleData = %q; want it to passthrough the fake backend's return", got)
+		}
+		if fake.getPath != "Vehicle.Speed" {
+			t.Errorf("fake backend got path = %q; want Vehicle.Speed", fake.getPath)
+		}
+	})
+}
+
+// TestSetVehicleData_DispatchesToStateBackend — same property for the
+// Set side.
+func TestSetVehicleData_DispatchesToStateBackend(t *testing.T) {
+	fake := &fakeBackend{setReturn: "2026-01-01T00:00:00Z"}
+	withBackend(fake, func() {
+		got := setVehicleData("Vehicle.Speed", "100")
+		if got != fake.setReturn {
+			t.Errorf("setVehicleData = %q; want %q", got, fake.setReturn)
+		}
+		if fake.setPath != "Vehicle.Speed" || fake.setValue != "100" {
+			t.Errorf("fake backend recorded path=%q, value=%q; want Vehicle.Speed / 100", fake.setPath, fake.setValue)
+		}
+	})
+}
+
+// TestHandleServiceSet_WithSuccessfulBackend exercises the success
+// path of handleServiceSet — previously uncovered because the test
+// suite (PR #129) had no way to inject a working backend. With the
+// interface in place, we substitute a fakeBackend that returns a real
+// timestamp on Set and confirm handleServiceSet emits the success
+// response rather than the service_unavailable error.
+func TestHandleServiceSet_WithSuccessfulBackend(t *testing.T) {
+	fake := &fakeBackend{setReturn: "2026-01-01T00:00:00Z"}
+	withBackend(fake, func() {
+		resetErrorResponseMap()
+		dataChan := make(chan map[string]interface{}, 1)
+		req := map[string]interface{}{
+			"RouterId":  "0?0",
+			"action":    "set",
+			"requestId": "1",
+			"path":      "Vehicle.Speed",
+			"value":     "100",
+		}
+		resp := buildServiceResponseMap(req)
+		go handleServiceSet(req, resp, dataChan)
+		select {
+		case got := <-dataChan:
+			if _, isErr := got["error"]; isErr {
+				t.Fatalf("expected success response; got error %v", got)
+			}
+			if got["ts"] != "2026-01-01T00:00:00Z" {
+				t.Errorf("ts = %v; want the backend's returned ts", got["ts"])
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("handleServiceSet did not reply on dataChan")
+		}
+	})
+
+	// The fakeBackend should have seen the request.
+	if fake.setPath != "Vehicle.Speed" {
+		t.Errorf("backend got setPath=%q; want Vehicle.Speed", fake.setPath)
+	}
+	if fake.setValue != "100" {
+		t.Errorf("backend got setValue=%q; want 100", fake.setValue)
+	}
+}
+
+// TestHandleServiceSet_WithFailingBackend pins the existing failure
+// behaviour — a backend that returns "" from Set still triggers
+// service_unavailable. This duplicates a check from
+// serviceMgr_dispatch_test.go but expressed in terms of the new
+// interface so the connection between Set returning "" and the
+// service_unavailable response is explicit.
+func TestHandleServiceSet_WithFailingBackend(t *testing.T) {
+	fake := &fakeBackend{setReturn: ""}
+	withBackend(fake, func() {
+		resetErrorResponseMap()
+		dataChan := make(chan map[string]interface{}, 1)
+		req := map[string]interface{}{
+			"RouterId":  "0?0",
+			"action":    "set",
+			"requestId": "1",
+			"path":      "Vehicle.Speed",
+			"value":     "100",
+		}
+		resp := buildServiceResponseMap(req)
+		go handleServiceSet(req, resp, dataChan)
+		select {
+		case got := <-dataChan:
+			errMap, ok := got["error"].(map[string]interface{})
+			if !ok || errMap["reason"] != "service_unavailable" {
+				t.Errorf("expected service_unavailable error; got %v", got)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("handleServiceSet did not reply on dataChan")
+		}
+	})
+}


### PR DESCRIPTION
Closes out the four Tier-1 bugs that PRs #130 and #131 documented as `PRESERVED` / `HAZARD` in their new doc comments. Each bug existed in the original inline code; the refactor series preserved them deliberately so the refactors themselves stayed behaviour-preserving and reviewable. This is the dedicated fix.

### Bugs fixed

**1. Subscribe arm sends a double response on empty FilterList.**
`handleServiceSubscribe` sent an `invalid_data` error response for an empty FilterList, then **fell through** to append the empty-filter subscription anyway, producing a second message on `dataChan` and growing the subscription list with garbage. Fix: `return` after the error response.

**2. Subscribe arm panics on malformed JSON path arrays.**
`handleServiceSubscribe` accessed `subscriptionState.Path[0]` without a nil/empty check. A path string that opens a JSON array but doesn't close it (e.g. `["Vehicle.Speed`) makes `unpackPaths` return `nil`, and the `Path[0]` access panics. Fix: short-circuit with `bad_request` when `len(Path)==0`.

**3. CL notification panics when removing the last subscription on close signal.**
`handleCurveLogNotification`, after the close-signal branch called `removeFromsubscriptionList`, indexed `subscriptionList[index]` to build the notification map. `removeFromsubscriptionList` does swap-with-last + truncate, so when the removed entry was the last one in the list, the index now points past the end of the slice and the access panics. Fix: return early after the remove — a removed subscription has no notification event to forward anyway.

**4. Race on closeClSubId.**
`handleCurveLogNotification` read and wrote `closeClSubId` without holding `mcloseClSubId`, while `deactivateSubscription` writes it under the mutex. The CL goroutine could observe a stale value or race with `deactivateSubscription` clearing it. Fix: take `mcloseClSubId` for the read-modify-write block. `-race` verifies.

### Tests updated / added

| Test | Bug | What it pins |
|---|---|---|
| `TestHandleServiceSubscribe_EmptyFilterListReturnsError` *(renamed from `_BugPreserved`)* | 1 | single error response, list & id unchanged, no fall-through message |
| `TestHandleServiceSubscribe_MalformedPathReturnsError` *(new)* | 2 | malformed JSON path emits `bad_request` and does not panic |
| `TestHandleCurveLogNotification_CloseSignalRemovesEntryAndReturns` *(new)* | 3 | close signal for the last entry removes it cleanly, `closeClSubId` cleared, no stray notification |
| `-race` flag verifies | 4 | `mcloseClSubId` covers the previously-unguarded reads/writes |

All 33 tests in the serviceMgr test suite pass with `-race` (11 from #129 + 4 from #130 + 9 from #131 + 8 from #132 + 1 renamed + 2 new from this PR).

### Why a single PR for four bugs

They cluster naturally:
- Bugs 1 and 2 are both in the same function (`handleServiceSubscribe`) and both relate to the same chain of "validate inputs before mutating state" defensive checks. Splitting would have made one PR confusingly small.
- Bugs 3 and 4 share the exact same lines (the close-signal branch in `handleCurveLogNotification`). The bug-3 fix restructures the branch in a way that makes the bug-4 mutex placement obvious; splitting them would require an awkward two-pass edit of the same handful of lines.

### Depends on

PRs #129, #130, #131, and #132 merging first — this branch is stacked on `refactor/servicemgr-storage-backend-interface`.

### Series fully wrapped

| PR | Subsystem | Type |
|---|---|---|
| #129 | serviceMgr (main dispatch arms) | refactor + tests |
| #130 | serviceMgr subscribe arm | refactor + tests |
| #131 | serviceMgr notification arms | refactor + tests |
| #132 | StorageBackend interface | refactor + tests |
| **this PR** | **4 pre-existing bugs documented as preserved/hazard above** | **bug fix** |

The "preserve the bug, write a test that pins it, fix it in a follow-up PR" discipline pays off here — each fix is a tiny, focused change that flips an explicit assertion in the test suite.