### PR TITLE
Fix: 8 bugs in wsMgrFT — path traversal, OOB DoS, session-index, FD l…

### DIFF
--- a/server/vissv2server/wsMgrFT/wsMgrFT.go
+++ b/server/vissv2server/wsMgrFT/wsMgrFT.go
@@ -11,6 +11,7 @@ import (
 	utils "github.com/covesa/vissr/utils"
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"io"
 	"crypto/sha1"

--- a/server/vissv2server/wsMgrFT/wsMgrFT.go
+++ b/server/vissv2server/wsMgrFT/wsMgrFT.go
@@ -27,7 +27,7 @@ import (
 // sessionListMu protects the sessionList read-modify-write in
 // getDataSessionIndex / returnDataSessionIndex from concurrent WS
 // upgrade goroutines.
-var sessionListMu sync.Mutex
+//var sessionListMu sync.Mutex
 
 // validateTransferName rejects file-transfer names that contain path
 // separators or parent-directory references. Without this, a VISS

--- a/server/vissv2server/wsMgrFT/wsMgrFT.go
+++ b/server/vissv2server/wsMgrFT/wsMgrFT.go
@@ -10,12 +10,16 @@ package wsMgrFT
 import (
 	utils "github.com/covesa/vissr/utils"
 	"bytes"
+	"errors"
 	"os"
 	"io"
 	"crypto/sha1"
 	"encoding/binary"
 	"encoding/hex"
 	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
 	"github.com/gorilla/websocket"
 )
 
@@ -31,11 +35,22 @@ var Upgrader = websocket.Upgrader{
 const MAXSESSIONS = 10
 var clientChan []chan []byte
 var sessionList [MAXSESSIONS]bool
+var sessionListMu sync.Mutex // guards sessionList — getDataSessionIndex
+                              // runs on the HTTP handler goroutine,
+                              // returnDataSessionIndex on the per-session
+                              // reader goroutine
 
 var clientIndex int
 
 var fileTransferCache []utils.FileTransferCache
 const FILETRANSFERCACHESIZE = 10
+
+// Maximum file size we will accept for upload. The chunk-size
+// calculation in initFtSession truncates a 64-bit Stat result into
+// the `int` ChunkSize field; capping the file size here keeps the
+// math safe on 32-bit and guards against pathological inputs on
+// 64-bit. (utils.FileTransferCache.ChunkSize is `int`.)
+const MAX_FILE_SIZE = (1 << 31) - 1 // 2 GiB - 1
 
 type ChunkDataCache struct {
 	MessageNo byte
@@ -43,7 +58,32 @@ type ChunkDataCache struct {
 	ChunkSize []byte
 	Chunk []byte
 }
-var chunkDataCache = ChunkDataCache{}
+
+// One chunkDataCache per session so that session B's writeChunkData
+// cannot clobber session A's resend buffer. Previously a single
+// package-global ChunkDataCache was shared across all MAXSESSIONS,
+// which corrupted resend behaviour under concurrent transfers.
+var chunkDataCache [MAXSESSIONS]ChunkDataCache
+
+// sanitizeFileName validates a client-supplied file name before it
+// is concatenated with the configured Path. Originally
+// `os.Create(Path + Name)` was passed Name verbatim, so a client
+// sending Name="../../etc/passwd" could overwrite arbitrary files
+// relative to the server's working directory.
+//
+// Rule: a valid name has no directory separators and is not "." or
+// "..". This blocks all path-traversal attempts (which require a
+// separator) while still permitting legitimate names that happen to
+// contain ".." mid-token like "foo..bar" or "config.v..1".
+func sanitizeFileName(name string) (string, error) {
+	if name == "" || name == "." || name == ".." {
+		return "", errors.New("invalid file name: " + name)
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return "", errors.New("file name contains path separator: " + name)
+	}
+	return name, nil
+}
 
 func WsMgrFTInit(ftChannel chan utils.FileTransferCache) {
 	var clientRequest utils.FileTransferCache
@@ -84,72 +124,113 @@ func WsMgrFTInit(ftChannel chan utils.FileTransferCache) {
 		case dataMessage = <-clientChan[9]:
 			clientId = 9
 		}
-		dataResponse = getDataResponse(dataMessage)
+		dataResponse = getDataResponse(dataMessage, clientId)
 		if len(dataResponse) > 0 {
 			clientChan[clientId] <- dataResponse
 		}
 	}
 }
 
-func getDataResponse(req []byte) []byte {
+func getDataResponse(req []byte, sessionIndex int) []byte {
 	if len(req) > 6 {
 		return getDataResponseDl(req)
-	} else {
-		return getDataResponseUl(req)
 	}
+	return getDataResponseUl(req, sessionIndex)
 }
 
+// DL_HEADER_SIZE is uid(4) + messageNo(1) + chunkSize(4) + lastMessage(1).
+// A download request shorter than this would have caused slice OOB
+// panics at the uid/messageNo/chunkSize/lastMessage decode sites.
+const DL_HEADER_SIZE = 10
+
 func getDataResponseDl(req []byte) []byte {  // request: uid(4)|messageNo(1)|chunkSize(4)| lastMessage(1)|chunk(N)
-	resp := make([]byte, 4+1+1)  // response: uid(4)|messageNo(1)|status(1)
+	if len(req) < DL_HEADER_SIZE {
+		utils.Error.Printf("getDataResponseDl: malformed packet, len=%d < %d", len(req), DL_HEADER_SIZE)
+		uid := make([]byte, utils.UIDLEN) // zero uid; caller's uid field is unknown
+		if len(req) >= utils.UIDLEN {
+			uid = req[:utils.UIDLEN]
+		}
+		return createDlResponse(uid, byte(0x00), byte(0xFF)) // terminate session
+	}
 	uid := []byte(req[:4])
 	var messageNo uint8
 	buf := bytes.NewReader(req[4:5])
 	err := binary.Read(buf, binary.BigEndian, &messageNo)
 	if err != nil {
 		utils.Error.Println("binary.Read failed for messageNo:", err)
-		return createDlResponse(uid, byte(0x00), byte(0xFF)) // terminate session error response
+		return createDlResponse(uid, byte(0x00), byte(0xFF))
 	}
 	var chunkSize uint32
 	buf = bytes.NewReader(req[5:9])
 	err = binary.Read(buf, binary.BigEndian, &chunkSize)
 	if err != nil {
 		utils.Error.Println("binary.Read failed for chunkSize:", err)
-		return createDlResponse(uid, byte(0x00), byte(0xFF)) // terminate session error response
+		return createDlResponse(uid, byte(0x00), byte(0xFF))
 	}
 	var lastMessage uint8
 	buf = bytes.NewReader(req[9:10])
 	err = binary.Read(buf, binary.BigEndian, &lastMessage)
 	if err != nil {
 		utils.Error.Println("binary.Read failed for lastMessage:", err)
-		return createDlResponse(uid, byte(0x00), byte(0xFF)) // terminate session error response
+		return createDlResponse(uid, byte(0x00), byte(0xFF))
 	}
 	chunk := req[10:]
 	cacheIndex := findFileTransferCacheIndex(uid)
-	if cacheIndex != -1 {
-		if uint32(len(chunk)) != chunkSize {
-			return createDlResponse(uid, req[4], byte(0x01))
-		}
-		n, err := fileTransferCache[cacheIndex].FileDescriptor.Write(chunk)
-		if err != nil {
-			return createDlResponse(uid, req[4], byte(0x01))
-		}
-		fileTransferCache[cacheIndex].FileOffset += n
-		if lastMessage != 0 {
-			fileTransferCache[cacheIndex].FileDescriptor.Close()
-			if calculateHash(fileTransferCache[cacheIndex].Path + fileTransferCache[cacheIndex].Name) != fileTransferCache[cacheIndex].Hash {
-				return createDlResponse(uid, byte(0x00), byte(0x01))
-			}
-			fileTransferCache[cacheIndex].Uid = clearUid() // delete cache entry
-			return createDlResponse(uid, req[4], byte(0x00))
-		}
-		return createDlResponse(uid, req[4], byte(0x00))
-	} else {
+	if cacheIndex == -1 {
 		return createDlResponse(uid, byte(0x00), byte(0xFF)) // terminate session error response
 	}
-	return resp
+	if uint32(len(chunk)) != chunkSize {
+		return createDlResponse(uid, req[4], byte(0x01))
+	}
+	n, err := fileTransferCache[cacheIndex].FileDescriptor.Write(chunk)
+	if err != nil {
+		return createDlResponse(uid, req[4], byte(0x01))
+	}
+	fileTransferCache[cacheIndex].FileOffset += n
+	if lastMessage == 0 {
+		return createDlResponse(uid, req[4], byte(0x00))
+	}
+	// End-of-transfer: verify hash against the file we just wrote.
+	// The original code closed the fd and reopened the file by path,
+	// which was both a TOCTOU vector (path-traversal-controlled name
+	// could swap files between close and reopen) and pointless I/O.
+	// We now hash from the already-open fd before closing it.
+	fd := fileTransferCache[cacheIndex].FileDescriptor
+	if _, seekErr := fd.Seek(0, io.SeekStart); seekErr != nil {
+		fd.Close()
+		fileTransferCache[cacheIndex].Uid = clearUid()
+		return createDlResponse(uid, byte(0x00), byte(0x01))
+	}
+	h := sha1.New()
+	if _, copyErr := io.Copy(h, fd); copyErr != nil {
+		fd.Close()
+		fileTransferCache[cacheIndex].Uid = clearUid()
+		return createDlResponse(uid, byte(0x00), byte(0x01))
+	}
+	fd.Close()
+	gotHash := hex.EncodeToString(h.Sum(nil))
+	fileTransferCache[cacheIndex].Uid = clearUid() // delete cache entry regardless of result
+	if gotHash != fileTransferCache[cacheIndex].Hash {
+		return createDlResponse(uid, byte(0x00), byte(0x01))
+	}
+	return createDlResponse(uid, req[4], byte(0x00))
 }
 
-func getDataResponseUl(req []byte) []byte {  // request: uid(4)|messageNo(1)|status(1)
+// UL_HEADER_SIZE is uid(4) + messageNo(1) + status(1).
+// An upload-status request shorter than this would have caused slice
+// OOB panics decoding the uid / messageNo / status fields.
+const UL_HEADER_SIZE = 6
+
+func getDataResponseUl(req []byte, sessionIndex int) []byte {  // request: uid(4)|messageNo(1)|status(1)
+	if len(req) < UL_HEADER_SIZE {
+		utils.Error.Printf("getDataResponseUl: malformed packet, len=%d < %d", len(req), UL_HEADER_SIZE)
+		// No safely-derivable uid; respond with zeros to signal error.
+		uid := make([]byte, utils.UIDLEN)
+		if len(req) >= utils.UIDLEN {
+			uid = req[:utils.UIDLEN]
+		}
+		return createUlResponse(uid, 0, byte(0x00), []byte{0, 0, 0, 0}, nil)
+	}
 	uid := req[:4]
 	messageNo := req[4]
 	status := req[5]
@@ -157,61 +238,76 @@ func getDataResponseUl(req []byte) []byte {  // request: uid(4)|messageNo(1)|sta
 	chunkSize := make([]byte,4)
 	var chunk []byte
 	cacheIndex := findFileTransferCacheIndex([]byte(uid))
-	if cacheIndex != -1 {
-		if status == byte(0x00) {
-			var n int
-			var err error
-			chunk = make([]byte, fileTransferCache[cacheIndex].ChunkSize)
-			n, err = fileTransferCache[cacheIndex].FileDescriptor.Read(chunk)
-			if err != nil {
-				if err == io.EOF {
-					lastMessage = byte(0x01)
-					fileTransferCache[cacheIndex].FileDescriptor.Close()
-					fileTransferCache[cacheIndex].Uid = clearUid() // delete cache entry
-				} else {
-					return createUlResponse(uid, messageNo, lastMessage, []byte{0,0,0,0}, chunk)
-				}
-			}
-			messageNo += 1
-			fileTransferCache[cacheIndex].FileOffset += n
-			buf := new(bytes.Buffer)
-			err = binary.Write(buf, binary.BigEndian, uint32(n))
-			if err != nil {
-				utils.Error.Printf("binary.Write failed:%s", err)
-				return createUlResponse(uid, messageNo, lastMessage, []byte{0,0,0,0}, nil)
-			}
-			for i := 0; i < 4; i++ {
-				chunkSize[i] = buf.Bytes()[i]
-			}
-		} else if status == byte(0xFF) {
-			return createUlResponse(uid, messageNo, lastMessage, []byte{0,0,0,0}, nil) // error
-		} else {
-			lastMessage, chunkSize, chunk = readChunkData(messageNo)
-			if len(chunk) > 0 {
-				return createUlResponse(uid, messageNo, lastMessage, chunkSize, chunk) // resend previous message
-			} else {
-				return createUlResponse(uid, messageNo, lastMessage, []byte{0,0,0,0}, nil)  //error
-			}
-		}
-	} else {
+	if cacheIndex == -1 {
 		return createUlResponse(uid, messageNo, lastMessage, []byte{0,0,0,0}, nil)  //error
 	}
-	writeChunkData(messageNo, lastMessage, chunkSize, chunk)
+	if status == byte(0x00) {
+		chunk = make([]byte, fileTransferCache[cacheIndex].ChunkSize)
+		n, err := fileTransferCache[cacheIndex].FileDescriptor.Read(chunk)
+		if err != nil {
+			if err == io.EOF {
+				lastMessage = byte(0x01)
+				fileTransferCache[cacheIndex].FileDescriptor.Close()
+				fileTransferCache[cacheIndex].Uid = clearUid() // delete cache entry
+			} else {
+				// Fix: previously this returned without closing the fd
+				// or clearing the cache entry — a per-error file
+				// descriptor leak that also left the slot pinned.
+				utils.Error.Printf("getDataResponseUl: read error on uid=%x, err=%s", uid, err)
+				fileTransferCache[cacheIndex].FileDescriptor.Close()
+				fileTransferCache[cacheIndex].Uid = clearUid()
+				return createUlResponse(uid, messageNo, lastMessage, []byte{0,0,0,0}, chunk)
+			}
+		}
+		messageNo += 1
+		fileTransferCache[cacheIndex].FileOffset += n
+		buf := new(bytes.Buffer)
+		err = binary.Write(buf, binary.BigEndian, uint32(n))
+		if err != nil {
+			utils.Error.Printf("binary.Write failed:%s", err)
+			return createUlResponse(uid, messageNo, lastMessage, []byte{0,0,0,0}, nil)
+		}
+		for i := 0; i < 4; i++ {
+			chunkSize[i] = buf.Bytes()[i]
+		}
+	} else if status == byte(0xFF) {
+		return createUlResponse(uid, messageNo, lastMessage, []byte{0,0,0,0}, nil) // error
+	} else {
+		lastMessage, chunkSize, chunk = readChunkData(messageNo, sessionIndex)
+		if len(chunk) > 0 {
+			return createUlResponse(uid, messageNo, lastMessage, chunkSize, chunk) // resend previous message
+		}
+		return createUlResponse(uid, messageNo, lastMessage, []byte{0,0,0,0}, nil)  //error
+	}
+	writeChunkData(messageNo, lastMessage, chunkSize, chunk, sessionIndex)
 	return createUlResponse(uid, messageNo, lastMessage, chunkSize, chunk)
 }
 
-func readChunkData(messageNo byte) (byte, []byte, []byte) {
-	if messageNo != chunkDataCache.MessageNo {
+// readChunkData / writeChunkData now key by sessionIndex so each
+// session has its own resend buffer. Previously a single
+// package-global chunkDataCache was shared across all MAXSESSIONS,
+// causing cross-session data corruption when two clients were
+// resending different chunks concurrently.
+func readChunkData(messageNo byte, sessionIndex int) (byte, []byte, []byte) {
+	if sessionIndex < 0 || sessionIndex >= MAXSESSIONS {
 		return byte(0), nil, nil
 	}
-	return chunkDataCache.LastMessage, chunkDataCache.ChunkSize, chunkDataCache.Chunk
+	cache := &chunkDataCache[sessionIndex]
+	if messageNo != cache.MessageNo {
+		return byte(0), nil, nil
+	}
+	return cache.LastMessage, cache.ChunkSize, cache.Chunk
 }
 
-func writeChunkData(messageNo byte, lastMessage byte, chunkSize []byte, chunk []byte) {
-	chunkDataCache.MessageNo = messageNo
-	chunkDataCache.LastMessage = lastMessage
-	chunkDataCache.ChunkSize = chunkSize
-	chunkDataCache.Chunk = chunk
+func writeChunkData(messageNo byte, lastMessage byte, chunkSize []byte, chunk []byte, sessionIndex int) {
+	if sessionIndex < 0 || sessionIndex >= MAXSESSIONS {
+		return
+	}
+	cache := &chunkDataCache[sessionIndex]
+	cache.MessageNo = messageNo
+	cache.LastMessage = lastMessage
+	cache.ChunkSize = chunkSize
+	cache.Chunk = chunk
 }
 
 func clearUid() [utils.UIDLEN]byte {
@@ -250,35 +346,61 @@ func createUlResponse(uid []byte, messNo byte, lastMessage byte, chunkSize []byt
 func initFtSession(clientRequest utils.FileTransferCache) int {
 	status := 1  // assume error
 	cacheIndex := getFileTransferCacheIndex(clientRequest.Uid)
-	if cacheIndex != -1 {
-		var fd *os.File
-		var err error
-		if !clientRequest.UploadTransfer { // download
-			fd, err = os.Create(clientRequest.Path + clientRequest.Name) //overwrites existing file...
-		} else { // upload
-			fd, err = os.Open(clientRequest.Path + clientRequest.Name)
-			if err != nil {
-				utils.Error.Printf("Server failed to get file size, error =%s", err)
-			} else {
-				fileSize := getFileSize(fd)
-				clientRequest.ChunkSize = fileSize/10 + 1
+	if cacheIndex == -1 {
+		return status
+	}
+	// Sanitize the client-supplied file name BEFORE concatenating it
+	// with Path. Previously `os.Create(Path + Name)` was vulnerable to
+	// path traversal: a Name like "../../etc/passwd" would write
+	// outside the configured directory.
+	safeName, nameErr := sanitizeFileName(clientRequest.Name)
+	if nameErr != nil {
+		utils.Error.Printf("initFtSession: rejecting file name: %s", nameErr)
+		return status
+	}
+	clientRequest.Name = safeName
+	fullPath := filepath.Join(clientRequest.Path, safeName)
+
+	var fd *os.File
+	var err error
+	if !clientRequest.UploadTransfer { // download
+		fd, err = os.Create(fullPath) // overwrites existing file in the sanitized dir
+	} else { // upload
+		fd, err = os.Open(fullPath)
+		if err != nil {
+			utils.Error.Printf("Server failed to open file for upload, error =%s", err)
+		} else {
+			fileSize := getFileSize(fd)
+			if fileSize < 0 || fileSize > MAX_FILE_SIZE {
+				utils.Error.Printf("initFtSession: file too large for transfer: %d bytes (max %d)", fileSize, MAX_FILE_SIZE)
+				fd.Close()
+				return status
 			}
+			// fileSize fits in int after the cap check above. Cap the
+			// derived chunk size so make([]byte, ChunkSize) in the
+			// upload path can't be asked for a multi-GB allocation.
+			chunkSize := int(fileSize)/10 + 1
+			const MAX_CHUNK_SIZE = 1 << 20 // 1 MiB
+			if chunkSize > MAX_CHUNK_SIZE {
+				chunkSize = MAX_CHUNK_SIZE
+			}
+			clientRequest.ChunkSize = chunkSize
 		}
-		if err == nil {
-			populateFTCache(cacheIndex, clientRequest, fd)
-			status = 0
-		}
+	}
+	if err == nil {
+		populateFTCache(cacheIndex, clientRequest, fd)
+		status = 0
 	}
 	return status
 }
 
-func getFileSize(fp *os.File) int {
+func getFileSize(fp *os.File) int64 {
 	fi, err := fp.Stat()
 	if err != nil {
 		utils.Error.Printf("Server failed to get file size, error =%s", err)
 		return 0
 	}
-	return int(fi.Size())
+	return fi.Size()
 }
 
 func findFileTransferCacheIndex(uid []byte) int {
@@ -386,9 +508,20 @@ func dataSession(conn *websocket.Conn, clientChannel chan []byte, sessionIndex i
 	}
 }
 
+// getDataSessionIndex returns the first free session slot and MARKS
+// IT TAKEN. The original implementation returned the first false
+// index without setting it true, so every new WebSocket session got
+// index 0 and all sessions collided on clientChan[0] — the
+// multi-client path was completely broken.
+//
+// Mutex protects against the case where two upgrades land at roughly
+// the same time on the HTTP handler goroutines (one per request).
 func getDataSessionIndex() int {
-	for i := 0; i< MAXSESSIONS; i++ {
+	sessionListMu.Lock()
+	defer sessionListMu.Unlock()
+	for i := 0; i < MAXSESSIONS; i++ {
 		if !sessionList[i] {
+			sessionList[i] = true
 			return i
 		}
 	}
@@ -396,5 +529,10 @@ func getDataSessionIndex() int {
 }
 
 func returnDataSessionIndex(index int) {
+	if index < 0 || index >= MAXSESSIONS {
+		return
+	}
+	sessionListMu.Lock()
 	sessionList[index] = false
+	sessionListMu.Unlock()
 }

--- a/server/vissv2server/wsMgrFT/wsMgrFT_test.go
+++ b/server/vissv2server/wsMgrFT/wsMgrFT_test.go
@@ -1,0 +1,224 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* Tests for the Tier-2 bug-fixes applied to wsMgrFT. Eight bugs were
+* fixed in this PR; this file covers the ones that can be exercised
+* without a live WebSocket connection or a real file system swap.
+*
+*   - sanitizeFileName              (bug 1: path traversal via Name)
+*   - getDataResponseDl OOB guards  (bug 2: slice OOB on short packets)
+*   - getDataResponseUl OOB guards  (bug 2 mirror + bug 3: UID short slice)
+*   - getDataSessionIndex          (bug 5: index never marked taken)
+*   - per-session chunk cache       (bug 6: cross-session corruption)
+**/
+package wsMgrFT
+
+import (
+	"os"
+	"testing"
+
+	"github.com/covesa/vissr/utils"
+)
+
+func TestMain(m *testing.M) {
+	utils.InitLog("wsMgrFT-test.log", os.TempDir(), false, "error")
+	os.Exit(m.Run())
+}
+
+// TestSanitizeFileName pins the bug-1 fix: client-supplied file
+// names with path traversal or directory separators must be rejected
+// or stripped before being concatenated with the configured Path.
+func TestSanitizeFileName(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"firmware.bin", "firmware.bin", false},
+		{"a-b_c.123", "a-b_c.123", false},
+
+		// Direct traversal attempts.
+		{"../../etc/passwd", "", true},
+		{"..", "", true},
+		{".", "", true},
+		{"", "", true},
+		{"/", "", true},
+
+		// Absolute paths.
+		{"/etc/passwd", "", true},
+		{`C:\Windows\System32\config`, "", true},
+
+		// Slashes / backslashes anywhere.
+		{"foo/bar", "", true},
+		{`foo\bar`, "", true},
+		{"sub/../firmware.bin", "", true}, // Clean would normalize to "firmware.bin" but we reject the ..
+	}
+	for _, tc := range cases {
+		got, err := sanitizeFileName(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("sanitizeFileName(%q) = %q, nil; want error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("sanitizeFileName(%q) returned error: %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("sanitizeFileName(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestGetDataResponseDl_ShortPacketDoesNotPanic exercises the bug-2
+// fix: download requests shorter than DL_HEADER_SIZE used to slice
+// req[5:9] / req[9:10] / req[10:] without bounds checks, panicking
+// the WsMgrFTInit goroutine. The handler must now respond with the
+// terminate-session error byte.
+func TestGetDataResponseDl_ShortPacketDoesNotPanic(t *testing.T) {
+	// Initialise the file-transfer cache so findFileTransferCacheIndex
+	// can run safely even though we don't expect it to match.
+	fileTransferCache = initFileTransferCache()
+
+	cases := [][]byte{
+		{0, 0, 0, 0, 0, 0, 0},                         // len 7 — used to OOB at req[5:9]
+		{0, 0, 0, 0, 0, 0, 0, 0},                      // len 8 — same
+		{0, 0, 0, 0, 0, 0, 0, 0, 0},                   // len 9 — used to OOB at req[9:10]
+		{1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // len 15 — sane size; should reach findFileTransferCacheIndex
+	}
+	for _, req := range cases {
+		resp := getDataResponseDl(req)
+		if len(resp) != 6 {
+			t.Errorf("getDataResponseDl(len=%d) returned response of len %d; want 6", len(req), len(resp))
+		}
+	}
+}
+
+// TestGetDataResponseUl_ShortPacketDoesNotPanic exercises the bug-3
+// fix: upload-status requests shorter than UL_HEADER_SIZE used to
+// slice req[:4] / req[4] / req[5] without bounds checks, panicking
+// the goroutine.
+func TestGetDataResponseUl_ShortPacketDoesNotPanic(t *testing.T) {
+	fileTransferCache = initFileTransferCache()
+
+	cases := [][]byte{
+		{},                  // len 0
+		{0, 0, 0},           // len 3 — used to OOB at req[:4]
+		{0, 0, 0, 0},        // len 4 — used to OOB at req[4]
+		{0, 0, 0, 0, 0},     // len 5 — used to OOB at req[5]
+		{0, 0, 0, 0, 0, 0},  // len 6 — minimum valid; should reach cache lookup
+	}
+	for _, req := range cases {
+		// Must not panic.
+		_ = getDataResponseUl(req, 0)
+	}
+}
+
+// TestGetDataSessionIndex_MarksSlotsTaken pins the bug-5 fix: the
+// original returned 0, 0, 0... because it never marked the slot
+// taken. After the fix, consecutive calls must return 0, 1, 2,
+// ... up to MAXSESSIONS-1, then -1.
+func TestGetDataSessionIndex_MarksSlotsTaken(t *testing.T) {
+	// Reset state.
+	for i := range sessionList {
+		sessionList[i] = false
+	}
+	defer func() {
+		for i := range sessionList {
+			sessionList[i] = false
+		}
+	}()
+
+	for want := 0; want < MAXSESSIONS; want++ {
+		got := getDataSessionIndex()
+		if got != want {
+			t.Fatalf("call #%d: getDataSessionIndex() = %d; want %d", want, got, want)
+		}
+	}
+	// All slots full → -1.
+	if got := getDataSessionIndex(); got != -1 {
+		t.Errorf("after %d allocations: getDataSessionIndex() = %d; want -1", MAXSESSIONS, got)
+	}
+
+	// Returning a slot makes it available again.
+	returnDataSessionIndex(3)
+	if got := getDataSessionIndex(); got != 3 {
+		t.Errorf("after returning slot 3: getDataSessionIndex() = %d; want 3", got)
+	}
+}
+
+// TestReturnDataSessionIndex_BoundsDefensive confirms the bounds
+// check on the returnDataSessionIndex helper (added as part of the
+// bug-5 fix). An out-of-range index must not panic.
+func TestReturnDataSessionIndex_BoundsDefensive(t *testing.T) {
+	returnDataSessionIndex(-1)         // must not panic
+	returnDataSessionIndex(MAXSESSIONS) // must not panic
+	returnDataSessionIndex(1000)        // must not panic
+}
+
+// TestChunkDataCache_PerSession pins the bug-6 fix: the per-session
+// chunk cache must isolate sessions from each other. Previously a
+// single package-global ChunkDataCache served all 10 sessions, so
+// session B's writeChunkData would clobber session A's resend
+// buffer.
+func TestChunkDataCache_PerSession(t *testing.T) {
+	// Wipe to a known state.
+	for i := range chunkDataCache {
+		chunkDataCache[i] = ChunkDataCache{}
+	}
+
+	// Session 0 caches a chunk with messageNo=7.
+	writeChunkData(7, byte(0), []byte{0, 0, 0, 4}, []byte{0xAA, 0xBB, 0xCC, 0xDD}, 0)
+	// Session 1 caches a different chunk with messageNo=7.
+	writeChunkData(7, byte(1), []byte{0, 0, 0, 2}, []byte{0x11, 0x22}, 1)
+
+	// Reading session 0's cache must return session 0's data, not
+	// session 1's. Previously these would have collided.
+	lastMsg0, _, chunk0 := readChunkData(7, 0)
+	if lastMsg0 != byte(0) {
+		t.Errorf("session 0 lastMsg = %d; want 0", lastMsg0)
+	}
+	if len(chunk0) != 4 || chunk0[0] != 0xAA {
+		t.Errorf("session 0 chunk = %v; want [AA BB CC DD]", chunk0)
+	}
+
+	lastMsg1, _, chunk1 := readChunkData(7, 1)
+	if lastMsg1 != byte(1) {
+		t.Errorf("session 1 lastMsg = %d; want 1", lastMsg1)
+	}
+	if len(chunk1) != 2 || chunk1[0] != 0x11 {
+		t.Errorf("session 1 chunk = %v; want [11 22]", chunk1)
+	}
+}
+
+// TestReadChunkData_WrongMessageNoReturnsEmpty confirms the resend
+// guard still works: a request for a messageNo that doesn't match
+// the cached one returns no data.
+func TestReadChunkData_WrongMessageNoReturnsEmpty(t *testing.T) {
+	for i := range chunkDataCache {
+		chunkDataCache[i] = ChunkDataCache{}
+	}
+	writeChunkData(7, byte(0), []byte{0, 0, 0, 4}, []byte{0xAA, 0xBB, 0xCC, 0xDD}, 0)
+	_, _, chunk := readChunkData(8, 0) // wrong messageNo
+	if chunk != nil {
+		t.Errorf("readChunkData with wrong messageNo returned %v; want nil", chunk)
+	}
+}
+
+// TestReadChunkData_OutOfRangeSessionIndexIsSafe confirms the bounds
+// check on the per-session cache helpers.
+func TestReadChunkData_OutOfRangeSessionIndexIsSafe(t *testing.T) {
+	_, _, c1 := readChunkData(0, -1)         // must not panic
+	_, _, c2 := readChunkData(0, MAXSESSIONS) // must not panic
+	if c1 != nil || c2 != nil {
+		t.Errorf("out-of-range session index should return nil chunk; got %v / %v", c1, c2)
+	}
+	writeChunkData(0, 0, nil, []byte{1}, -1)         // must not panic
+	writeChunkData(0, 0, nil, []byte{1}, MAXSESSIONS) // must not panic
+}


### PR DESCRIPTION
First of three Tier-2 bug-fix PRs from a focused audit of `atServer` / `mqttMgr` / `wsMgrFT` — the manager subsystems untouched by the recent refactor series. This PR fixes 8 real bugs in `wsMgrFT.go`. Subsequent PRs will cover `mqttMgr` and `atServer`.

### Bugs fixed

#### Critical

**1. Path traversal via client-supplied `Name`** (`wsMgrFT.go:259`/`:261`)
`os.Create(Path + Name)` concatenated a server-set `Path` with a client-supplied `Name` with no sanitization. `Name = "../../etc/passwd"` overwrote arbitrary files relative to the server's working directory. Same risk on the upload-side `os.Open` (information disclosure). Fix: new `sanitizeFileName()` rejects directory separators and the special names `.` / `..`; path construction uses `filepath.Join`.

**2. Slice OOB DoS on short DL packets** (`getDataResponseDl`)
The dispatcher routed any packet with `len > 6` to the DL handler, which then sliced `req[5:9]`, `req[9:10]`, and `req[10:]` without bounds checks. A 7–9 byte message panicked the `WsMgrFTInit` goroutine — remote DoS via a single crafted WebSocket message. Fix: explicit `DL_HEADER_SIZE = 10` guard at the top of the handler.

**3. Slice OOB DoS on short UL packets** (`getDataResponseUl`)
Same shape on the upload side: `len < 6` sliced `req[:4]` / `req[4]` / `req[5]` without checks. Fix: `UL_HEADER_SIZE = 6` guard.

**5. Multi-client completely broken** (`getDataSessionIndex`)
Returned the first `false` slot in `sessionList` but **never marked it `true`**. Every new WebSocket session got index 0; all sessions collided on `clientChan[0]`. The multi-client path of the file-transfer manager has been silently broken since this function existed. Fix: set the slot `true` before returning. Mutex added to guard against concurrent HTTP-handler upgrades on different goroutines.

#### High

**4. TOCTOU + no path validation on end-of-transfer hash check**
The original closed the fd, then reopened the file by path via `calculateHash(Path + Name)`. Between close and reopen an attacker controlling the filesystem could swap the file. Combined with bug 1 — where the path was attacker-influenced — the hash check was trivially bypassable. Fix: rewind the existing fd and hash from it before closing. No second open by path.

**6. Cross-session data corruption on `chunkDataCache`**
A **single** package-global `ChunkDataCache` served all `MAXSESSIONS` sessions. Session B's `writeChunkData` clobbered session A's resend buffer, so the "resend previous message" branch returned the wrong data to the wrong client. Fix: `var chunkDataCache [MAXSESSIONS]ChunkDataCache`; `readChunkData` / `writeChunkData` take a `sessionIndex` parameter.

**7. File descriptor leak on non-EOF read error** (`getDataResponseUl`)
A non-`io.EOF` `Read` error returned without closing the fd or clearing the cache entry. Repeated read errors leaked one fd per error and pinned the cache slot. Fix: close + clear on the error path.

**8. File-size truncation on 2GB+ files**
`getFileSize` returned `int` (truncating the `int64` `Stat` result on 32-bit; pathological on 64-bit). Combined with `chunkSize = fileSize/10 + 1` and a subsequent `make([]byte, ChunkSize)`, very large files could produce negative or absurd chunk sizes. Fix: return `int64`; cap file size at 2 GiB - 1; cap chunk size at 1 MiB.

### Tests added (`wsMgrFT_test.go`)

| Test | Bug |
|---|---|
| `TestSanitizeFileName` | 1 (table of traversal, separators, special names) |
| `TestGetDataResponseDl_ShortPacketDoesNotPanic` | 2 |
| `TestGetDataResponseUl_ShortPacketDoesNotPanic` | 3 |
| `TestGetDataSessionIndex_MarksSlotsTaken` | 5 (sequential allocation 0, 1, 2, …, -1 when full) |
| `TestReturnDataSessionIndex_BoundsDefensive` | 5 hardening (negative / out-of-range index) |
| `TestChunkDataCache_PerSession` | 6 (two sessions, same messageNo, must not collide) |
| `TestReadChunkData_WrongMessageNoReturnsEmpty` | 6 supporting |
| `TestReadChunkData_OutOfRangeSessionIndexIsSafe` | 6 hardening |

All 8 tests pass with `-race`.

### Independence

This branch is off master, not stacked on any of the recent refactor series — `wsMgrFT.go` was untouched by PRs #124–#133. Reviewable on its own.

### Series context

| PR | Subsystem | Status |
|---|---|---|
| **this PR** | `wsMgrFT` (8 bugs) | now |
| (next) | `mqttMgr` (10 bugs) | follows |
| (next) | `atServer` (10 bugs) | follows |