### PR TITLE
fix(serviceMgr): patch 12 bugs in curvelog + complete unit tests

### DIFF
--- a/server/vissv2server/serviceMgr/curvelog.go
+++ b/server/vissv2server/serviceMgr/curvelog.go
@@ -81,11 +81,13 @@ const MAXCLBUFSIZE = 240  // something large...
 const MAXCLSESSIONS = 25 // This value depends on the HW memory and performance
 var clServerChan [MAXCLSESSIONS]chan string
 var numOfClSessions int = 0
+var numOfClSessionsMu = &sync.Mutex{}
 
 type TriggChannelElem struct {
 	Busy bool
 }
 var triggChannelList []TriggChannelElem
+var triggChannelMu = &sync.Mutex{}
 
 type TriggRoutingElem struct {
 	Index int
@@ -102,8 +104,8 @@ var clRouterChan chan TriggRoutingData
 func initClResources() {
 	CLChannel = make(chan CLPack, 5) // allow some buffering...
 	for i := range clServerChan {
-		clServerChan[i] = make(chan string)
-	}	
+		clServerChan[i] = make(chan string, 10) // buffered to prevent curveLogServer from blocking
+	}
 	triggChannelList = make([]TriggChannelElem, MAXCLSESSIONS)
 	for i := 0; i < MAXCLSESSIONS; i++ {
 		triggChannelList[i].Busy = false
@@ -167,9 +169,12 @@ type Dim3Elem struct {
 	Path3 string `json:"path3"`
 }
 
+// SignalDimensionLists groups dim2/dim3 path-tuples. JSON tags would be
+// pointless here because we decode via map[string]interface{} in
+// unpacksignalDimensionMap rather than directly into this struct.
 type SignalDimensionLists struct {
-	dim2List []Dim2Elem `json:"dim2"`
-	dim3List []Dim3Elem `json:"dim3"`
+	dim2List []Dim2Elem
+	dim3List []Dim3Elem
 }
 
 type PathDimElem struct {
@@ -178,7 +183,10 @@ type PathDimElem struct {
 	Populated bool
 }
 
-func unpacksignalDimensionMap(signalDimensionMap map[string]interface{}, signalDimensionLists SignalDimensionLists) SignalDimensionLists {
+func unpacksignalDimensionMap(signalDimensionMap map[string]interface{}, signalDimensionLists *SignalDimensionLists) *SignalDimensionLists {
+	if signalDimensionLists == nil {
+		return nil
+	}
 	for dimKey, v := range signalDimensionMap {
 		switch vv := v.(type) {
 		case map[string]interface{}:
@@ -197,7 +205,12 @@ func unpacksignalDimensionMap(signalDimensionMap map[string]interface{}, signalD
 				signalDimensionLists.dim3List = make([]Dim3Elem, len(vv))
 			}
 			for k, v := range vv {
-				unPackDimSignalsLevel1(k, v.(map[string]interface{}), dimKey, signalDimensionLists)
+				inner, ok := v.(map[string]interface{})
+				if !ok {
+					utils.Error.Printf("unpacksignalDimensionMap: element %d not an object, got %T", k, v)
+					continue
+				}
+				unPackDimSignalsLevel1(k, inner, dimKey, signalDimensionLists)
 			}
 		default:
 			utils.Info.Println(dimKey, "is of an unknown type")
@@ -206,18 +219,29 @@ func unpacksignalDimensionMap(signalDimensionMap map[string]interface{}, signalD
 	return signalDimensionLists
 }
 
-func unPackDimSignalsLevel1(index int, signalDimMap map[string]interface{}, dimKey string, signalDimensionLists SignalDimensionLists) {
+func unPackDimSignalsLevel1(index int, signalDimMap map[string]interface{}, dimKey string, signalDimensionLists *SignalDimensionLists) {
+	if signalDimensionLists == nil {
+		return
+	}
 	for pathKey, v := range signalDimMap {
 		switch vv := v.(type) {
 		case string:
 			utils.Info.Println(vv, "is string")
 			if dimKey == "dim2" {
+				if index < 0 || index >= len(signalDimensionLists.dim2List) {
+					utils.Error.Printf("unPackDimSignalsLevel1: dim2 index %d out of range %d", index, len(signalDimensionLists.dim2List))
+					return
+				}
 				if pathKey == "path1" {
 					signalDimensionLists.dim2List[index].Path1 = vv
 				} else {
 					signalDimensionLists.dim2List[index].Path2 = vv
 				}
 			} else {
+				if index < 0 || index >= len(signalDimensionLists.dim3List) {
+					utils.Error.Printf("unPackDimSignalsLevel1: dim3 index %d out of range %d", index, len(signalDimensionLists.dim3List))
+					return
+				}
 				if pathKey == "path1" {
 					signalDimensionLists.dim3List[index].Path1 = vv
 				} else if pathKey == "path2" {
@@ -240,8 +264,7 @@ func jsonToStructList(data string) *SignalDimensionLists {
 		utils.Error.Printf("Error unmarshal signal dimension list=%s", err)
 		return nil
 	}
-	signalDimensionLists = unpacksignalDimensionMap(signalDimensionMap, signalDimensionLists)
-	return &signalDimensionLists
+	return unpacksignalDimensionMap(signalDimensionMap, &signalDimensionLists)
 }
 
 func readSignalDimensions(fname string) *SignalDimensionLists {
@@ -254,11 +277,18 @@ func readSignalDimensions(fname string) *SignalDimensionLists {
 }
 
 func populateDimLists(paths []string) ([]string, []Dim2Elem, []Dim3Elem) {
+	signalDimensionList := readSignalDimensions("signaldimension.json")
+	return populateDimListsFromSignals(paths, signalDimensionList)
+}
+
+// populateDimListsFromSignals is the testable form of populateDimLists; it
+// takes the parsed signal-dimension list as an argument instead of reading
+// it from disk.
+func populateDimListsFromSignals(paths []string, signalDimensionList *SignalDimensionLists) ([]string, []Dim2Elem, []Dim3Elem) {
 	var dim1List []string
 	var dim2List []Dim2Elem
 	var dim3List []Dim3Elem
 
-	signalDimensionList := readSignalDimensions("signaldimension.json")
 	pathDimList := analyzeSignalDimensions(paths, signalDimensionList)
 
 	for i := 0; i < len(paths); i++ {
@@ -277,7 +307,7 @@ func populateDimLists(paths []string) ([]string, []Dim2Elem, []Dim3Elem) {
 
 		} else if pathDimList[i].Dim == 3 && pathDimList[i].Populated == false {
 			for j := i + 1; j < len(paths); j++ {
-				if pathDimList[j].Dim == 3 && pathDimList[j].Id == pathDimList[j].Id {
+				if pathDimList[j].Dim == 3 && pathDimList[j].Id == pathDimList[i].Id {
 					for k := j + 1; k < len(paths); k++ {
 						if pathDimList[k].Dim == 3 && pathDimList[k].Id == pathDimList[i].Id {
 							var dim3Elem Dim3Elem
@@ -293,7 +323,7 @@ func populateDimLists(paths []string) ([]string, []Dim2Elem, []Dim3Elem) {
 			}
 		}
 	}
-	return dim1List, dim2List, nil
+	return dim1List, dim2List, dim3List
 }
 
 func analyzeSignalDimensions(paths []string, signalDimensionList *SignalDimensionLists) []PathDimElem {
@@ -395,10 +425,10 @@ func is3dim(path string, index int, dim3List []Dim3Elem) bool {
 func getSleepDuration(newTime time.Time, oldTime time.Time, wantedDuration int) time.Duration {
 	workDuration := newTime.Sub(oldTime)
 	sleepDuration := time.Duration(wantedDuration) * time.Millisecond
-	if sleepDuration - workDuration > 0 {
+	if sleepDuration-workDuration > 0 {
 		return sleepDuration - workDuration
 	}
-	return 1  // used by ticker that panics on <= 0
+	return time.Millisecond // ticker panics on <= 0; 1 ns busy-loops, so use 1ms as a safe floor
 }
 
 func curveLoggingDispatcher(clChan chan CLPack, subscriptionId int, opValue string, paths []string) (TriggRoutingData, SubThreads) {
@@ -406,112 +436,217 @@ func curveLoggingDispatcher(clChan chan CLPack, subscriptionId int, opValue stri
 	if bufSize > MAXCLBUFSIZE {
 		bufSize = MAXCLBUFSIZE
 	}
+	if bufSize < 1 {
+		bufSize = 1
+	}
 	dim1List, dim2List, dim3List := populateDimLists(paths)
 	var triggRoutingData TriggRoutingData
 	triggRoutingData.SubscriptionId = strconv.Itoa(subscriptionId)
 	var triggRoutingElem TriggRoutingElem
+	startedThreads := 0
 	for i := 0; i < len(dim1List); i++ {
-		if numOfClSessions > MAXCLSESSIONS {
+		if !incrementClSessionsIfAvailable() {
 			utils.Error.Printf("Curve logging: All resources are utilized.")
+			break
+		}
+		triggChannelIndex := allocateTriggChannelIndex()
+		if triggChannelIndex < 0 {
+			utils.Error.Printf("Curve logging: no free trigger channel available.")
+			decrementClSessions()
 			break
 		}
 		returnSingleDp(clChan, subscriptionId, dim1List[i])
-		triggChannelIndex := allocateTriggChannelIndex()
 		go clCapture1dim(clChan, triggChannelIndex, subscriptionId, dim1List[i], bufSize, maxError)
 		triggRoutingElem.Index = triggChannelIndex
-		triggRoutingElem.Path = dim1List
+		triggRoutingElem.Path = []string{dim1List[i]}
 		triggRoutingData.TriggRoutingList = append(triggRoutingData.TriggRoutingList, triggRoutingElem)
-		numOfClSessions++
+		startedThreads++
 	}
 	for i := 0; i < len(dim2List); i++ {
-		if numOfClSessions > MAXCLSESSIONS {
+		if !incrementClSessionsIfAvailable() {
 			utils.Error.Printf("Curve logging: All resources are utilized.")
 			break
 		}
-		returnSingleDp2(clChan, subscriptionId, dim2List[i])
 		triggChannelIndex := allocateTriggChannelIndex()
+		if triggChannelIndex < 0 {
+			utils.Error.Printf("Curve logging: no free trigger channel available.")
+			decrementClSessions()
+			break
+		}
+		returnSingleDp2(clChan, subscriptionId, dim2List[i])
 		go clCapture2dim(clChan, triggChannelIndex, subscriptionId, dim2List[i], bufSize, maxError)
 		triggRoutingElem.Index = triggChannelIndex
 		triggRoutingElem.Path = dim1TransformDim2(dim2List[i])
 		triggRoutingData.TriggRoutingList = append(triggRoutingData.TriggRoutingList, triggRoutingElem)
-		numOfClSessions++
+		startedThreads++
 	}
 	for i := 0; i < len(dim3List); i++ {
-		if numOfClSessions > MAXCLSESSIONS {
+		if !incrementClSessionsIfAvailable() {
 			utils.Error.Printf("Curve logging: All resources are utilized.")
 			break
 		}
-		returnSingleDp3(clChan, subscriptionId, dim3List[i])
 		triggChannelIndex := allocateTriggChannelIndex()
+		if triggChannelIndex < 0 {
+			utils.Error.Printf("Curve logging: no free trigger channel available.")
+			decrementClSessions()
+			break
+		}
+		returnSingleDp3(clChan, subscriptionId, dim3List[i])
 		go clCapture3dim(clChan, triggChannelIndex, subscriptionId, dim3List[i], bufSize, maxError)
 		triggRoutingElem.Index = triggChannelIndex
 		triggRoutingElem.Path = dim1TransformDim3(dim3List[i])
 		triggRoutingData.TriggRoutingList = append(triggRoutingData.TriggRoutingList, triggRoutingElem)
-		numOfClSessions++
+		startedThreads++
 	}
 	var subThreads SubThreads
-	subThreads.NumofThreads = len(dim1List) + len(dim2List) + len(dim3List)
+	subThreads.NumofThreads = startedThreads
 	subThreads.SubscriptionId = subscriptionId
 	return triggRoutingData, subThreads
 
+}
+
+// incrementClSessionsIfAvailable returns true and increments numOfClSessions
+// iff there is capacity. Otherwise returns false and leaves the counter unchanged.
+func incrementClSessionsIfAvailable() bool {
+	numOfClSessionsMu.Lock()
+	defer numOfClSessionsMu.Unlock()
+	if numOfClSessions >= MAXCLSESSIONS {
+		return false
+	}
+	numOfClSessions++
+	return true
+}
+
+// decrementClSessions is paired with incrementClSessionsIfAvailable when a
+// session fails to start (e.g. no triggChannel) or when a session ends.
+func decrementClSessions() {
+	numOfClSessionsMu.Lock()
+	defer numOfClSessionsMu.Unlock()
+	if numOfClSessions > 0 {
+		numOfClSessions--
+	}
+}
+
+// getClSessionsCount returns the current number of active CL sessions (test-friendly accessor).
+func getClSessionsCount() int {
+	numOfClSessionsMu.Lock()
+	defer numOfClSessionsMu.Unlock()
+	return numOfClSessions
 }
 
 func curveLogServer() {
 	var routingDataList []TriggRoutingData
 	for {
 		select {
-			case message := <- fromFeederCl:
-				if len(message) == 0 {
-					continue
-				}
-				var messageMap map[string]interface{}
-				err := json.Unmarshal([]byte(message), &messageMap)
-				if err != nil || messageMap["action"] == nil {
-					utils.Error.Printf("Error in trigg message=%s", message)
-					continue
-				}
-				switch messageMap["action"].(string) {
-					case "subscribe":
-						if messageMap["status"] != nil && messageMap["status"].(string) == "ok" {
-							// notify all existing compute threads
-							for i  := 0; i < len(routingDataList); i++ {
-								for j  := 0; j < len(routingDataList[i].TriggRoutingList); j++ {
-									clServerChan[routingDataList[i].TriggRoutingList[j].Index] <- message
-								}
-							}
-						}
-					case "unsubscribe":
-						if messageMap["subscriptionId"] != nil {
-							//remove from routingDataList
-							subscriptionId := messageMap["subscriptionId"].(string)
-							for i  := 0; i < len(routingDataList); i++ {
-								if routingDataList[i].SubscriptionId == subscriptionId {
-									deallocateTriggChannels(i, routingDataList)
-									slices.Delete(routingDataList, i, i+1)
-								}
-							}
-						}
-					case "subscription":
-						if messageMap["path"] != nil {
-							// notify all threads that use the path
-							path := messageMap["path"].(string)
-							for j  := 0; j < len(routingDataList); j++ {
-								for k  := 0; k < len(routingDataList[j].TriggRoutingList); k++ {
-									for l  := 0; l < len(routingDataList[j].TriggRoutingList[k].Path); l++ {
-										if routingDataList[j].TriggRoutingList[k].Path[l] == path {
-											clServerChan[routingDataList[j].TriggRoutingList[k].Index] <- message
-											break
-										}
-									}
-								}
-							}
-						}
-					default:
-						utils.Error.Printf("Unknown action=%s", messageMap["action"].(string))
-				}
-			case routingData := <- clRouterChan:
-				routingDataList = append(routingDataList, routingData)
+		case message := <-fromFeederCl:
+			routingDataList = handleCurveLogServerMessage(message, routingDataList)
+		case routingData := <-clRouterChan:
+			routingDataList = append(routingDataList, routingData)
 		}
+	}
+}
+
+// handleCurveLogServerMessage processes a single feeder message and returns
+// the (possibly mutated) routing-data list. Extracted from curveLogServer
+// so the dispatch is unit-testable.
+func handleCurveLogServerMessage(message string, routingDataList []TriggRoutingData) []TriggRoutingData {
+	if len(message) == 0 {
+		return routingDataList
+	}
+	var messageMap map[string]interface{}
+	err := json.Unmarshal([]byte(message), &messageMap)
+	if err != nil {
+		utils.Error.Printf("Error in trigg message=%s err=%v", message, err)
+		return routingDataList
+	}
+	actionRaw, ok := messageMap["action"]
+	if !ok || actionRaw == nil {
+		utils.Error.Printf("Error in trigg message (missing action)=%s", message)
+		return routingDataList
+	}
+	action, ok := actionRaw.(string)
+	if !ok {
+		utils.Error.Printf("Error in trigg message (action not string)=%s", message)
+		return routingDataList
+	}
+	switch action {
+	case "subscribe":
+		statusRaw, present := messageMap["status"]
+		if !present || statusRaw == nil {
+			return routingDataList
+		}
+		status, ok := statusRaw.(string)
+		if !ok || status != "ok" {
+			return routingDataList
+		}
+		// notify all existing compute threads
+		for i := 0; i < len(routingDataList); i++ {
+			for j := 0; j < len(routingDataList[i].TriggRoutingList); j++ {
+				idx := routingDataList[i].TriggRoutingList[j].Index
+				if idx < 0 || idx >= MAXCLSESSIONS {
+					continue
+				}
+				sendToClServerChan(idx, message)
+			}
+		}
+	case "unsubscribe":
+		subIdRaw, present := messageMap["subscriptionId"]
+		if !present || subIdRaw == nil {
+			return routingDataList
+		}
+		subscriptionId, ok := subIdRaw.(string)
+		if !ok {
+			utils.Error.Printf("unsubscribe: subscriptionId not string in=%s", message)
+			return routingDataList
+		}
+		// remove every matching entry from routingDataList
+		for i := 0; i < len(routingDataList); {
+			if routingDataList[i].SubscriptionId == subscriptionId {
+				deallocateTriggChannels(i, routingDataList)
+				routingDataList = slices.Delete(routingDataList, i, i+1)
+				// don't advance i: the next element shifted into position i
+				continue
+			}
+			i++
+		}
+	case "subscription":
+		pathRaw, present := messageMap["path"]
+		if !present || pathRaw == nil {
+			return routingDataList
+		}
+		path, ok := pathRaw.(string)
+		if !ok {
+			utils.Error.Printf("subscription: path not string in=%s", message)
+			return routingDataList
+		}
+		// notify all threads that use the path
+		for j := 0; j < len(routingDataList); j++ {
+			for k := 0; k < len(routingDataList[j].TriggRoutingList); k++ {
+				for l := 0; l < len(routingDataList[j].TriggRoutingList[k].Path); l++ {
+					if routingDataList[j].TriggRoutingList[k].Path[l] == path {
+						idx := routingDataList[j].TriggRoutingList[k].Index
+						if idx >= 0 && idx < MAXCLSESSIONS {
+							sendToClServerChan(idx, message)
+						}
+						break
+					}
+				}
+			}
+		}
+	default:
+		utils.Error.Printf("Unknown action=%s", action)
+	}
+	return routingDataList
+}
+
+// sendToClServerChan does a non-blocking send into the per-session channel.
+// The channel is buffered, but a slow consumer could still wedge the dispatcher
+// if we sent blocking; dropping is preferable to blocking the entire server.
+func sendToClServerChan(index int, message string) {
+	select {
+	case clServerChan[index] <- message:
+	default:
+		utils.Error.Printf("curveLogServer: clServerChan[%d] full, dropping message", index)
 	}
 }
 
@@ -531,8 +666,10 @@ func dim1TransformDim3(dim3List Dim3Elem) []string {
 }
 
 func allocateTriggChannelIndex() int {
+	triggChannelMu.Lock()
+	defer triggChannelMu.Unlock()
 	for i := 0; i < MAXCLSESSIONS; i++ {
-		if !triggChannelList[i].Busy {
+		if i < len(triggChannelList) && !triggChannelList[i].Busy {
 			triggChannelList[i].Busy = true
 			return i
 		}
@@ -541,8 +678,25 @@ func allocateTriggChannelIndex() int {
 }
 
 func deallocateTriggChannels(i int, routingDataList []TriggRoutingData) {
-	for j  := 0; j < len(routingDataList[i].TriggRoutingList); j++ {
-		triggChannelList[routingDataList[i].TriggRoutingList[j].Index].Busy = false
+	if i < 0 || i >= len(routingDataList) {
+		return
+	}
+	released := 0
+	triggChannelMu.Lock()
+	for j := 0; j < len(routingDataList[i].TriggRoutingList); j++ {
+		idx := routingDataList[i].TriggRoutingList[j].Index
+		if idx < 0 || idx >= len(triggChannelList) {
+			continue
+		}
+		if triggChannelList[idx].Busy {
+			triggChannelList[idx].Busy = false
+			released++
+		}
+	}
+	triggChannelMu.Unlock()
+	// account for the closed sessions
+	for j := 0; j < released; j++ {
+		decrementClSessions()
 	}
 }
 
@@ -552,22 +706,34 @@ func decodeFeederMessageCl(feederMessage string, feederNotification bool) (bool,
 	}
 	var messageMap map[string]interface{}
 	err := json.Unmarshal([]byte(feederMessage), &messageMap)
-	if err != nil || messageMap["action"] == nil {
-		utils.Error.Printf("Error in feeder message=%s", feederMessage)
+	if err != nil {
+		utils.Error.Printf("Error in feeder message=%s err=%v", feederMessage, err)
+		return false, feederNotification
+	}
+	actionRaw, present := messageMap["action"]
+	if !present || actionRaw == nil {
+		utils.Error.Printf("Error in feeder message (missing action)=%s", feederMessage)
+		return false, feederNotification
+	}
+	action, ok := actionRaw.(string)
+	if !ok {
+		utils.Error.Printf("Error in feeder message (action not string)=%s", feederMessage)
 		return false, feederNotification
 	}
 	doCapture := false
-	switch messageMap["action"].(string) {
-		case "subscribe":
-			if messageMap["status"] != nil && messageMap["status"].(string) == "ok" {
+	switch action {
+	case "subscribe":
+		if statusRaw, ok := messageMap["status"]; ok && statusRaw != nil {
+			if status, ok := statusRaw.(string); ok && status == "ok" {
 				feederNotification = true
 			}
-		case "subscription":
-			if messageMap["path"] != nil {
-				doCapture = true
-			}
-		default:
-			utils.Error.Printf("Unknown action=%s", messageMap["action"].(string))
+		}
+	case "subscription":
+		if pathRaw, ok := messageMap["path"]; ok && pathRaw != nil {
+			doCapture = true
+		}
+	default:
+		utils.Error.Printf("Unknown action=%s", action)
 	}
 	return doCapture, feederNotification
 }
@@ -607,12 +773,17 @@ func clCapture1dim(clChan chan CLPack, triggChannelIndex int, subscriptionId int
 		dp := getVehicleData(path)
 		utils.Info.Printf("**** dp =%s ", dp)
 		utils.MapRequest(dp, &dpMap)
-		if dpMap["value"].(string) == "visserr:Data-not-available" {
+		valStr, okVal := stringField(dpMap, "value")
+		tsStrNew, okTs := stringField(dpMap, "ts")
+		if !okVal || !okTs {
+			continue
+		}
+		if valStr == "visserr:Data-not-available" {
 			continue
 		}
 		_, ts := readRing(&aRingBuffer, 0) // read latest written
-		if ts != dpMap["ts"].(string) {
-			writeRing(&aRingBuffer, dpMap["value"].(string), dpMap["ts"].(string))
+		if ts != tsStrNew {
+			writeRing(&aRingBuffer, valStr, tsStrNew)
 		}
 		currentBufSize := getNumOfPopulatedRingElements(&aRingBuffer)
 		if (currentBufSize == bufSize) || (closeClSession == true) {
@@ -645,6 +816,10 @@ func clCapture1dim(clChan chan CLPack, triggChannelIndex int, subscriptionId int
 func clAnalyze1dim(aRingBuffer *RingBuffer, bufSize int, maxError float64) (string, int, int) { // [{"value":"X","ts":"Y"},..{}] ; square brackets optional
 	clBuffer := make([]CLBufElement, bufSize) // array holds transformed value/ts pairs, from latest to first captured
 	clBuffer = transformDataPoints(aRingBuffer, clBuffer, bufSize)
+	if clBuffer == nil {
+		val, ts := readRing(aRingBuffer, 0)
+		return `{"value":"` + val + `","ts":"` + ts + `"}`, 0, 0
+	}
 	savedIndex := clReduction1Dim(clBuffer, 0, bufSize-1, maxError)
 	dataPoint := ""
 	lastSelected := 0  // index for last dp in ring buffer that is selected by RDP-algo, or last value in buffer if none selected
@@ -748,7 +923,6 @@ func postProcess1dim(aRingBuffer *RingBuffer, firstSelected int, lastSelected in
 			}
 		}
 	}
-	return "", postProc // should not happen
 }
 
 func writePostProcElement1dim(aRingBuffer *RingBuffer, firstSelected int, postProc []PostProcessBufElement1dim, pos int) []PostProcessBufElement1dim {
@@ -777,9 +951,21 @@ func saveNonPdrDp(postProc []PostProcessBufElement1dim, maxError float64) bool {
 }
 
 func transformDataPoints(aRingBuffer *RingBuffer, clBuffer []CLBufElement, bufSize int) []CLBufElement {
+	if aRingBuffer == nil || bufSize <= 0 || bufSize > len(clBuffer) {
+		return nil
+	}
 	var status bool
 	_, tsBaseStr := readRing(aRingBuffer, bufSize-1) // get ts for first dp in buffer
-	tsBase, _ := time.Parse(time.RFC3339Nano, tsBaseStr)
+	tsBase, err := time.Parse(time.RFC3339Nano, tsBaseStr)
+	if err != nil {
+		// fall back to UnixMilli-as-int
+		if t2, err2 := strconv.ParseInt(tsBaseStr, 10, 64); err2 == nil {
+			tsBase = time.UnixMilli(t2)
+		} else {
+			utils.Error.Printf("transformDataPoints: cannot parse base timestamp=%q err=%v", tsBaseStr, err)
+			return nil
+		}
+	}
 	for index := 0; index < bufSize; index++ {
 		clBuffer[index], status = transformDataPoint(aRingBuffer, index, tsBase)
 		if status == false {
@@ -843,32 +1029,32 @@ func returnSingleDp3(clChan chan CLPack, subscriptionId int, paths Dim3Elem) {
 	clChan <- clPack
 }
 
-func clCapture2dim(clChan chan CLPack,triggChannelIndex int, subscriptionId int, paths Dim2Elem, bufSize int, maxError float64) {
+func clCapture2dim(clChan chan CLPack, triggChannelIndex int, subscriptionId int, paths Dim2Elem, bufSize int, maxError float64) {
 	aRingBuffer1 := createRingBuffer(bufSize + 1)
 	aRingBuffer2 := createRingBuffer(bufSize + 1)
 	var dpMap1 = make(map[string]interface{})
 	var dpMap2 = make(map[string]interface{})
 	closeClSession := false
-	oldTime := getCurrentUtcTime()  // captureTicker start/reset time
+	oldTime := getCurrentUtcTime() // captureTicker start/reset time
 	captureTicker := time.NewTicker(10 * time.Millisecond)
 	feederNotification := false
 	var doCapture bool
 	updatedTail := 0
 	for {
 		select {
-			case <- captureTicker.C:
-				if !feederNotification {
-					newTime := getCurrentUtcTime()
-					captureTicker.Reset(getSleepDuration(newTime, oldTime, 90)) // 90 msec sufficient?
-					oldTime = newTime
-				} else {
-					captureTicker.Stop()
-				}
-			case feederMessage := <- clServerChan[triggChannelIndex]:
-				doCapture, feederNotification = decodeFeederMessageCl(feederMessage, feederNotification)
-				if !doCapture {
-					continue
-				}
+		case <-captureTicker.C:
+			if !feederNotification {
+				newTime := getCurrentUtcTime()
+				captureTicker.Reset(getSleepDuration(newTime, oldTime, 90)) // 90 msec sufficient?
+				oldTime = newTime
+			} else {
+				captureTicker.Stop()
+			}
+		case feederMessage := <-clServerChan[triggChannelIndex]:
+			doCapture, feederNotification = decodeFeederMessageCl(feederMessage, feederNotification)
+			if !doCapture {
+				continue
+			}
 		}
 		mcloseClSubId.Lock()
 		if closeClSubId == subscriptionId {
@@ -879,18 +1065,29 @@ func clCapture2dim(clChan chan CLPack,triggChannelIndex int, subscriptionId int,
 		dp2 := getVehicleData(paths.Path2)
 		utils.MapRequest(dp1, &dpMap1)
 		utils.MapRequest(dp2, &dpMap2)
-		if dpMap1["value"].(string) == "visserr:Data-not-available" || dpMap2["value"].(string) == "visserr:Data-not-available" {
+		val1Str, ok1 := stringField(dpMap1, "value")
+		val2Str, ok2 := stringField(dpMap2, "value")
+		if !ok1 || !ok2 {
+			continue
+		}
+		if val1Str == "visserr:Data-not-available" || val2Str == "visserr:Data-not-available" {
+			continue
+		}
+		ts1New, ok1 := stringField(dpMap1, "ts")
+		ts2New, ok2 := stringField(dpMap2, "ts")
+		if !ok1 || !ok2 {
 			continue
 		}
 		_, ts1 := readRing(&aRingBuffer1, 0)
 		_, ts2 := readRing(&aRingBuffer2, 0)
-		if ts1 != dpMap1["ts"].(string) && ts2 != dpMap2["ts"].(string) && dpMap1["ts"].(string) == dpMap2["ts"].(string) {
-			writeRing(&aRingBuffer1, dpMap1["value"].(string), dpMap1["ts"].(string))
-			writeRing(&aRingBuffer2, dpMap2["value"].(string), dpMap2["ts"].(string))
+		if ts1 != ts1New && ts2 != ts2New && ts1New == ts2New {
+			writeRing(&aRingBuffer1, val1Str, ts1New)
+			writeRing(&aRingBuffer2, val2Str, ts2New)
 		}
 		currentBufSize := getNumOfPopulatedRingElements(&aRingBuffer1)
 		if (currentBufSize == bufSize) || (closeClSession == true) {
-			data1, data2, updatedTail := clAnalyze2dim(&aRingBuffer1, &aRingBuffer2, currentBufSize, maxError)
+			data1, data2, ut := clAnalyze2dim(&aRingBuffer1, &aRingBuffer2, currentBufSize, maxError)
+			updatedTail = ut
 			var clPack CLPack
 			clPack.DataPack = `[{"path":"` + paths.Path1 + `","dp":` + data1 + "}," + `{"path":"` + paths.Path2 + `","dp":` + data2 + "}]"
 			clPack.SubscriptionId = subscriptionId
@@ -907,11 +1104,30 @@ func clCapture2dim(clChan chan CLPack,triggChannelIndex int, subscriptionId int,
 	}
 }
 
+// stringField returns m[key] as a string if present and string-typed, else "", false.
+func stringField(m map[string]interface{}, key string) (string, bool) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
+}
+
 func clAnalyze2dim(aRingBuffer1 *RingBuffer, aRingBuffer2 *RingBuffer, bufSize int, maxError float64) (string, string, int) {
 	clBuffer1 := make([]CLBufElement, bufSize)
 	clBuffer2 := make([]CLBufElement, bufSize)
 	clBuffer1 = transformDataPoints(aRingBuffer1, clBuffer1, bufSize)
 	clBuffer2 = transformDataPoints(aRingBuffer2, clBuffer2, bufSize)
+	if clBuffer1 == nil || clBuffer2 == nil {
+		val1, ts1 := readRing(aRingBuffer1, 0)
+		val2, ts2 := readRing(aRingBuffer2, 0)
+		return `{"value":"` + val1 + `","ts":"` + ts1 + `"}`,
+			`{"value":"` + val2 + `","ts":"` + ts2 + `"}`, 0
+	}
 	savedIndex := clReduction2Dim(clBuffer1, clBuffer2, 0, bufSize-1, maxError)
 	dataPoint1 := ""
 	dataPoint2 := ""
@@ -983,26 +1199,26 @@ func clCapture3dim(clChan chan CLPack, triggChannelIndex int, subscriptionId int
 	var dpMap2 = make(map[string]interface{})
 	var dpMap3 = make(map[string]interface{})
 	closeClSession := false
-	oldTime := getCurrentUtcTime()  // captureTicker start/reset time
+	oldTime := getCurrentUtcTime() // captureTicker start/reset time
 	captureTicker := time.NewTicker(10 * time.Millisecond)
 	feederNotification := false
 	var doCapture bool
 	updatedTail := 0
 	for {
 		select {
-			case <- captureTicker.C:
-				if !feederNotification {
-					newTime := getCurrentUtcTime()
-					captureTicker.Reset(getSleepDuration(newTime, oldTime, 90)) // 90 msec sufficient?
-					oldTime = newTime
-				} else {
-					captureTicker.Stop()
-				}
-			case feederMessage := <- clServerChan[triggChannelIndex]:
-				doCapture, feederNotification = decodeFeederMessageCl(feederMessage, feederNotification)
-				if !doCapture {
-					continue
-				}
+		case <-captureTicker.C:
+			if !feederNotification {
+				newTime := getCurrentUtcTime()
+				captureTicker.Reset(getSleepDuration(newTime, oldTime, 90)) // 90 msec sufficient?
+				oldTime = newTime
+			} else {
+				captureTicker.Stop()
+			}
+		case feederMessage := <-clServerChan[triggChannelIndex]:
+			doCapture, feederNotification = decodeFeederMessageCl(feederMessage, feederNotification)
+			if !doCapture {
+				continue
+			}
 		}
 		mcloseClSubId.Lock()
 		if closeClSubId == subscriptionId {
@@ -1015,21 +1231,34 @@ func clCapture3dim(clChan chan CLPack, triggChannelIndex int, subscriptionId int
 		utils.MapRequest(dp1, &dpMap1)
 		utils.MapRequest(dp2, &dpMap2)
 		utils.MapRequest(dp3, &dpMap3)
-		if dpMap1["value"].(string) == "visserr:Data-not-available" || dpMap2["value"].(string) == "visserr:Data-not-available" || dpMap3["value"].(string) == "visserr:Data-not-available" {
+		val1Str, ok1 := stringField(dpMap1, "value")
+		val2Str, ok2 := stringField(dpMap2, "value")
+		val3Str, ok3 := stringField(dpMap3, "value")
+		if !ok1 || !ok2 || !ok3 {
+			continue
+		}
+		if val1Str == "visserr:Data-not-available" || val2Str == "visserr:Data-not-available" || val3Str == "visserr:Data-not-available" {
+			continue
+		}
+		ts1New, ok1 := stringField(dpMap1, "ts")
+		ts2New, ok2 := stringField(dpMap2, "ts")
+		ts3New, ok3 := stringField(dpMap3, "ts")
+		if !ok1 || !ok2 || !ok3 {
 			continue
 		}
 		_, ts1 := readRing(&aRingBuffer1, 0)
 		_, ts2 := readRing(&aRingBuffer2, 0)
 		_, ts3 := readRing(&aRingBuffer3, 0)
-		if ts1 != dpMap1["ts"].(string) && ts2 != dpMap2["ts"].(string) && ts3 != dpMap3["ts"].(string) &&
-			dpMap1["ts"].(string) == dpMap2["ts"].(string) && dpMap2["ts"].(string) == dpMap3["ts"].(string) {
-			writeRing(&aRingBuffer1, dpMap1["value"].(string), dpMap1["ts"].(string))
-			writeRing(&aRingBuffer2, dpMap2["value"].(string), dpMap2["ts"].(string))
-			writeRing(&aRingBuffer3, dpMap3["value"].(string), dpMap3["ts"].(string))
+		if ts1 != ts1New && ts2 != ts2New && ts3 != ts3New &&
+			ts1New == ts2New && ts2New == ts3New {
+			writeRing(&aRingBuffer1, val1Str, ts1New)
+			writeRing(&aRingBuffer2, val2Str, ts2New)
+			writeRing(&aRingBuffer3, val3Str, ts3New)
 		}
 		currentBufSize := getNumOfPopulatedRingElements(&aRingBuffer1)
 		if (currentBufSize == bufSize) || (closeClSession == true) {
-			data1, data2, data3, updatedTail := clAnalyze3dim(&aRingBuffer1, &aRingBuffer2, &aRingBuffer3, currentBufSize, maxError)
+			data1, data2, data3, ut := clAnalyze3dim(&aRingBuffer1, &aRingBuffer2, &aRingBuffer3, currentBufSize, maxError)
+			updatedTail = ut
 			var clPack CLPack
 			clPack.DataPack = `[{"path":"` + paths.Path1 + `","dp":` + data1 + `},{"path":"` + paths.Path2 + `","dp":` + data2 + `},{"path":"` + paths.Path3 + `","dp":` + data3 + "}]"
 			clPack.SubscriptionId = subscriptionId
@@ -1054,6 +1283,14 @@ func clAnalyze3dim(aRingBuffer1 *RingBuffer, aRingBuffer2 *RingBuffer, aRingBuff
 	clBuffer1 = transformDataPoints(aRingBuffer1, clBuffer1, bufSize)
 	clBuffer2 = transformDataPoints(aRingBuffer2, clBuffer2, bufSize)
 	clBuffer3 = transformDataPoints(aRingBuffer3, clBuffer3, bufSize)
+	if clBuffer1 == nil || clBuffer2 == nil || clBuffer3 == nil {
+		val1, ts1 := readRing(aRingBuffer1, 0)
+		val2, ts2 := readRing(aRingBuffer2, 0)
+		val3, ts3 := readRing(aRingBuffer3, 0)
+		return `{"value":"` + val1 + `","ts":"` + ts1 + `"}`,
+			`{"value":"` + val2 + `","ts":"` + ts2 + `"}`,
+			`{"value":"` + val3 + `","ts":"` + ts3 + `"}`, 0
+	}
 	savedIndex := clReduction3Dim(clBuffer1, clBuffer2, clBuffer3, 0, bufSize-1, maxError)
 	dataPoint1 := ""
 	dataPoint2 := ""

--- a/server/vissv2server/serviceMgr/curvelog_test.go
+++ b/server/vissv2server/serviceMgr/curvelog_test.go
@@ -1,0 +1,1372 @@
+/**
+* (C) 2026 Matt Jones / Ford
+*
+* Tests for curvelog.go that pin each of the bug fixes in this branch
+* (see fix/curvelog-bugs). Each test references the original bug by
+* number in its comment.
+**/
+
+package serviceMgr
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/covesa/vissr/utils"
+)
+
+func init() {
+	// Make sure logging output won't panic during tests.
+	utils.InitLog("curvelog_test-log.txt", "./logs", false, "info")
+}
+
+// resetClState fully resets the package-level CL globals between tests so
+// that they don't bleed counters/channels across tests.
+func resetClState() {
+	numOfClSessionsMu.Lock()
+	numOfClSessions = 0
+	numOfClSessionsMu.Unlock()
+
+	triggChannelMu.Lock()
+	triggChannelList = make([]TriggChannelElem, MAXCLSESSIONS)
+	for i := 0; i < MAXCLSESSIONS; i++ {
+		triggChannelList[i].Busy = false
+	}
+	triggChannelMu.Unlock()
+
+	for i := range clServerChan {
+		clServerChan[i] = make(chan string, 10)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Bug #1 — getSleepDuration returns time.Millisecond, never 1 nanosecond
+// --------------------------------------------------------------------------
+
+func TestGetSleepDuration_FloorIsOneMillisecond(t *testing.T) {
+	now := time.Now()
+	earlier := now.Add(-time.Second) // workDuration = 1s, far exceeds 1ms wantedDuration
+	got := getSleepDuration(now, earlier, 1)
+	if got < time.Millisecond {
+		t.Fatalf("getSleepDuration returned %v; expected >= 1ms (the 1-nanosecond default would busy-loop the ticker)", got)
+	}
+}
+
+func TestGetSleepDuration_HappyPathReturnsRemainder(t *testing.T) {
+	oldT := time.Now()
+	newT := oldT.Add(10 * time.Millisecond)
+	got := getSleepDuration(newT, oldT, 100) // 100ms wanted, 10ms used
+	if got <= 0 {
+		t.Fatalf("getSleepDuration returned %v; expected positive remainder", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Bug #2 — numOfClSessions has a mutex and never goes negative
+// --------------------------------------------------------------------------
+
+func TestNumOfClSessions_RaceFreeUnderConcurrency(t *testing.T) {
+	resetClState()
+
+	var wg sync.WaitGroup
+	const N = 100
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if incrementClSessionsIfAvailable() {
+				time.Sleep(time.Microsecond)
+				decrementClSessions()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := getClSessionsCount(); got != 0 {
+		t.Fatalf("after balanced concurrent incr/decr, expected 0 active sessions; got %d", got)
+	}
+}
+
+func TestIncrementClSessions_CappedAtMax(t *testing.T) {
+	resetClState()
+	granted := 0
+	for i := 0; i < MAXCLSESSIONS+5; i++ {
+		if incrementClSessionsIfAvailable() {
+			granted++
+		}
+	}
+	if granted != MAXCLSESSIONS {
+		t.Fatalf("expected exactly %d grants; got %d", MAXCLSESSIONS, granted)
+	}
+	// over-decrementing must not go negative
+	for i := 0; i < MAXCLSESSIONS+3; i++ {
+		decrementClSessions()
+	}
+	if got := getClSessionsCount(); got != 0 {
+		t.Fatalf("expected sessions floor at 0; got %d", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Bug #3 — allocateTriggChannelIndex is mutex-protected and bounded
+// --------------------------------------------------------------------------
+
+func TestAllocateTriggChannelIndex_NoDoubleAllocation(t *testing.T) {
+	resetClState()
+
+	var (
+		mu   sync.Mutex
+		seen = make(map[int]int)
+	)
+	var wg sync.WaitGroup
+	const N = MAXCLSESSIONS
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			idx := allocateTriggChannelIndex()
+			mu.Lock()
+			seen[idx]++
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	for idx, count := range seen {
+		if idx == -1 {
+			t.Errorf("allocateTriggChannelIndex returned -1 unexpectedly during normal allocation")
+			continue
+		}
+		if count > 1 {
+			t.Errorf("triggChannel %d was allocated to %d callers; concurrent allocator is racy", idx, count)
+		}
+	}
+}
+
+func TestAllocateTriggChannelIndex_ReturnsMinusOneWhenFull(t *testing.T) {
+	resetClState()
+	for i := 0; i < MAXCLSESSIONS; i++ {
+		if got := allocateTriggChannelIndex(); got < 0 {
+			t.Fatalf("unexpected -1 at iteration %d", i)
+		}
+	}
+	if got := allocateTriggChannelIndex(); got != -1 {
+		t.Fatalf("expected -1 when fully allocated; got %d", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Bug #4 — slices.Delete result is captured (unsubscribe really removes)
+// Bug #5 — unsubscribe loop handles index correctly after deletion
+// --------------------------------------------------------------------------
+
+func TestHandleCurveLogServerMessage_UnsubscribeRemovesEntry(t *testing.T) {
+	resetClState()
+	rdl := []TriggRoutingData{
+		{SubscriptionId: "1", TriggRoutingList: []TriggRoutingElem{{Index: 0}}},
+		{SubscriptionId: "2", TriggRoutingList: []TriggRoutingElem{{Index: 1}}},
+		{SubscriptionId: "3", TriggRoutingList: []TriggRoutingElem{{Index: 2}}},
+	}
+	msg := `{"action":"unsubscribe","subscriptionId":"2"}`
+	got := handleCurveLogServerMessage(msg, rdl)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 routing entries after unsubscribe; got %d", len(got))
+	}
+	for _, e := range got {
+		if e.SubscriptionId == "2" {
+			t.Fatalf("unsubscribed entry still present: %+v", e)
+		}
+	}
+}
+
+func TestHandleCurveLogServerMessage_UnsubscribeRemovesAllMatchingEntries(t *testing.T) {
+	resetClState()
+	// Two entries with the same id — without the loop fix one would survive.
+	rdl := []TriggRoutingData{
+		{SubscriptionId: "9", TriggRoutingList: []TriggRoutingElem{{Index: 0}}},
+		{SubscriptionId: "9", TriggRoutingList: []TriggRoutingElem{{Index: 1}}},
+		{SubscriptionId: "other", TriggRoutingList: []TriggRoutingElem{{Index: 2}}},
+	}
+	got := handleCurveLogServerMessage(`{"action":"unsubscribe","subscriptionId":"9"}`, rdl)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly the non-matching entry to remain; got %d entries", len(got))
+	}
+	if got[0].SubscriptionId != "other" {
+		t.Fatalf("wrong entry remained: %+v", got[0])
+	}
+}
+
+// --------------------------------------------------------------------------
+// Bug #6 — clServerChan is buffered AND non-blocking send drops on overflow
+// --------------------------------------------------------------------------
+
+func TestSendToClServerChan_NonBlockingOnFullChannel(t *testing.T) {
+	resetClState()
+	// Saturate channel 0
+	for i := 0; i < cap(clServerChan[0]); i++ {
+		clServerChan[0] <- fmt.Sprintf("filler-%d", i)
+	}
+	done := make(chan struct{})
+	go func() {
+		sendToClServerChan(0, "should not block")
+		close(done)
+	}()
+	select {
+	case <-done:
+		// good
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("sendToClServerChan blocked on a full channel; non-blocking send was supposed to drop")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Bug #7 — Defensive type assertions: no panic on bad shapes
+// --------------------------------------------------------------------------
+
+func TestHandleCurveLogServerMessage_InvalidShapesDoNotPanic(t *testing.T) {
+	resetClState()
+	cases := []string{
+		``,                                       // empty
+		`not json`,                               // bad JSON
+		`{}`,                                     // no action
+		`{"action":42}`,                          // action not string
+		`{"action":"unsubscribe"}`,               // no subscriptionId
+		`{"action":"unsubscribe","subscriptionId":42}`,
+		`{"action":"subscription"}`,              // no path
+		`{"action":"subscription","path":42}`,    // path not string
+		`{"action":"subscribe"}`,                 // no status
+		`{"action":"subscribe","status":42}`,     // status not string
+		`{"action":"subscribe","status":"nope"}`, // status not ok
+		`{"action":"weird"}`,                     // unknown action
+	}
+	for _, in := range cases {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("handleCurveLogServerMessage panicked on %q: %v", in, r)
+				}
+			}()
+			_ = handleCurveLogServerMessage(in, nil)
+		}()
+	}
+}
+
+func TestDecodeFeederMessageCl_InvalidShapesDoNotPanic(t *testing.T) {
+	cases := []string{
+		``,
+		`not json`,
+		`{}`,
+		`{"action":42}`,
+		`{"action":"subscribe"}`,
+		`{"action":"subscribe","status":42}`,
+		`{"action":"subscription"}`,
+		`{"action":"foo"}`,
+	}
+	for _, in := range cases {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("decodeFeederMessageCl panicked on %q: %v", in, r)
+				}
+			}()
+			_, _ = decodeFeederMessageCl(in, false)
+		}()
+	}
+}
+
+func TestDecodeFeederMessageCl_HappyPathSubscribeFlipsNotification(t *testing.T) {
+	doCap, notif := decodeFeederMessageCl(`{"action":"subscribe","status":"ok"}`, false)
+	if doCap {
+		t.Errorf("subscribe should not request capture")
+	}
+	if !notif {
+		t.Errorf("subscribe-ok should set feederNotification=true")
+	}
+
+	doCap, notif = decodeFeederMessageCl(`{"action":"subscription","path":"Vehicle.Speed"}`, false)
+	if !doCap {
+		t.Errorf("subscription with path should request capture")
+	}
+	if notif {
+		t.Errorf("subscription should not change feederNotification")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Bug #8 — populateDimLists returns dim3List, not nil
+// Bug #9 — populateDimLists pairs dim3 entries against pathDimList[i].Id
+// --------------------------------------------------------------------------
+
+func TestPopulateDimListsFromSignals_ReturnsDim3List(t *testing.T) {
+	// Pin Bug #8: pre-fix the function returned `nil` for the third slice
+	// regardless of whether dim3 entries existed.
+	sdl := &SignalDimensionLists{
+		dim3List: []Dim3Elem{
+			{Path1: "Vehicle.X", Path2: "Vehicle.Y", Path3: "Vehicle.Z"},
+		},
+	}
+	paths := []string{"Vehicle.X", "Vehicle.Y", "Vehicle.Z"}
+	d1, d2, d3 := populateDimListsFromSignals(paths, sdl)
+	if len(d1) != 0 {
+		t.Errorf("expected no dim1 entries; got %v", d1)
+	}
+	if len(d2) != 0 {
+		t.Errorf("expected no dim2 entries; got %v", d2)
+	}
+	if len(d3) != 1 {
+		t.Fatalf("expected 1 dim3 entry; got %v (pre-fix this returned nil!)", d3)
+	}
+	if d3[0].Path1 != "Vehicle.X" || d3[0].Path2 != "Vehicle.Y" || d3[0].Path3 != "Vehicle.Z" {
+		t.Errorf("dim3 entry mismatch: %+v", d3[0])
+	}
+}
+
+func TestPopulateDimListsFromSignals_GroupsDim3ByOwnerIndex(t *testing.T) {
+	// Pin Bug #9: pre-fix the inner `pathDimList[j].Id == pathDimList[j].Id`
+	// comparison was always true and would cross-mix members of different
+	// dim3 groups. With two distinct dim3 groups present, each group's
+	// members must stay together.
+	sdl := &SignalDimensionLists{
+		dim3List: []Dim3Elem{
+			{Path1: "Vehicle.A1", Path2: "Vehicle.A2", Path3: "Vehicle.A3"},
+			{Path1: "Vehicle.B1", Path2: "Vehicle.B2", Path3: "Vehicle.B3"},
+		},
+	}
+	paths := []string{
+		"Vehicle.A1", "Vehicle.A2", "Vehicle.A3",
+		"Vehicle.B1", "Vehicle.B2", "Vehicle.B3",
+	}
+	_, _, d3 := populateDimListsFromSignals(paths, sdl)
+	if len(d3) != 2 {
+		t.Fatalf("expected 2 dim3 groups; got %d", len(d3))
+	}
+	// Group 0 should be A*, group 1 should be B*.
+	if d3[0].Path1 != "Vehicle.A1" {
+		t.Errorf("group 0 lead = %q; want Vehicle.A1", d3[0].Path1)
+	}
+	if d3[1].Path1 != "Vehicle.B1" {
+		t.Errorf("group 1 lead = %q; want Vehicle.B1", d3[1].Path1)
+	}
+}
+
+func TestPopulateDimListsFromSignals_AllDim1WhenNoSignals(t *testing.T) {
+	paths := []string{"Vehicle.A", "Vehicle.B", "Vehicle.C"}
+	d1, d2, d3 := populateDimListsFromSignals(paths, nil)
+	if len(d1) != 3 {
+		t.Errorf("expected 3 dim1 entries; got %d", len(d1))
+	}
+	if len(d2) != 0 {
+		t.Errorf("expected 0 dim2 entries; got %d", len(d2))
+	}
+	if len(d3) != 0 {
+		t.Errorf("expected 0 dim3 entries; got %d", len(d3))
+	}
+}
+
+func TestPopulateDimListsFromSignals_Dim2Groups(t *testing.T) {
+	sdl := &SignalDimensionLists{
+		dim2List: []Dim2Elem{
+			{Path1: "Vehicle.X", Path2: "Vehicle.Y"},
+		},
+	}
+	paths := []string{"Vehicle.X", "Vehicle.Y", "Vehicle.Z"}
+	d1, d2, d3 := populateDimListsFromSignals(paths, sdl)
+	if len(d2) != 1 {
+		t.Fatalf("expected 1 dim2 entry; got %d", len(d2))
+	}
+	if d2[0].Path1 != "Vehicle.X" || d2[0].Path2 != "Vehicle.Y" {
+		t.Errorf("dim2 mismatch: %+v", d2[0])
+	}
+	// Vehicle.Z falls through as dim1
+	if len(d1) != 1 || d1[0] != "Vehicle.Z" {
+		t.Errorf("dim1 mismatch: %v", d1)
+	}
+	if len(d3) != 0 {
+		t.Errorf("expected 0 dim3 entries; got %d", len(d3))
+	}
+}
+
+func TestAnalyzeSignalDimensions_NilSignalListIsSafe(t *testing.T) {
+	pdl := analyzeSignalDimensions([]string{"a", "b", "c"}, nil)
+	if len(pdl) != 3 {
+		t.Fatalf("expected 3 entries; got %d", len(pdl))
+	}
+	for i, e := range pdl {
+		if e.Dim != 1 {
+			t.Errorf("entry %d: expected Dim=1 default; got %+v", i, e)
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
+// Bug #10 — unpacksignalDimensionMap mutates the original via *pointer*
+// --------------------------------------------------------------------------
+
+func TestUnpacksignalDimensionMap_PointerMutatesOriginal(t *testing.T) {
+	jsonBlob := `{
+		"dim2":[{"path1":"A1","path2":"A2"},{"path1":"B1","path2":"B2"}],
+		"dim3":[{"path1":"X","path2":"Y","path3":"Z"}]
+	}`
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonBlob), &m); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	var out SignalDimensionLists
+	ret := unpacksignalDimensionMap(m, &out)
+	if ret == nil {
+		t.Fatalf("expected non-nil return")
+	}
+	if len(ret.dim2List) != 2 {
+		t.Fatalf("expected 2 dim2 entries; got %d", len(ret.dim2List))
+	}
+	if ret.dim2List[0].Path1 != "A1" || ret.dim2List[0].Path2 != "A2" {
+		t.Errorf("dim2[0] = %+v", ret.dim2List[0])
+	}
+	if ret.dim2List[1].Path1 != "B1" || ret.dim2List[1].Path2 != "B2" {
+		t.Errorf("dim2[1] = %+v", ret.dim2List[1])
+	}
+	if len(ret.dim3List) != 1 {
+		t.Fatalf("expected 1 dim3 entry; got %d", len(ret.dim3List))
+	}
+	if ret.dim3List[0].Path1 != "X" || ret.dim3List[0].Path2 != "Y" || ret.dim3List[0].Path3 != "Z" {
+		t.Errorf("dim3[0] = %+v", ret.dim3List[0])
+	}
+}
+
+func TestUnpacksignalDimensionMap_NilTargetIsSafe(t *testing.T) {
+	if got := unpacksignalDimensionMap(map[string]interface{}{}, nil); got != nil {
+		t.Errorf("expected nil when target is nil; got %v", got)
+	}
+}
+
+func TestUnpacksignalDimensionMap_NonObjectArrayElementIsSkipped(t *testing.T) {
+	// Pre-fix this would have done v.(map[string]interface{}) and panicked.
+	m := map[string]interface{}{
+		"dim2": []interface{}{
+			"not-an-object",
+			map[string]interface{}{"path1": "real1", "path2": "real2"},
+		},
+	}
+	var out SignalDimensionLists
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unpacksignalDimensionMap panicked on string element: %v", r)
+		}
+	}()
+	ret := unpacksignalDimensionMap(m, &out)
+	if ret == nil {
+		t.Fatalf("expected non-nil return")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Bug #11 — getCurveLoggingParams defaults bufSize to 1, not 0
+// --------------------------------------------------------------------------
+
+func TestGetCurveLoggingParams_BadBufSizeDefaultsToOne(t *testing.T) {
+	// Pre-fix: bad bufsize → bufSize=0, which then panics in createRingBuffer.
+	op := `{"maxerr":"0.1","bufsize":"nonsense"}`
+	_, buf := getCurveLoggingParams(op)
+	if buf < 1 {
+		t.Fatalf("expected bufSize >= 1 on parse failure; got %d", buf)
+	}
+}
+
+func TestGetCurveLoggingParams_BadMaxErrDefaultsToZero(t *testing.T) {
+	op := `{"maxerr":"nonsense","bufsize":"5"}`
+	maxErr, buf := getCurveLoggingParams(op)
+	if maxErr != 0.0 {
+		t.Fatalf("expected maxErr=0 on parse failure; got %v", maxErr)
+	}
+	if buf != 5 {
+		t.Fatalf("expected bufSize=5; got %d", buf)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Bug #12 — transformDataPoints handles unparseable base timestamps
+// --------------------------------------------------------------------------
+
+func TestTransformDataPoints_BadBaseTimestampReturnsNil(t *testing.T) {
+	// Build a small ring buffer with a malformed timestamp at the base position
+	// (index = bufSize-1, which is read first as tsBase).
+	rb := createRingBuffer(4)
+	writeRing(&rb, "1.0", "not-a-timestamp")
+	writeRing(&rb, "2.0", "2026-05-16T12:00:01Z")
+	writeRing(&rb, "3.0", "2026-05-16T12:00:02Z")
+
+	clBuf := make([]CLBufElement, 3)
+	got := transformDataPoints(&rb, clBuf, 3)
+	if got != nil {
+		t.Fatalf("expected nil on unparseable base timestamp; got %+v", got)
+	}
+}
+
+func TestTransformDataPoints_NilRingBufferIsSafe(t *testing.T) {
+	clBuf := make([]CLBufElement, 3)
+	if got := transformDataPoints(nil, clBuf, 3); got != nil {
+		t.Errorf("expected nil for nil ring buffer; got %+v", got)
+	}
+}
+
+func TestTransformDataPoints_BadBufSizeReturnsNil(t *testing.T) {
+	rb := createRingBuffer(4)
+	clBuf := make([]CLBufElement, 2)
+	if got := transformDataPoints(&rb, clBuf, 0); got != nil {
+		t.Errorf("expected nil for bufSize=0; got %+v", got)
+	}
+	if got := transformDataPoints(&rb, clBuf, 5); got != nil {
+		t.Errorf("expected nil for bufSize > len(clBuf); got %+v", got)
+	}
+}
+
+func TestTransformDataPoints_UnixMilliFallbackParses(t *testing.T) {
+	// Base timestamp as int milliseconds — UnixMilli fallback should kick in.
+	rb := createRingBuffer(4)
+	writeRing(&rb, "1.0", "1747405200000")
+	writeRing(&rb, "2.0", "1747405201000")
+	writeRing(&rb, "3.0", "1747405202000")
+
+	clBuf := make([]CLBufElement, 3)
+	got := transformDataPoints(&rb, clBuf, 3)
+	if got == nil {
+		t.Fatalf("expected non-nil result with UnixMilli base timestamp")
+	}
+	if got[0].Value != 3.0 || got[1].Value != 2.0 || got[2].Value != 1.0 {
+		t.Errorf("unexpected value order in clBuffer: %+v", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// stringField helper — exercise both branches.
+// --------------------------------------------------------------------------
+
+func TestStringField(t *testing.T) {
+	m := map[string]interface{}{
+		"a": "hello",
+		"b": 42,
+		"c": nil,
+	}
+	if v, ok := stringField(m, "a"); !ok || v != "hello" {
+		t.Errorf("a: got %q,%v; want hello,true", v, ok)
+	}
+	if _, ok := stringField(m, "b"); ok {
+		t.Errorf("b: non-string returned ok=true")
+	}
+	if _, ok := stringField(m, "c"); ok {
+		t.Errorf("c: nil returned ok=true")
+	}
+	if _, ok := stringField(m, "missing"); ok {
+		t.Errorf("missing: returned ok=true")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Ring buffer round-trip — protects against future regressions in
+// createRingBuffer / writeRing / readRing / getNumOfPopulatedRingElements.
+// --------------------------------------------------------------------------
+
+func TestRingBuffer_RoundTrip(t *testing.T) {
+	rb := createRingBuffer(4)
+	writeRing(&rb, "a", "ts-a")
+	writeRing(&rb, "b", "ts-b")
+	writeRing(&rb, "c", "ts-c")
+	if got := getNumOfPopulatedRingElements(&rb); got != 3 {
+		// Tail starts at 0; with 3 writes and head=3, populated count = 3 - 0 = 3.
+		t.Fatalf("populated = %d; want 3", got)
+	}
+	v, ts := readRing(&rb, 0)
+	if v != "c" || ts != "ts-c" {
+		t.Errorf("read 0 = %q,%q; want c,ts-c", v, ts)
+	}
+	v, ts = readRing(&rb, 1)
+	if v != "b" || ts != "ts-b" {
+		t.Errorf("read 1 = %q,%q; want b,ts-b", v, ts)
+	}
+	v, ts = readRing(&rb, 2)
+	if v != "a" || ts != "ts-a" {
+		t.Errorf("read 2 = %q,%q; want a,ts-a", v, ts)
+	}
+}
+
+// --------------------------------------------------------------------------
+// dim1TransformDim* — keep them honest.
+// --------------------------------------------------------------------------
+
+func TestDim1TransformDim2(t *testing.T) {
+	got := dim1TransformDim2(Dim2Elem{Path1: "A", Path2: "B"})
+	if len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Errorf("got %v; want [A B]", got)
+	}
+}
+
+func TestDim1TransformDim3(t *testing.T) {
+	got := dim1TransformDim3(Dim3Elem{Path1: "A", Path2: "B", Path3: "C"})
+	if len(got) != 3 || got[0] != "A" || got[1] != "B" || got[2] != "C" {
+		t.Errorf("got %v; want [A B C]", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// deallocateTriggChannels — frees slots AND decrements session counter
+// --------------------------------------------------------------------------
+
+func TestDeallocateTriggChannels_FreesSlotsAndDecrementsCounter(t *testing.T) {
+	resetClState()
+	// Allocate three trigger channels
+	a := allocateTriggChannelIndex()
+	b := allocateTriggChannelIndex()
+	c := allocateTriggChannelIndex()
+	if a < 0 || b < 0 || c < 0 {
+		t.Fatalf("setup: expected three valid indices; got %d,%d,%d", a, b, c)
+	}
+	// Simulate that the dispatcher incremented the session counter for them.
+	for i := 0; i < 3; i++ {
+		_ = incrementClSessionsIfAvailable()
+	}
+
+	rdl := []TriggRoutingData{
+		{
+			SubscriptionId: "sub-1",
+			TriggRoutingList: []TriggRoutingElem{
+				{Index: a}, {Index: b}, {Index: c},
+			},
+		},
+	}
+	deallocateTriggChannels(0, rdl)
+
+	for _, idx := range []int{a, b, c} {
+		if triggChannelList[idx].Busy {
+			t.Errorf("triggChannelList[%d] still Busy after deallocate", idx)
+		}
+	}
+	if got := getClSessionsCount(); got != 0 {
+		t.Errorf("expected session counter to drop to 0 after deallocate; got %d", got)
+	}
+}
+
+func TestDeallocateTriggChannels_OutOfRangeIndexIsSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("deallocateTriggChannels panicked on out-of-range index: %v", r)
+		}
+	}()
+	deallocateTriggChannels(-1, nil)
+	deallocateTriggChannels(99, []TriggRoutingData{{SubscriptionId: "x"}})
+}
+
+// --------------------------------------------------------------------------
+// transformDataPoint — covers parse fallback and failure paths
+// --------------------------------------------------------------------------
+
+func TestTransformDataPoint_RFC3339Path(t *testing.T) {
+	rb := createRingBuffer(2)
+	writeRing(&rb, "1.5", "2026-05-16T12:00:00Z")
+	got, ok := transformDataPoint(&rb, 0, time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Value != 1.5 {
+		t.Errorf("value=%v; want 1.5", got.Value)
+	}
+	if got.Timestamp != 0 {
+		t.Errorf("ts=%v; want 0", got.Timestamp)
+	}
+}
+
+func TestTransformDataPoint_UnparseableValueFails(t *testing.T) {
+	rb := createRingBuffer(2)
+	writeRing(&rb, "not-a-float", "2026-05-16T12:00:00Z")
+	_, ok := transformDataPoint(&rb, 0, time.Now())
+	if ok {
+		t.Errorf("expected ok=false on unparseable value")
+	}
+}
+
+func TestTransformDataPoint_UnparseableTimestampFails(t *testing.T) {
+	rb := createRingBuffer(2)
+	writeRing(&rb, "1.5", "totally-not-a-time")
+	_, ok := transformDataPoint(&rb, 0, time.Now())
+	if ok {
+		t.Errorf("expected ok=false on unparseable timestamp")
+	}
+}
+
+func TestTransformDataPoint_UnixMilliTimestampFallback(t *testing.T) {
+	rb := createRingBuffer(2)
+	writeRing(&rb, "2.5", "1747405200000") // unix millis
+	got, ok := transformDataPoint(&rb, 0, time.UnixMilli(1747405200000))
+	if !ok {
+		t.Fatalf("expected ok=true on UnixMilli timestamp")
+	}
+	if got.Value != 2.5 {
+		t.Errorf("value=%v; want 2.5", got.Value)
+	}
+	if got.Timestamp != 0 {
+		t.Errorf("ts=%v; want 0 (same as tsBase)", got.Timestamp)
+	}
+}
+
+// --------------------------------------------------------------------------
+// getRingHead / setRingTail — ring-buffer geometry helpers
+// --------------------------------------------------------------------------
+
+func TestGetRingHead_TracksWrites(t *testing.T) {
+	rb := createRingBuffer(4)
+	if got := getRingHead(&rb); got != 0 {
+		t.Errorf("fresh ring head = %d; want 0", got)
+	}
+	writeRing(&rb, "v", "ts")
+	if got := getRingHead(&rb); got != 1 {
+		t.Errorf("ring head after 1 write = %d; want 1", got)
+	}
+}
+
+func TestSetRingTail_ComputesFromHead(t *testing.T) {
+	rb := createRingBuffer(4)
+	for i := 0; i < 3; i++ {
+		writeRing(&rb, "v", "ts")
+	}
+	// Head is at 3, calling setRingTail(2) means tail = 3 - (2+1) = 0
+	setRingTail(&rb, 2)
+	if rb.Tail != 0 {
+		t.Errorf("tail = %d; want 0", rb.Tail)
+	}
+}
+
+func TestRingBufferWrapAround(t *testing.T) {
+	rb := createRingBuffer(3)
+	writeRing(&rb, "a", "ta")
+	writeRing(&rb, "b", "tb")
+	writeRing(&rb, "c", "tc")
+	if rb.Head != 0 {
+		t.Errorf("head should wrap to 0 after filling bufSize=3 elements; got %d", rb.Head)
+	}
+	writeRing(&rb, "d", "td") // overwrites slot 0
+	v, ts := readRing(&rb, 0)
+	if v != "d" || ts != "td" {
+		t.Errorf("after wrap-around overwrite, latest = %q,%q; want d,td", v, ts)
+	}
+}
+
+// --------------------------------------------------------------------------
+// is2dim / is3dim — predicate functions over signal-dimension lists
+// --------------------------------------------------------------------------
+
+func TestIs2dim_MatchesByIndex(t *testing.T) {
+	list := []Dim2Elem{{Path1: "A1", Path2: "A2"}, {Path1: "B1", Path2: "B2"}}
+	if !is2dim("A1", 1, list) {
+		t.Errorf("A1 should match index 1 (Path1)")
+	}
+	if !is2dim("A2", 2, list) {
+		t.Errorf("A2 should match index 2 (Path2)")
+	}
+	if is2dim("A1", 2, list) {
+		t.Errorf("A1 should not match index 2 (Path2)")
+	}
+	if is2dim("nope", 1, list) {
+		t.Errorf("unknown path should not match")
+	}
+	if is2dim("A1", 3, list) {
+		t.Errorf("invalid index should return false")
+	}
+}
+
+func TestIs3dim_MatchesByIndex(t *testing.T) {
+	list := []Dim3Elem{{Path1: "X1", Path2: "X2", Path3: "X3"}}
+	if !is3dim("X1", 1, list) {
+		t.Errorf("X1 should match index 1")
+	}
+	if !is3dim("X2", 2, list) {
+		t.Errorf("X2 should match index 2")
+	}
+	if !is3dim("X3", 3, list) {
+		t.Errorf("X3 should match index 3")
+	}
+	if is3dim("X3", 1, list) {
+		t.Errorf("X3 should not match index 1")
+	}
+	if is3dim("nope", 1, list) {
+		t.Errorf("unknown path should not match")
+	}
+	if is3dim("X1", 99, list) {
+		t.Errorf("invalid index should return false")
+	}
+}
+
+func TestIs2dim_EmptyListReturnsFalse(t *testing.T) {
+	if is2dim("anything", 1, nil) {
+		t.Errorf("empty list should return false")
+	}
+}
+
+func TestIs3dim_EmptyListReturnsFalse(t *testing.T) {
+	if is3dim("anything", 1, nil) {
+		t.Errorf("empty list should return false")
+	}
+}
+
+// --------------------------------------------------------------------------
+// unPackDimSignalsLevel1 — both dim2 and dim3 paths, plus nil-safety
+// --------------------------------------------------------------------------
+
+func TestUnPackDimSignalsLevel1_Dim2Paths(t *testing.T) {
+	out := &SignalDimensionLists{dim2List: make([]Dim2Elem, 1)}
+	signalDimMap := map[string]interface{}{
+		"path1": "alpha",
+		"path2": "beta",
+	}
+	unPackDimSignalsLevel1(0, signalDimMap, "dim2", out)
+	if out.dim2List[0].Path1 != "alpha" || out.dim2List[0].Path2 != "beta" {
+		t.Errorf("dim2 unpack mismatch: %+v", out.dim2List[0])
+	}
+}
+
+func TestUnPackDimSignalsLevel1_Dim3Paths(t *testing.T) {
+	out := &SignalDimensionLists{dim3List: make([]Dim3Elem, 1)}
+	signalDimMap := map[string]interface{}{
+		"path1": "p1",
+		"path2": "p2",
+		"path3": "p3",
+	}
+	unPackDimSignalsLevel1(0, signalDimMap, "dim3", out)
+	if out.dim3List[0].Path1 != "p1" || out.dim3List[0].Path2 != "p2" || out.dim3List[0].Path3 != "p3" {
+		t.Errorf("dim3 unpack mismatch: %+v", out.dim3List[0])
+	}
+}
+
+func TestUnPackDimSignalsLevel1_NilTargetIsSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("nil target panicked: %v", r)
+		}
+	}()
+	unPackDimSignalsLevel1(0, map[string]interface{}{"path1": "x"}, "dim2", nil)
+}
+
+func TestUnPackDimSignalsLevel1_OutOfRangeIndexIsSafe(t *testing.T) {
+	out := &SignalDimensionLists{dim2List: make([]Dim2Elem, 1)}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("out-of-range index panicked: %v", r)
+		}
+	}()
+	unPackDimSignalsLevel1(5, map[string]interface{}{"path1": "x"}, "dim2", out)
+	unPackDimSignalsLevel1(-1, map[string]interface{}{"path1": "x"}, "dim2", out)
+}
+
+func TestUnPackDimSignalsLevel1_NonStringValueIgnored(t *testing.T) {
+	out := &SignalDimensionLists{dim2List: make([]Dim2Elem, 1)}
+	signalDimMap := map[string]interface{}{
+		"path1": 42, // int, not string
+		"path2": "real",
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("non-string value caused panic: %v", r)
+		}
+	}()
+	unPackDimSignalsLevel1(0, signalDimMap, "dim2", out)
+	// path2 should still be set
+	if out.dim2List[0].Path2 != "real" {
+		t.Errorf("path2 should still parse despite path1 being non-string: %+v", out.dim2List[0])
+	}
+}
+
+// --------------------------------------------------------------------------
+// jsonToStructList / readSignalDimensions — file-format helpers
+// --------------------------------------------------------------------------
+
+func TestJsonToStructList_ValidInput(t *testing.T) {
+	in := `{
+		"dim2":[{"path1":"X","path2":"Y"}],
+		"dim3":[{"path1":"A","path2":"B","path3":"C"}]
+	}`
+	got := jsonToStructList(in)
+	if got == nil {
+		t.Fatalf("expected non-nil")
+	}
+	if len(got.dim2List) != 1 || got.dim2List[0].Path1 != "X" || got.dim2List[0].Path2 != "Y" {
+		t.Errorf("dim2 wrong: %+v", got.dim2List)
+	}
+	if len(got.dim3List) != 1 || got.dim3List[0].Path3 != "C" {
+		t.Errorf("dim3 wrong: %+v", got.dim3List)
+	}
+}
+
+func TestJsonToStructList_InvalidJsonReturnsNil(t *testing.T) {
+	if got := jsonToStructList("not-json"); got != nil {
+		t.Errorf("expected nil for invalid JSON; got %+v", got)
+	}
+}
+
+func TestReadSignalDimensions_MissingFileReturnsNil(t *testing.T) {
+	if got := readSignalDimensions("/does/not/exist/signaldimension.json"); got != nil {
+		t.Errorf("expected nil for missing file; got %+v", got)
+	}
+}
+
+func TestReadSignalDimensions_ParsesValidFile(t *testing.T) {
+	dir := t.TempDir()
+	fp := dir + "/sd.json"
+	content := []byte(`{"dim2":[{"path1":"X","path2":"Y"}]}`)
+	if err := os.WriteFile(fp, content, 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	got := readSignalDimensions(fp)
+	if got == nil {
+		t.Fatalf("expected non-nil")
+	}
+	if len(got.dim2List) != 1 || got.dim2List[0].Path1 != "X" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// clReduction1Dim / clReduction2Dim / clReduction3Dim — RDP-style reducers
+// --------------------------------------------------------------------------
+
+func TestClReduction1Dim_PerfectLineKeepsNothing(t *testing.T) {
+	// On a perfectly linear ramp, no point exceeds the error threshold, so
+	// the reducer should return nil (= keep nothing extra beyond endpoints).
+	buf := []CLBufElement{
+		{Value: 0.0, Timestamp: 0.0},
+		{Value: 1.0, Timestamp: 1.0},
+		{Value: 2.0, Timestamp: 2.0},
+		{Value: 3.0, Timestamp: 3.0},
+	}
+	got := clReduction1Dim(buf, 0, 3, 0.0001)
+	if got != nil {
+		t.Errorf("expected nil for perfectly linear data; got %v", got)
+	}
+}
+
+func TestClReduction1Dim_StepFunctionKeepsCorner(t *testing.T) {
+	// A step function should preserve the corner index.
+	buf := []CLBufElement{
+		{Value: 0.0, Timestamp: 0.0},
+		{Value: 0.0, Timestamp: 1.0},
+		{Value: 10.0, Timestamp: 2.0},
+		{Value: 10.0, Timestamp: 3.0},
+	}
+	got := clReduction1Dim(buf, 0, 3, 1.0)
+	if got == nil {
+		t.Fatalf("expected non-nil savedIndex for step function")
+	}
+}
+
+func TestClReduction1Dim_ShortBufferReturnsNil(t *testing.T) {
+	buf := []CLBufElement{
+		{Value: 0.0, Timestamp: 0.0},
+		{Value: 1.0, Timestamp: 1.0},
+	}
+	if got := clReduction1Dim(buf, 0, 1, 0.5); got != nil {
+		t.Errorf("expected nil for lastIndex-firstIndex<=1; got %v", got)
+	}
+}
+
+func TestClReduction2Dim_PerfectLineKeepsNothing(t *testing.T) {
+	buf1 := []CLBufElement{
+		{Value: 0.0, Timestamp: 0.0},
+		{Value: 1.0, Timestamp: 1.0},
+		{Value: 2.0, Timestamp: 2.0},
+	}
+	buf2 := []CLBufElement{
+		{Value: 0.0, Timestamp: 0.0},
+		{Value: 2.0, Timestamp: 1.0},
+		{Value: 4.0, Timestamp: 2.0},
+	}
+	if got := clReduction2Dim(buf1, buf2, 0, 2, 0.0001); got != nil {
+		t.Errorf("expected nil for perfectly linear pair; got %v", got)
+	}
+}
+
+func TestClReduction3Dim_PerfectLineKeepsNothing(t *testing.T) {
+	buf1 := []CLBufElement{
+		{Value: 0.0, Timestamp: 0.0},
+		{Value: 1.0, Timestamp: 1.0},
+		{Value: 2.0, Timestamp: 2.0},
+	}
+	buf2 := []CLBufElement{
+		{Value: 5.0, Timestamp: 0.0},
+		{Value: 6.0, Timestamp: 1.0},
+		{Value: 7.0, Timestamp: 2.0},
+	}
+	buf3 := []CLBufElement{
+		{Value: 10.0, Timestamp: 0.0},
+		{Value: 11.0, Timestamp: 1.0},
+		{Value: 12.0, Timestamp: 2.0},
+	}
+	if got := clReduction3Dim(buf1, buf2, buf3, 0, 2, 0.0001); got != nil {
+		t.Errorf("expected nil for perfectly linear triple; got %v", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// clAnalyze1dim / 2dim / 3dim — wrappers that include nil-buffer fallback
+// --------------------------------------------------------------------------
+
+func TestClAnalyze1dim_NilBufferFromBadTimestampFallsBack(t *testing.T) {
+	// Make a ring buffer whose base timestamp is unparseable so
+	// transformDataPoints returns nil.
+	rb := createRingBuffer(4)
+	writeRing(&rb, "1.0", "not-a-timestamp") // becomes the base on read at index bufSize-1
+	writeRing(&rb, "2.0", "2026-05-16T12:00:01Z")
+	writeRing(&rb, "3.0", "2026-05-16T12:00:02Z")
+
+	dp, lastSel, firstSel := clAnalyze1dim(&rb, 3, 0.1)
+	if dp == "" {
+		t.Errorf("expected fallback dp string; got empty")
+	}
+	if lastSel != 0 || firstSel != 0 {
+		t.Errorf("expected lastSel=firstSel=0 on fallback; got %d,%d", lastSel, firstSel)
+	}
+}
+
+func TestClAnalyze2dim_NilBufferFromBadTimestampFallsBack(t *testing.T) {
+	rb1 := createRingBuffer(4)
+	rb2 := createRingBuffer(4)
+	writeRing(&rb1, "1.0", "bad-ts")
+	writeRing(&rb1, "2.0", "2026-05-16T12:00:01Z")
+	writeRing(&rb2, "10.0", "bad-ts")
+	writeRing(&rb2, "20.0", "2026-05-16T12:00:01Z")
+
+	dp1, dp2, ut := clAnalyze2dim(&rb1, &rb2, 2, 0.1)
+	if dp1 == "" || dp2 == "" {
+		t.Errorf("expected non-empty fallback dps")
+	}
+	if ut != 0 {
+		t.Errorf("expected updatedTail=0 on fallback; got %d", ut)
+	}
+}
+
+func TestClAnalyze3dim_NilBufferFromBadTimestampFallsBack(t *testing.T) {
+	rb1 := createRingBuffer(4)
+	rb2 := createRingBuffer(4)
+	rb3 := createRingBuffer(4)
+	writeRing(&rb1, "1.0", "bad-ts")
+	writeRing(&rb1, "2.0", "2026-05-16T12:00:01Z")
+	writeRing(&rb2, "10.0", "bad-ts")
+	writeRing(&rb2, "20.0", "2026-05-16T12:00:01Z")
+	writeRing(&rb3, "100.0", "bad-ts")
+	writeRing(&rb3, "200.0", "2026-05-16T12:00:01Z")
+
+	dp1, dp2, dp3, ut := clAnalyze3dim(&rb1, &rb2, &rb3, 2, 0.1)
+	if dp1 == "" || dp2 == "" || dp3 == "" {
+		t.Errorf("expected non-empty fallback dps")
+	}
+	if ut != 0 {
+		t.Errorf("expected updatedTail=0 on fallback; got %d", ut)
+	}
+}
+
+func TestClAnalyze1dim_HappyPathWithLinearData(t *testing.T) {
+	rb := createRingBuffer(5)
+	base := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 4; i++ {
+		writeRing(&rb,
+			fmt.Sprintf("%d", i),
+			base.Add(time.Duration(i)*time.Second).Format(time.RFC3339Nano))
+	}
+	dp, _, _ := clAnalyze1dim(&rb, 4, 0.0001) // perfectly linear → savedIndex=nil
+	if dp == "" {
+		t.Errorf("expected a non-empty datapoint string")
+	}
+}
+
+// --------------------------------------------------------------------------
+// returnSingleDp / returnSingleDp2 / returnSingleDp3 — channel publishers
+// --------------------------------------------------------------------------
+
+func TestReturnSingleDp_PublishesToChannel(t *testing.T) {
+	resetClState()
+	// Stub the storage layer enough that getVehicleData returns something.
+	// getVehicleData is implemented in serviceMgr.go; we only need its
+	// fallback (visserr:Data-not-available) for an end-to-end push.
+	ch := make(chan CLPack, 1)
+	go returnSingleDp(ch, 42, "Vehicle.Speed")
+	select {
+	case pack := <-ch:
+		if pack.SubscriptionId != 42 {
+			t.Errorf("subscriptionId = %d; want 42", pack.SubscriptionId)
+		}
+		if pack.DataPack == "" {
+			t.Errorf("DataPack should be non-empty")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("returnSingleDp did not publish in time")
+	}
+}
+
+func TestReturnSingleDp2_PublishesToChannel(t *testing.T) {
+	resetClState()
+	ch := make(chan CLPack, 1)
+	go returnSingleDp2(ch, 7, Dim2Elem{Path1: "Vehicle.A", Path2: "Vehicle.B"})
+	select {
+	case pack := <-ch:
+		if pack.SubscriptionId != 7 {
+			t.Errorf("subscriptionId = %d; want 7", pack.SubscriptionId)
+		}
+		if pack.DataPack == "" || pack.DataPack[0] != '[' {
+			t.Errorf("expected JSON array DataPack; got %q", pack.DataPack)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("returnSingleDp2 did not publish in time")
+	}
+}
+
+func TestReturnSingleDp3_PublishesToChannel(t *testing.T) {
+	resetClState()
+	ch := make(chan CLPack, 1)
+	go returnSingleDp3(ch, 9, Dim3Elem{Path1: "P1", Path2: "P2", Path3: "P3"})
+	select {
+	case pack := <-ch:
+		if pack.SubscriptionId != 9 {
+			t.Errorf("subscriptionId = %d; want 9", pack.SubscriptionId)
+		}
+		if pack.DataPack == "" || pack.DataPack[0] != '[' {
+			t.Errorf("expected JSON array DataPack; got %q", pack.DataPack)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("returnSingleDp3 did not publish in time")
+	}
+}
+
+// --------------------------------------------------------------------------
+// postProcess1dim / writePostProcElement1dim / movePostProcElement1dim /
+// saveNonPdrDp — the curve-logging post-processing state machine
+// --------------------------------------------------------------------------
+
+func makePostProcRing(t *testing.T) *RingBuffer {
+	t.Helper()
+	rb := createRingBuffer(5)
+	base := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 4; i++ {
+		writeRing(&rb,
+			fmt.Sprintf("%d", i),
+			base.Add(time.Duration(i)*time.Second).Format(time.RFC3339Nano))
+	}
+	return &rb
+}
+
+func TestWritePostProcElement1dim_PopulatesSlot(t *testing.T) {
+	rb := makePostProcRing(t)
+	pp := make([]PostProcessBufElement1dim, 3)
+	pp = writePostProcElement1dim(rb, 0, pp, 0)
+	if pp[0].Dp == "" {
+		t.Errorf("expected non-empty Dp string")
+	}
+	if pp[0].Type != 0 {
+		t.Errorf("expected Type=firstSelected=0; got %d", pp[0].Type)
+	}
+}
+
+func TestMovePostProcElement1dim_CopiesFields(t *testing.T) {
+	pp := make([]PostProcessBufElement1dim, 3)
+	pp[1].Dp = "src-dp"
+	pp[1].Type = 7
+	pp[1].Data = CLBufElement{Value: 1.5, Timestamp: 2.5}
+	pp = movePostProcElement1dim(pp, 1, 0)
+	if pp[0].Dp != "src-dp" || pp[0].Type != 7 {
+		t.Errorf("move did not copy: %+v", pp[0])
+	}
+	if pp[0].Data.Value != 1.5 || pp[0].Data.Timestamp != 2.5 {
+		t.Errorf("move did not copy Data: %+v", pp[0].Data)
+	}
+}
+
+func TestSaveNonPdrDp_DetectsNonLinearMiddle(t *testing.T) {
+	pp := []PostProcessBufElement1dim{
+		{Data: CLBufElement{Value: 0.0, Timestamp: 0.0}},
+		{Data: CLBufElement{Value: 5.0, Timestamp: 1.0}}, // way above the line 0..2
+		{Data: CLBufElement{Value: 2.0, Timestamp: 2.0}},
+	}
+	if !saveNonPdrDp(pp, 1.0) {
+		t.Errorf("expected save=true when interpolation error exceeds maxError")
+	}
+}
+
+func TestSaveNonPdrDp_KeepsLinearMiddle(t *testing.T) {
+	pp := []PostProcessBufElement1dim{
+		{Data: CLBufElement{Value: 0.0, Timestamp: 0.0}},
+		{Data: CLBufElement{Value: 1.0, Timestamp: 1.0}}, // exactly on line
+		{Data: CLBufElement{Value: 2.0, Timestamp: 2.0}},
+	}
+	if saveNonPdrDp(pp, 0.5) {
+		t.Errorf("expected save=false when point sits on interpolation line")
+	}
+}
+
+func TestPostProcess1dim_InitialStateFillsSlotZero(t *testing.T) {
+	rb := makePostProcRing(t)
+	pp := make([]PostProcessBufElement1dim, 3)
+	pp[0].Type = -1 // init state
+	pp[1].Type = -1
+	pp[2].Type = -1
+	extra, out := postProcess1dim(rb, 0, 0, pp, 0.1)
+	if extra != "" {
+		t.Errorf("init step should return empty extra; got %q", extra)
+	}
+	if out[0].Type == -1 {
+		t.Errorf("slot 0 should be populated after init step")
+	}
+}
+
+// --------------------------------------------------------------------------
+// initClResources — sanity-check the package-level initializer
+// --------------------------------------------------------------------------
+
+func TestInitClResources_AllocatesChannelsAndList(t *testing.T) {
+	initClResources()
+	if CLChannel == nil || cap(CLChannel) == 0 {
+		t.Errorf("CLChannel should be allocated and buffered")
+	}
+	if len(triggChannelList) != MAXCLSESSIONS {
+		t.Errorf("triggChannelList should have %d entries; got %d", MAXCLSESSIONS, len(triggChannelList))
+	}
+	for i := range clServerChan {
+		if clServerChan[i] == nil {
+			t.Errorf("clServerChan[%d] not initialized", i)
+		}
+		if cap(clServerChan[i]) == 0 {
+			t.Errorf("clServerChan[%d] should be buffered (bug-6 regression check)", i)
+		}
+	}
+	if clRouterChan == nil {
+		t.Errorf("clRouterChan should be allocated")
+	}
+}
+
+// --------------------------------------------------------------------------
+// curveLoggingDispatcher — happy path with default (no signal-dimension)
+// --------------------------------------------------------------------------
+
+func TestCurveLoggingDispatcher_BadOpValueDoesNotPanic(t *testing.T) {
+	resetClState()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("curveLoggingDispatcher panicked on bad opValue: %v", r)
+		}
+	}()
+	ch := make(chan CLPack, 10)
+	_, _ = curveLoggingDispatcher(ch, 1, "not-valid-json", []string{})
+}
+
+func TestCurveLoggingDispatcher_RespectsMaxBufSize(t *testing.T) {
+	resetClState()
+	op := fmt.Sprintf(`{"maxerr":"0.1","bufsize":"%d"}`, MAXCLBUFSIZE*2)
+	ch := make(chan CLPack, 100)
+	// No paths means no goroutines started, just exercise the cap path.
+	_, threads := curveLoggingDispatcher(ch, 1, op, []string{})
+	if threads.SubscriptionId != 1 {
+		t.Errorf("subThreads.SubscriptionId = %d; want 1", threads.SubscriptionId)
+	}
+	if threads.NumofThreads != 0 {
+		t.Errorf("with no paths, expected 0 threads; got %d", threads.NumofThreads)
+	}
+}
+
+// --------------------------------------------------------------------------
+// handleCurveLogServerMessage — happy paths for subscribe / subscription
+// --------------------------------------------------------------------------
+
+func TestHandleCurveLogServerMessage_SubscribeNotifiesAllChannels(t *testing.T) {
+	resetClState()
+	// Pre-populate routing data pointing at index 0 and 1
+	rdl := []TriggRoutingData{
+		{
+			SubscriptionId: "sub-1",
+			TriggRoutingList: []TriggRoutingElem{
+				{Index: 0, Path: []string{"A"}},
+				{Index: 1, Path: []string{"B"}},
+			},
+		},
+	}
+	msg := `{"action":"subscribe","status":"ok"}`
+	got := handleCurveLogServerMessage(msg, rdl)
+	if len(got) != 1 {
+		t.Errorf("subscribe should not mutate routing list; got %d entries", len(got))
+	}
+	// Both channels should have received the message
+	for _, idx := range []int{0, 1} {
+		select {
+		case got := <-clServerChan[idx]:
+			if got != msg {
+				t.Errorf("clServerChan[%d] got %q; want %q", idx, got, msg)
+			}
+		case <-time.After(200 * time.Millisecond):
+			t.Errorf("clServerChan[%d] did not receive subscribe notification", idx)
+		}
+	}
+}
+
+func TestHandleCurveLogServerMessage_SubscriptionRoutesByPath(t *testing.T) {
+	resetClState()
+	rdl := []TriggRoutingData{
+		{
+			SubscriptionId: "sub-1",
+			TriggRoutingList: []TriggRoutingElem{
+				{Index: 5, Path: []string{"Vehicle.Match"}},
+				{Index: 6, Path: []string{"Vehicle.Other"}},
+			},
+		},
+	}
+	msg := `{"action":"subscription","path":"Vehicle.Match"}`
+	_ = handleCurveLogServerMessage(msg, rdl)
+	select {
+	case got := <-clServerChan[5]:
+		if got != msg {
+			t.Errorf("matching channel got %q", got)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Errorf("matching channel did not receive notification")
+	}
+	// Non-matching channel should NOT receive anything
+	select {
+	case got := <-clServerChan[6]:
+		t.Errorf("non-matching channel received %q; should be silent", got)
+	case <-time.After(50 * time.Millisecond):
+		// good
+	}
+}
+
+func TestHandleCurveLogServerMessage_SubscribeWithBadStatusIsNoop(t *testing.T) {
+	resetClState()
+	rdl := []TriggRoutingData{
+		{
+			SubscriptionId: "sub-1",
+			TriggRoutingList: []TriggRoutingElem{{Index: 0, Path: []string{"x"}}},
+		},
+	}
+	msg := `{"action":"subscribe","status":"failed"}`
+	_ = handleCurveLogServerMessage(msg, rdl)
+	select {
+	case got := <-clServerChan[0]:
+		t.Errorf("subscribe with status!=ok should not notify; got %q", got)
+	case <-time.After(50 * time.Millisecond):
+		// good
+	}
+}
+
+// --------------------------------------------------------------------------
+// allocateTriggChannelIndex — exhaustion + reuse-after-release
+// --------------------------------------------------------------------------
+
+func TestAllocateTriggChannelIndex_ReusableAfterRelease(t *testing.T) {
+	resetClState()
+	idx := allocateTriggChannelIndex()
+	if idx < 0 {
+		t.Fatalf("first allocation failed")
+	}
+	triggChannelMu.Lock()
+	triggChannelList[idx].Busy = false
+	triggChannelMu.Unlock()
+	// Should be reusable
+	again := allocateTriggChannelIndex()
+	if again != idx {
+		t.Errorf("expected released slot %d to be reused; got %d", idx, again)
+	}
+}

--- a/server/vissv2server/serviceMgr/redisVinFeeder/vin_feeder.go
+++ b/server/vissv2server/serviceMgr/redisVinFeeder/vin_feeder.go
@@ -25,7 +25,7 @@ func redisSet(client *redis.Client, path string, val string, ts string) int {
 		fmt.Printf("Job failed. Err=%s\n", err)
 		return -1
 	} else {
-		fmt.Println("Datapoint=%s\n", dp)
+		fmt.Printf("Datapoint=%s\n", dp)
 		return 0
 	}
 }

--- a/server/vissv2server/serviceMgr/serviceMgr.go
+++ b/server/vissv2server/serviceMgr/serviceMgr.go
@@ -480,13 +480,19 @@ func getCurveLoggingParams(opValue string) (float64, int) { // {"maxerr": "X", "
 	}
 	maxErr, err := strconv.ParseFloat(cLData.MaxErr, 64)
 	if err != nil {
-		utils.Error.Printf("getIntervalPeriod: MaxErr invalid integer, maxErr=%s", cLData.MaxErr)
+		utils.Error.Printf("getCurveLoggingParams: MaxErr invalid, maxErr=%s err=%v", cLData.MaxErr, err)
 		maxErr = 0.0
 	}
 	bufSize, err := strconv.Atoi(cLData.BufSize)
 	if err != nil {
-		utils.Error.Printf("getIntervalPeriod: BufSize invalid integer, BufSize=%s", cLData.BufSize)
-		maxErr = 0.0
+		// Bug-11 fix: the previous line read `maxErr = 0.0` —
+		// likely a copy-paste leaving bufSize at the strconv.Atoi
+		// zero-result. bufSize == 0 then propagated into
+		// createRingBuffer(0+1) and a make([]CLBufElement, 0) that
+		// panicked further down. Reset bufSize to a safe minimum
+		// (1) and log loudly so the operator notices.
+		utils.Error.Printf("getCurveLoggingParams: BufSize invalid, BufSize=%s err=%v; defaulting to 1", cLData.BufSize, err)
+		bufSize = 1
 	}
 	return maxErr, bufSize
 }
@@ -1906,7 +1912,7 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 			handleFeederRegistration(feederReq, feederRegChan)
 		} // select
 	} // for
-utils.Info.Printf("Service manager exit")
+	// Unreachable - infinite for/select loop above never exits.
 }
 
 func checkRCFilterAndIssueMessages(triggeredPath string, subscriptionList []SubscriptionState, backendChan chan map[string]interface{}) []SubscriptionState {

--- a/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
+++ b/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
@@ -56,12 +56,9 @@
 package serviceMgr
 
 import (
-	"os"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/covesa/vissr/utils"
 )
 
 // TestMain initialises utils.Info / utils.Error so the helpers can
@@ -71,11 +68,6 @@ import (
 // touching the live storage backends. That keeps these tests
 // self-contained and exercises the service_unavailable / empty-data
 // paths.
-func TestMain(m *testing.M) {
-	utils.InitLog("serviceMgr-dispatch-test.log", os.TempDir(), false, "error")
-	os.Exit(m.Run())
-}
-
 // resetErrorResponseMap clears the shared package-level
 // errorResponseMap between tests. The production code mutates it in
 // place on the assumption that one request is being processed at a


### PR DESCRIPTION
## Summary

Audit + fix + tests for `server/vissv2server/serviceMgr/curvelog.go`.

73 new unit tests in `curvelog_test.go` — race-mode clean, covering every public and unexported function in the file. Each numbered bug has at least one regression test pinned to it.

## Bugs fixed in `curvelog.go`

| # | Function | Bug |
|---|---|---|
| 1 | `getSleepDuration` | Returned `1` (= 1 nanosecond) as the floor — busy-loops the capture ticker. Now returns `time.Millisecond`. |
| 2 | `numOfClSessions` | Concurrent reads/writes without a mutex, and the counter was never decremented on unsubscribe so it leaked until process restart. Added `numOfClSessionsMu` + `decrementClSessions` on unsubscribe. |
| 3 | `triggChannelList` / `allocateTriggChannelIndex` | Concurrent access without a mutex; callers ignored the `-1` return and fed it directly into `clServerChan[-1]`. Added `triggChannelMu` and `-1` checks at all three call sites. |
| 4 | `curveLogServer` unsubscribe | `slices.Delete(routingDataList, i, i+1)` return value discarded — the entry was never actually removed. Now `routingDataList = slices.Delete(...)`. |
| 5 | `curveLogServer` unsubscribe loop | After deletion the loop incremented `i` past the shifted-in element, so a second match with the same `subscriptionId` survived. Loop now holds `i` after deletion. |
| 6 | `clServerChan` | Unbuffered — a slow capture goroutine wedged the entire dispatcher. Now buffered (10) and the dispatcher uses a non-blocking send that drops on overflow. |
| 7 | `curveLogServer` / `decodeFeederMessageCl` | `messageMap["action"].(string)` and friends panic on malformed messages from the feeder side. Every assertion now uses the comma-ok form with a defensive early return. |
| 8 | `populateDimLists` | Returned `nil` for `dim3List` unconditionally — 3-dim subscriptions silently dropped. Now returns the real slice. |
| 9 | `populateDimLists` | Self-compare typo `pathDimList[j].Id == pathDimList[j].Id` (always true) could pair members of different dim3 groups. Now `pathDimList[j].Id == pathDimList[i].Id`. |
| 10 | `unpacksignalDimensionMap` / `unPackDimSignalsLevel1` | Took the target by value, plus an unchecked `v.(map[string]interface{})` could panic. Now takes a pointer, with bounds- and nil-checks on every index/target. |
| 11 | `getCurveLoggingParams` (in `serviceMgr.go`) | On bad `bufsize`, set `maxErr = 0.0` (the wrong variable) and left `bufSize = 0`, which then panicked further down in `createRingBuffer`. Now defaults `bufSize` to `1`. |
| 12 | `transformDataPoints` | Ignored `time.Parse` error, carrying a zero-value `tsBase` into the whole buffer. Now falls back to `UnixMilli` and fails safely if neither parse succeeds. |

**Bonus**: `clCapture2dim` and `clCapture3dim` did `data1, data2, updatedTail := clAnalyze2dim(...)` inside the inner `if`, which shadowed the outer `updatedTail`. The final `if updatedTail > 0 { returnSingleDp2(...) }` check then never fired. Dropped the `:=` so the outer variable is updated.

## Refactors that go with the tests

- `populateDimListsFromSignals` — testable form of `populateDimLists` (takes the signal-dimension list as an argument instead of reading it from disk).
- `handleCurveLogServerMessage` — testable form of the `curveLogServer` select-arm body.
- `sendToClServerChan` — shared non-blocking send helper.
- `stringField` — shared defensive `map[string]interface{}` string getter.
- `allocateTriggChannelIndex` / `deallocateTriggChannels` — mutex-safe and bounds-checked; `deallocate` now also drops the session counter.

## Drive-by vet cleanups

These were all pre-existing failures blocking `go test ./...` on a clean master checkout:

- `utils/managerhandlers.go:334` — Printf shape error (`"...", caCertFile, ", error ", err` → `"...%s, error %v", caCertFile, err`)
- `utils/pbutils.go:32` — Printf shape error (`"Marshaling error: ", err` → `"Marshaling error: %v", err`)
- `serviceMgr.go:461` — `Printf %s` for int `period`
- `serviceMgr.go:1760` — unreachable `utils.Info.Printf` after an infinite `for{}` loop
- `redisVinFeeder/vin_feeder.go:28` — `fmt.Println` called with `%s` directive
- `atServer/access_control_test.go:125` — corrupted lines (stray backslashes and random characters from a prior bad paste)

## Test results
$ go vet ./server/vissv2server/serviceMgr/
(clean)
$ go test -race ./server/vissv2server/serviceMgr/ -count=1
ok  github.com/covesa/vissr/server/vissv2server/serviceMgr 1.499s

73 tests pass, race detector clean.