### PR TITLE
Fix: 11 bugs in mqttMgr — validation bypass, VIN topic injection, pop…

### DIFF
--- a/server/vissv2server/mqttMgr/mqttMgr.go
+++ b/server/vissv2server/mqttMgr/mqttMgr.go
@@ -12,11 +12,10 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
+	"sync"
 
 	"github.com/covesa/vissr/utils"
 	MQTT "github.com/eclipse/paho.mqtt.golang"
-	//	"github.com/gorilla/websocket"
 )
 
 var mqttChannel chan string
@@ -39,6 +38,32 @@ type TopicList struct {
 }
 
 var topicList TopicList
+
+// topicListMu guards topicList. pushTopic / getTopic / popTopic are
+// all called from the main MqttMgrInit select loop today, so the
+// mutex is largely defensive — but popTopic is documented as
+// "TODO: to be used at unsubscribe..." which suggests it will
+// eventually be invoked from another goroutine.
+var topicListMu sync.Mutex
+
+// isValidVin guards against MQTT topic-name injection. The VIN
+// returned by the server core ultimately becomes part of the
+// subscribed topic ("/<VIN>/Vehicle"); if a VIN contained MQTT
+// wildcards ('+', '#') or path separators ('/'), the manager would
+// end up subscribing to topics it shouldn't. VINs are alphanumeric
+// per ISO 3779 but we allow '-' and '_' as well for legacy/test
+// values.
+func isValidVin(vin string) bool {
+	if vin == "" || len(vin) > 64 {
+		return false
+	}
+	for _, c := range vin {
+		if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
+			return false
+		}
+	}
+	return true
+}
 
 func vissV2Receiver(transportMgrChan chan string, vissv2Channel chan string) {
 	//	defer dataConn.Close()
@@ -85,130 +110,171 @@ func mqttSubscribe(brokerSocket string, topic string) MQTT.Client {
 		return nil
 	}
 	if token := c.Subscribe(topic, 0, nil); token.Wait() && token.Error() != nil {
-		utils.Error.Println(token.Error())
-		os.Exit(1)
+		// Previously this called os.Exit(1), tearing down the entire
+		// vissv2server process on any transient broker subscribe
+		// failure. Return nil instead and let the caller decide.
+		utils.Error.Println("mqttSubscribe: subscribe failed:", token.Error())
+		c.Disconnect(250)
+		return nil
 	}
 	return c
 }
 
 func getTopic(topicId int) string {
-	iterator := topicList.head
-	for i := 0; i < topicList.nodes; i++ {
-		if iterator.value.topicId == topicId {
-			return iterator.value.topic
+	topicListMu.Lock()
+	defer topicListMu.Unlock()
+	for n := topicList.head; n != nil; n = n.next {
+		if n.value.topicId == topicId {
+			return n.value.topic
 		}
-		iterator = iterator.next
 	}
 	return ""
 }
 
 func pushTopic(topic string, topicId int) {
-	var newNode Node
-	newNode.value.topic = topic
-	newNode.value.topicId = topicId
-	newNode.next = nil
-
-	if topicList.nodes == 0 {
-		topicList.head = &newNode
+	topicListMu.Lock()
+	defer topicListMu.Unlock()
+	newNode := &Node{value: NodeValue{topicId: topicId, topic: topic}}
+	if topicList.head == nil {
+		topicList.head = newNode
 		topicList.nodes++
 		return
 	}
-	iterator := topicList.head
-	for i := 0; i < topicList.nodes; i++ {
-		if iterator.next == nil {
-			iterator.next = &newNode
-			break
-		}
-		iterator = iterator.next
+	// Walk to the tail and append. The old code mixed a counter-based
+	// loop with `iterator.next == nil` and could leave the node count
+	// inconsistent if the structure was ever modified concurrently.
+	tail := topicList.head
+	for tail.next != nil {
+		tail = tail.next
 	}
+	tail.next = newNode
 	topicList.nodes++
 }
 
-func popTopic(topicId int) { //TODO: to be used at unsubscribe, get, set responses from VISSv2
-	if topicList.nodes > 0 && topicList.head.value.topicId == topicId {
-		if topicList.nodes > 1 {
-			topicList.head = topicList.head.next
-		} else {
-			topicList.head = nil
-		}
-		topicList.nodes--
-	}
-	iterator := topicList.head
-	var previousNode *Node
-	i := 0
-	for i = 0; i < topicList.nodes; i++ {
-		if iterator.value.topicId == topicId {
-			break
-		}
-		previousNode = iterator
-		iterator = iterator.next
-	}
-	if i == topicList.nodes {
+// popTopic removes the first node whose topicId matches and returns.
+// The original implementation had three structural bugs (nil-deref on
+// empty list, nil-deref after head removal, broken splice that could
+// drop nodes). This is a clean single-pass rewrite.
+func popTopic(topicId int) {
+	topicListMu.Lock()
+	defer topicListMu.Unlock()
+	if topicList.head == nil {
 		return
 	}
-	previousNode.next = iterator.next
-	topicList.nodes--
+	// Head case.
+	if topicList.head.value.topicId == topicId {
+		topicList.head = topicList.head.next
+		topicList.nodes--
+		return
+	}
+	// Walk with prev pointer; splice when found.
+	for prev := topicList.head; prev.next != nil; prev = prev.next {
+		if prev.next.value.topicId == topicId {
+			prev.next = prev.next.next
+			topicList.nodes--
+			return
+		}
+	}
 }
 
-func publishMessage(brokerSocket string, topic string, payload string) {
+// publishMessage publishes payload on the given MQTT topic via the
+// supplied already-connected client. The original implementation
+// created a fresh MQTT.NewClient and connected on every call —
+// generating a TCP storm against the broker under load — and called
+// os.Exit(1) on any Connect failure, killing the entire vissv2server
+// process for transient broker hiccups. Both problems are fixed by
+// reusing the long-lived subscription client (which can also publish).
+func publishMessage(client MQTT.Client, topic, payload string) {
 	utils.Info.Printf("publishMessage:Topic=%s, Payload=%s", topic, payload)
-	opts := MQTT.NewClientOptions().AddBroker(brokerSocket)
-	//    opts.SetClientID("VIN001")
-
-	c := MQTT.NewClient(opts)
-	if token := c.Connect(); token.Wait() && token.Error() != nil {
-		utils.Error.Println(token.Error())
-		os.Exit(1)
+	if client == nil {
+		utils.Error.Printf("publishMessage: nil client, dropping message for topic=%s", topic)
+		return
 	}
-	token := c.Publish(topic, 0, false, payload)
+	if topic == "" {
+		utils.Error.Printf("publishMessage: empty topic, dropping payload=%s", payload)
+		return
+	}
+	token := client.Publish(topic, 0, false, payload)
 	token.Wait()
-	c.Disconnect(250)
+	if err := token.Error(); err != nil {
+		utils.Error.Printf("publishMessage: publish failed for topic=%s: %s", topic, err)
+	}
 }
 
 func getVissV2Topic(transportMgrChan chan string, mgrId int) string {
-	vinRequest := "{\"RouterId\":\"" + strconv.Itoa(mgrId) + `?0", "action":"get", 
+	vinRequest := "{\"RouterId\":\"" + strconv.Itoa(mgrId) + `?0", "action":"get",
 	"path":"Vehicle.VehicleIdentification.VIN", "requestId":"570415", "origin":"internal"}`
-	/*	err := dataConn.WriteMessage(websocket.TextMessage, []byte(vinRequest))
-		if err != nil {
-			utils.Error.Println("Datachannel write error:" + err.Error())
-		}
-		_, response, err := dataConn.ReadMessage() // receive message from server core
-		if err != nil {
-			utils.Error.Println("Datachannel read error:" + err.Error())
-			os.Exit(1)
-		}*/
 	transportMgrChan <- vinRequest
 	response := <-transportMgrChan
 	vin := extractVin(string(response))
 	utils.Info.Printf("VIN=%s", vin)
+	if !isValidVin(vin) {
+		// MQTT topic-name injection guard: a VIN containing '+', '#',
+		// or '/' would let the manager subscribe to wildcard topics
+		// outside this vehicle's scope. Refuse to build a topic from
+		// an invalid VIN.
+		utils.Error.Printf("getVissV2Topic: refusing to build topic from invalid VIN=%q", vin)
+		return ""
+	}
 	return "/" + vin + "/Vehicle"
 }
 
+// extractVin parses the VIN out of a server-core get response. The
+// original implementation used strings.Index(response, "value") + 8
+// and trusted that the literal sequence `value":"<VIN>"` appeared
+// exactly that way — any pretty-printed JSON or whitespace shifted
+// the +8 offset onto the wrong characters, and a malformed response
+// caused either a wrong VIN or an OOB slice. Now we parse the
+// response as JSON and look for the value field at the well-known
+// nested location (data.dp.value) with a top-level fallback.
 func extractVin(response string) string {
-	vinStartIndex := strings.Index(response, "value")
-	if vinStartIndex == -1 {
-		utils.Error.Printf("VIN cannot be extracted in %s", response)
-		return "ULF001"  //???
+	var respMap map[string]interface{}
+	if err := json.Unmarshal([]byte(response), &respMap); err != nil {
+		utils.Error.Printf("extractVin: response not JSON: %s", response)
+		return ""
 	}
-	vinStartIndex += 8 // value”:”
-	vinEndIndex := utils.NextQuoteMark([]byte(response), vinStartIndex)
-	return response[vinStartIndex:vinEndIndex]
+	// Preferred path: data.dp.value (matches getDataPackMap output).
+	if data, ok := respMap["data"].(map[string]interface{}); ok {
+		if dp, ok := data["dp"].(map[string]interface{}); ok {
+			if v, ok := dp["value"].(string); ok {
+				return v
+			}
+		}
+		if v, ok := data["value"].(string); ok {
+			return v
+		}
+	}
+	// Fallback: top-level "value" (older formats / direct shape).
+	if v, ok := respMap["value"].(string); ok {
+		return v
+	}
+	utils.Error.Printf("extractVin: no value field found in response: %s", response)
+	return ""
 }
 
-func decomposeMqttPayload(mqttPayload string) (string, string) { // {"topic":"X", "request":"{...}"}
+func decomposeMqttPayload(mqttPayload string) (string, string) { // {"topic":"X", "request":{...}}
 	var payloadMap = make(map[string]interface{})
 	utils.MapRequest(mqttPayload, &payloadMap)
-	topic, err := json.Marshal(payloadMap["topic"])
-	if err != nil {
-		utils.Error.Printf("decomposeMqttPayload: cannot marshal topic in: %s", mqttPayload)
+	// Bug fix: the original used json.Marshal on payloadMap["topic"],
+	// which returned `"X"` (with surrounding quotes), and that quoted
+	// string was then handed to MQTT.Publish as the topic name —
+	// producing literal `"X"` topics on the wire. Worse, a missing
+	// "topic" key made Marshal return `"null"` (4 bytes), which
+	// silently passed the len(topic)==0 check at the call site.
+	// Type-assert to string instead so a missing/non-string topic
+	// fails closed (empty return).
+	topic, ok := payloadMap["topic"].(string)
+	if !ok {
+		utils.Error.Printf("decomposeMqttPayload: missing or non-string topic in: %s", mqttPayload)
 		return "", ""
 	}
+	// The request field IS a JSON object that needs re-marshaling.
 	payload, err := json.Marshal(payloadMap["request"])
 	if err != nil {
 		utils.Error.Printf("decomposeMqttPayload: cannot marshal request in:%s", mqttPayload)
-		return string(topic), "corrupt request"
+		return topic, "corrupt request"
 	}
-	return string(topic), string(payload)
+	return topic, string(payload)
 }
 
 func AddRoutingInfoAndForward(reqMessage string, mgrId int, clientId int, transportMgrChan chan string) {
@@ -222,7 +288,17 @@ func MqttMgrInit(mgrId int, transportMgrChan chan string) {
 	vissv2Channel := make(chan string)
 
 	brokerSocket := getBrokerSocket(false)
-	serverSubscription := mqttSubscribe(brokerSocket, getVissV2Topic(transportMgrChan, mgrId))
+	topic := getVissV2Topic(transportMgrChan, mgrId)
+	if topic == "" {
+		// Refused by isValidVin in getVissV2Topic — don't even try.
+		utils.Error.Printf("MqttMgrInit: refusing to start; could not derive a valid VISS v2 topic")
+		return
+	}
+	serverSubscription := mqttSubscribe(brokerSocket, topic)
+	if serverSubscription == nil {
+		utils.Error.Printf("MqttMgrInit: subscribe failed for topic=%s; manager not started", topic)
+		return
+	}
 	topicId := 0
 	topicList.nodes = 0
 
@@ -232,6 +308,13 @@ func MqttMgrInit(mgrId int, transportMgrChan chan string) {
 
 	utils.Info.Println("**** MQTT manager hub entering server loop... ****")
 
+	// The original loop had a `default: time.Sleep(25 * time.Millisecond)`
+	// arm that added 25ms of latency per message and woke this
+	// goroutine 40 times per second forever. It's gone now: a select
+	// with only blocking channel cases parks the goroutine until
+	// something actually arrives. The Disconnect(250) call that lived
+	// after this loop was also unreachable (the for has no break) and
+	// has been removed.
 	for {
 		select {
 
@@ -244,10 +327,17 @@ func MqttMgrInit(mgrId int, transportMgrChan chan string) {
 			utils.Info.Printf("MQTT mgr hub: Message from broker:Topic=%s, Payload=%s", topic, payload)
 			validationError := utils.JsonSchemaValidate(payload)
 			if len(validationError) > 0 {
+				// Bug fix: the original code published the error
+				// response back to the client AND THEN fell through
+				// to pushTopic + AddRoutingInfoAndForward, so the
+				// schema-invalid payload was still routed inward to
+				// the server core. `continue` short-circuits that
+				// fall-through.
 				var requestMap map[string]interface{}
 				utils.MapRequest(payload, &requestMap)
 				utils.SetErrorResponse(requestMap, errorResponseMap, 0, validationError) //bad_request
-				publishMessage(brokerSocket, topic, utils.FinalizeMessage(errorResponseMap))
+				publishMessage(serverSubscription, topic, utils.FinalizeMessage(errorResponseMap))
+				continue
 			}
 			pushTopic(topic, topicId)
 			AddRoutingInfoAndForward(payload, mgrId, topicId, transportMgrChan)
@@ -257,12 +347,7 @@ func MqttMgrInit(mgrId int, transportMgrChan chan string) {
 			utils.Info.Printf("MQTT hub: Message from VISSv2 server:%s", vissv2Message)
 			// link routerId to topic, remove routerId from message, create mqtt message, send message to mqtt transport
 			payload, topicHandle := utils.RemoveInternalData(string(vissv2Message))
-			publishMessage(brokerSocket, getTopic(topicHandle), payload)
-
-		default:
-			time.Sleep(25 * time.Millisecond)
+			publishMessage(serverSubscription, getTopic(topicHandle), payload)
 		}
 	}
-
-	serverSubscription.Disconnect(250)
 }

--- a/server/vissv2server/mqttMgr/mqttMgr_test.go
+++ b/server/vissv2server/mqttMgr/mqttMgr_test.go
@@ -1,0 +1,242 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* Tests for the Tier-2 bug-fixes applied to mqttMgr. 11 bugs were
+* fixed in this PR; this file covers the ones that can be exercised
+* without a live MQTT broker.
+*
+*   - isValidVin                topic-name injection guard (bug 9)
+*   - extractVin                JSON-based VIN extraction (bug 7)
+*   - decomposeMqttPayload      type-asserted topic, no quote-wrap (bug 8)
+*   - pushTopic / getTopic / popTopic   linked-list helpers (bug 6)
+*   - publishMessage with nil client    defensive guard (bug 4 fallout)
+**/
+package mqttMgr
+
+import (
+	"os"
+	"testing"
+
+	"github.com/covesa/vissr/utils"
+)
+
+func TestMain(m *testing.M) {
+	utils.InitLog("mqttMgr-test.log", os.TempDir(), false, "error")
+	os.Exit(m.Run())
+}
+
+// resetTopicList clears the package-level topicList between tests so
+// state doesn't leak.
+func resetTopicList() {
+	topicListMu.Lock()
+	topicList.head = nil
+	topicList.nodes = 0
+	topicListMu.Unlock()
+}
+
+// TestIsValidVin pins the bug-9 fix: only alphanumerics and -/_ are
+// accepted in a VIN. MQTT wildcards (+, #) and path separators must
+// be rejected so we never build "/<wildcards>/Vehicle" topics that
+// match traffic across other vehicles.
+func TestIsValidVin(t *testing.T) {
+	cases := []struct {
+		vin  string
+		want bool
+	}{
+		{"WVWZZZ1JZ3W386752", true}, // typical ISO 3779 VIN
+		{"ULF001", true},
+		{"test-vin_001", true},
+		{"123ABC", true},
+
+		// Invalid: MQTT wildcards.
+		{"+", false},
+		{"#", false},
+		{"V+IN", false},
+		{"VIN#", false},
+
+		// Invalid: path separators.
+		{"a/b", false},
+		{"/abs", false},
+
+		// Invalid: spaces / punctuation / quotes.
+		{"WVW ZZZ", false},
+		{`"VIN"`, false},
+		{"VIN.001", false},
+
+		// Edge cases.
+		{"", false},
+		{string(make([]byte, 65)), false}, // > 64 chars
+	}
+	for _, tc := range cases {
+		if got := isValidVin(tc.vin); got != tc.want {
+			t.Errorf("isValidVin(%q) = %v; want %v", tc.vin, got, tc.want)
+		}
+	}
+}
+
+// TestExtractVin pins the bug-7 fix: VIN extraction now goes through
+// json.Unmarshal instead of the brittle strings.Index + "+8" offset
+// trick. The original returned wrong data on whitespace and could
+// OOB-panic on malformed responses.
+func TestExtractVin(t *testing.T) {
+	cases := []struct {
+		name string
+		resp string
+		want string
+	}{
+		{
+			"nested data.dp.value (canonical getDataPackMap shape)",
+			`{"action":"get","data":{"path":"Vehicle.VehicleIdentification.VIN","dp":{"value":"WVWZZZ1JZ3W386752","ts":"2026-01-01T00:00:00Z"}},"requestId":"570415"}`,
+			"WVWZZZ1JZ3W386752",
+		},
+		{
+			"top-level value (older format)",
+			`{"action":"get","value":"ULF001","ts":"2026-01-01T00:00:00Z"}`,
+			"ULF001",
+		},
+		{
+			"pretty-printed JSON (would have broken the +8 offset trick)",
+			"{\n\t\"action\": \"get\",\n\t\"value\" : \"PRETTY01\"\n}",
+			"PRETTY01",
+		},
+		{
+			"missing value field",
+			`{"action":"get","ts":"2026-01-01T00:00:00Z"}`,
+			"",
+		},
+		{
+			"malformed JSON",
+			`{not json}`,
+			"",
+		},
+		{
+			"empty response",
+			``,
+			"",
+		},
+	}
+	for _, tc := range cases {
+		got := extractVin(tc.resp)
+		if got != tc.want {
+			t.Errorf("%s: extractVin = %q; want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestDecomposeMqttPayload pins the bug-8 fix: the topic comes back
+// as a bare string from a type-assertion, not as a json.Marshal'd
+// JSON-quoted value. The old code would have returned `"X"` (with
+// quotes) for an input where topic=="X".
+func TestDecomposeMqttPayload(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		topic, payload := decomposeMqttPayload(`{"topic":"/WVW1234/Vehicle","request":{"action":"get","path":"Speed"}}`)
+		if topic != "/WVW1234/Vehicle" {
+			t.Errorf("topic = %q; want \"/WVW1234/Vehicle\" (no surrounding quotes)", topic)
+		}
+		if payload == "" {
+			t.Errorf("payload was empty; want a re-marshaled request object")
+		}
+	})
+
+	t.Run("missing topic field", func(t *testing.T) {
+		topic, payload := decomposeMqttPayload(`{"request":{"action":"get"}}`)
+		if topic != "" || payload != "" {
+			t.Errorf("missing topic should return empty strings; got topic=%q payload=%q", topic, payload)
+		}
+	})
+
+	t.Run("non-string topic field", func(t *testing.T) {
+		topic, payload := decomposeMqttPayload(`{"topic":42,"request":{"action":"get"}}`)
+		if topic != "" || payload != "" {
+			t.Errorf("non-string topic should return empty strings; got topic=%q payload=%q", topic, payload)
+		}
+	})
+}
+
+// TestPushPopTopic_LinkedListMaintainsInvariants exercises the bug-6
+// fix: popTopic now handles empty-list, head-removal, middle-removal,
+// and tail-removal without nil-deref or broken splices.
+func TestPushPopTopic_LinkedListMaintainsInvariants(t *testing.T) {
+	resetTopicList()
+
+	// Pop on empty list — must not panic.
+	popTopic(99)
+
+	pushTopic("a", 1)
+	pushTopic("b", 2)
+	pushTopic("c", 3)
+	pushTopic("d", 4)
+
+	if topicList.nodes != 4 {
+		t.Fatalf("after 4 pushes: nodes = %d; want 4", topicList.nodes)
+	}
+	if got := getTopic(2); got != "b" {
+		t.Errorf("getTopic(2) = %q; want \"b\"", got)
+	}
+
+	// Pop the head.
+	popTopic(1)
+	if topicList.nodes != 3 || topicList.head.value.topicId != 2 {
+		t.Errorf("after popTopic(head): nodes=%d head=%v; want 3 / topicId 2", topicList.nodes, topicList.head.value)
+	}
+
+	// Pop a middle node.
+	popTopic(3)
+	if topicList.nodes != 2 {
+		t.Errorf("after popTopic(middle): nodes = %d; want 2", topicList.nodes)
+	}
+	if got := getTopic(3); got != "" {
+		t.Errorf("getTopic(3) after pop = %q; want \"\"", got)
+	}
+	if got := getTopic(2); got != "b" {
+		t.Errorf("getTopic(2) = %q; want \"b\" (should survive middle removal)", got)
+	}
+	if got := getTopic(4); got != "d" {
+		t.Errorf("getTopic(4) = %q; want \"d\" (should survive middle removal)", got)
+	}
+
+	// Pop the tail.
+	popTopic(4)
+	if topicList.nodes != 1 || topicList.head.value.topicId != 2 {
+		t.Errorf("after popTopic(tail): nodes=%d head=%v; want 1 / topicId 2", topicList.nodes, topicList.head.value)
+	}
+
+	// Pop the last remaining → empty.
+	popTopic(2)
+	if topicList.nodes != 0 || topicList.head != nil {
+		t.Errorf("after popping all: nodes=%d head=%v; want 0 / nil", topicList.nodes, topicList.head)
+	}
+
+	// Pop on now-empty list — must still not panic.
+	popTopic(99)
+
+	// Pop a non-existent id from a non-empty list — no-op, no panic.
+	pushTopic("x", 100)
+	popTopic(999)
+	if topicList.nodes != 1 {
+		t.Errorf("popTopic of non-existent id mutated list: nodes = %d; want 1", topicList.nodes)
+	}
+	resetTopicList()
+}
+
+// TestPublishMessage_NilClientIsSafe pins the defensive guard added
+// to publishMessage when changing it to take a client parameter.
+// Previously the function created its own client and os.Exit(1)'d on
+// connect failure; now it accepts a long-lived client which could
+// theoretically be nil if the subscribe failed.
+func TestPublishMessage_NilClientIsSafe(t *testing.T) {
+	// Must not panic. We don't have a way to assert "did not crash"
+	// other than reaching the assertion below.
+	publishMessage(nil, "any/topic", "{}")
+}
+
+// TestPublishMessage_EmptyTopicIsSafe pins the topic-emptiness guard.
+func TestPublishMessage_EmptyTopicIsSafe(t *testing.T) {
+	publishMessage(nil, "", "{}")
+}


### PR DESCRIPTION
Second of three Tier-2 bug-fix PRs from a focused audit of the manager subsystems untouched by the recent refactor series. This PR fixes 11 real bugs in `mqttMgr.go`. The third PR will cover `atServer`.

### Bugs fixed

#### Security

**1. Validation bypass: missing `continue` after `JsonSchemaValidate` failure** (`mqttMgr.go:252`)
The schema-invalid payload had the error response published back to the client AND was then **still routed inward** via `pushTopic` + `AddRoutingInfoAndForward`. The schema check was defeated. Fix: `continue` after the error send.

**9. Topic-name injection via client-controlled VIN**
`getVissV2Topic` built `/<VIN>/Vehicle` from the VIN returned by the server core without validating its characters. A VIN containing `+`, `#`, or `/` would let the manager subscribe to MQTT wildcard topics across other vehicles. Fix: new `isValidVin` guard (alphanumeric + `-`/`_`, bounded length); `MqttMgrInit` refuses to start when invalid.

#### Correctness

**6. `popTopic` nil-deref + broken splice** (three paths)
The original code derefed `previousNode` (nil zero-value) on an empty list; after head removal it continued walking with `previousNode == nil`; and the splice math could drop nodes. Fix: clean single-pass rewrite with `prev` pointer; bounds-safe for empty / head / middle / tail cases.

**7. `extractVin` OOB / fragile string-math**
Used `strings.Index(..., "value") + 8` to find the VIN start — OOB-panicked on malformed responses and returned wrong data on pretty-printed JSON (whitespace shifted the +8 offset). Fix: `json.Unmarshal` + nested `data.dp.value` lookup with a top-level `value` fallback.

**8. `decomposeMqttPayload` returned `json.Marshal`'d topic**
The function called `json.Marshal(payloadMap["topic"])`, which returns `"X"` (with surrounding quotes). The resulting MQTT topic literally included the quotes. Worse, a missing `topic` field made Marshal return `"null"` (4 bytes), silently passing the `len(topic)==0` check at the call site. Fix: type-assert to `string`; fail closed on missing/non-string.

**10. Latent race on `topicList`**
`pushTopic` / `getTopic` / `popTopic` all operate on the package-global `topicList` without locks. `popTopic` is documented as `TODO: to be used at unsubscribe...` which would introduce a real race once a different goroutine starts calling it. Fix: `sync.Mutex` around all three.

#### Robustness

**2. `os.Exit(1)` on subscribe failure** (`mqttSubscribe`)
A transient broker subscribe error tore down the whole `vissv2server` process. Fix: return `nil` + `Disconnect`; `MqttMgrInit` bails out cleanly.

**3 + 4. New MQTT client per outbound publish + `os.Exit(1)` on Connect failure** (`publishMessage`)
Under load this was a TCP storm against the broker, and any Connect failure killed the parent process. Fix: `publishMessage` takes the long-lived `serverSubscription` client as a parameter; no per-publish connect; logs and returns on publish error.

**5. Busy-wait `time.Sleep(25 * time.Millisecond)` in select `default` arm**
Added 25ms latency per message and woke the goroutine 40 times/second forever. Fix: deleted the `default` arm; the select now parks on its blocking channel cases.

**11. Unreachable `serverSubscription.Disconnect(250)`** after the infinite for loop. Dead code masking the absence of a real shutdown path. Fix: removed.

### Audit-flagged but **not** fixed

One audit finding (the bootstrap JSON literal in `getVissV2Topic`) was a false alarm — the raw-string concatenation produces valid JSON with embedded whitespace, which JSON parsers accept fine. The audit was confused by the quote/raw-string boundary in the source. No change.

### Tests added (`mqttMgr_test.go`)

| Test | Bug |
|---|---|
| `TestIsValidVin` (12 cases incl. wildcards, separators, oversize) | 9 |
| `TestExtractVin` (6 cases incl. pretty-printed JSON, missing field, malformed input) | 7 |
| `TestDecomposeMqttPayload/{happy_path,missing_topic_field,non-string_topic_field}` | 8 |
| `TestPushPopTopic_LinkedListMaintainsInvariants` (empty / head / middle / tail / no-op) | 6 |
| `TestPublishMessage_NilClientIsSafe` | 4 fallout |
| `TestPublishMessage_EmptyTopicIsSafe` | 4 fallout |

All pass with `-race`.

### Independence

This branch is off master, not stacked on any prior series — `mqttMgr.go` was untouched by PRs #124–#134. Reviewable on its own.

### Series context

| PR | Subsystem | Status |
|---|---|---|
| #134 | `wsMgrFT` (8 bugs) | shipped |
| **this PR** | `mqttMgr` (11 bugs) | now |
| (next) | `atServer` (10 bugs) | follows |