### PR TITLE
fix(feeder-evic): patch all panics + add complete unit tests

### DIFF
--- a/feeder/feeder-evic/evicFeeder.go
+++ b/feeder/feeder-evic/evicFeeder.go
@@ -11,17 +11,18 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"github.com/akamensky/argparse"
 	"github.com/covesa/vissr/utils"
 	"github.com/go-redis/redis"
 	_ "github.com/mattn/go-sqlite3"
+	"io"
 	"net"
 	"os"
 	"sort"
 	"strconv"
 	"time"
 
-	"flag"
 	"github.com/gorilla/websocket"
 	"net/http"
 	"net/url"
@@ -57,7 +58,7 @@ var scalingDataList []string
 var canDriverUrl string
 
 func initVSSInterfaceMgr(inputChan chan DomainData, outputChan chan DomainData) {
-	udsChan := make(chan DomainData, 1)
+	udsChan := make(chan DomainData, 32)
 	go initUdsEndpoint(udsChan)
 	for {
 		select {
@@ -68,7 +69,7 @@ func initVSSInterfaceMgr(inputChan chan DomainData, outputChan chan DomainData) 
 				utils.Error.Printf("initVSSInterfaceMgr():Redis write failed")
 			}
 		case actuatorData := <-udsChan:
-			inputChan <- actuatorData
+			pipelineSend(inputChan, actuatorData, "vssInputChan")
 		}
 	}
 }
@@ -90,8 +91,12 @@ func statestorageSet(path string, val string, ts string) int {
 		}
 		return 0
 	case "redis":
-		dp := `{"val":"` + val + `", "ts":"` + ts + `"}`
-		err := redisClient.Set(path, dp, time.Duration(0)).Err()
+		dpBytes, err := json.Marshal(map[string]string{"val": val, "ts": ts})
+		if err != nil {
+			utils.Error.Printf("statestorageSet:Marshal error=%s", err)
+			return -1
+		}
+		err = redisClient.Set(path, string(dpBytes), time.Duration(0)).Err()
 		if err != nil {
 			utils.Error.Printf("Job failed. Err=%s", err)
 			return -1
@@ -101,6 +106,11 @@ func statestorageSet(path string, val string, ts string) int {
 	return -1
 }
 
+// UdsBufSize is the per-read buffer for the server→feeder UDS channel.
+// Sized for a typical JSON datapoint with margin; messages larger than this
+// are dropped with a clear error rather than truncated silently.
+const UdsBufSize = 64 * 1024
+
 func initUdsEndpoint(udsChan chan DomainData) {
 	os.Remove("/var/tmp/vissv2/server-feeder-channel.sock")
 	listener, err := net.Listen("unix", "/var/tmp/vissv2/server-feeder-channel.sock") //the file must be the same as declared in the feeder-registration.json that the service mgr reads
@@ -108,42 +118,110 @@ func initUdsEndpoint(udsChan chan DomainData) {
 		utils.Error.Printf("initUdsEndpoint:UDS listen failed, err = %s", err)
 		os.Exit(-1)
 	}
-	conn, err := listener.Accept()
-	if err != nil {
-		utils.Error.Printf("initUdsEndpoint:UDS accept failed, err = %s", err)
-		os.Exit(-1)
-	}
-	defer conn.Close()
-	buf := make([]byte, 512)
 	for {
-		n, err := conn.Read(buf)
+		conn, err := listener.Accept()
 		if err != nil {
-			utils.Error.Printf("initUdsEndpoint:Read failed, err = %s", err)
+			utils.Error.Printf("initUdsEndpoint:UDS accept failed, err = %s", err)
+			// transient accept errors should not crash the feeder
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
-		utils.Info.Printf("Feeder:Server message: %s", string(buf[:n]))
-		domainData, _ := splitToDomainDataAndTs(string(buf[:n]))
-		udsChan <- domainData
+		handleUdsConn(conn, udsChan)
 	}
 }
 
-func splitToDomainDataAndTs(serverMessage string) (DomainData, string) { // server={"dp": {"ts": "Z","value": "Y"},"path": "X"}, redis={"value":"xxx", "ts":"zzz"}
+// handleUdsConn reads framed datapoints from a single accepted UDS connection
+// and forwards each parsed DomainData to udsChan. Returns when the connection
+// closes; the caller should accept again.
+func handleUdsConn(conn net.Conn, udsChan chan DomainData) {
+	defer conn.Close()
+	buf := make([]byte, UdsBufSize)
+	for {
+		n, err := conn.Read(buf)
+		if err != nil {
+			if err != io.EOF {
+				utils.Error.Printf("initUdsEndpoint:Read failed, err = %s", err)
+			}
+			return
+		}
+		if n == len(buf) {
+			utils.Error.Printf("initUdsEndpoint: message at UDS buffer size (%d bytes); may be truncated, dropping", n)
+			continue
+		}
+		utils.Info.Printf("Feeder:Server message: %s", string(buf[:n]))
+		domainData, _, ok := splitToDomainDataAndTs(string(buf[:n]))
+		if !ok {
+			continue
+		}
+		// non-blocking send: a wedged downstream must not back-pressure the reader
+		select {
+		case udsChan <- domainData:
+		default:
+			utils.Error.Printf("initUdsEndpoint: udsChan full, dropping datapoint for %q", domainData.Name)
+		}
+	}
+}
+
+// splitToDomainDataAndTs parses a server datapoint of the shape
+//   {"dp": {"ts": "Z","value": "Y"},"path": "X"}
+// and returns the extracted DomainData, the timestamp string, and ok=true.
+// On any parse / shape error, returns zero values and ok=false (without
+// panicking) so callers can keep processing further datapoints.
+func splitToDomainDataAndTs(serverMessage string) (DomainData, string, bool) {
 	var domainData DomainData
 	var serverMessageMap map[string]interface{}
 	err := json.Unmarshal([]byte(serverMessage), &serverMessageMap)
 	if err != nil {
 		utils.Error.Printf("splitToDomainDataAndTs:Unmarshal error=%s", err)
-		return domainData, ""
+		return domainData, "", false
 	}
-	domainData.Name = serverMessageMap["path"].(string)
-	dpMap := serverMessageMap["dp"].(map[string]interface{})
-	domainData.Value = dpMap["value"].(string)
-	return domainData, dpMap["ts"].(string)
+	name, ok := mapString(serverMessageMap, "path")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid 'path' in %q", serverMessage)
+		return domainData, "", false
+	}
+	dpRaw, present := serverMessageMap["dp"]
+	if !present || dpRaw == nil {
+		utils.Error.Printf("splitToDomainDataAndTs: missing 'dp' in %q", serverMessage)
+		return domainData, "", false
+	}
+	dpMap, ok := dpRaw.(map[string]interface{})
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: 'dp' not an object in %q", serverMessage)
+		return domainData, "", false
+	}
+	value, ok := mapString(dpMap, "value")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid 'value' in %q", serverMessage)
+		return domainData, "", false
+	}
+	ts, ok := mapString(dpMap, "ts")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid 'ts' in %q", serverMessage)
+		return domainData, "", false
+	}
+	domainData.Name = name
+	domainData.Value = value
+	return domainData, ts, true
+}
+
+// mapString fetches m[key] as a string. Returns "", false if absent, nil,
+// or the wrong type.
+func mapString(m map[string]interface{}, key string) (string, bool) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
 }
 
 func initVehicleInterfaceMgr(fMap []FeederMap, inputChan chan DomainData, outputChan chan DomainData) {
-	CanDriverOutputChan := make(chan DomainData, 1)
-	CanDriverInputChan := make(chan DomainData, 1)
+	CanDriverOutputChan := make(chan DomainData, 32)
+	CanDriverInputChan := make(chan DomainData, 32)
 	go initCanDriverOutput(CanDriverOutputChan)
 	go initCanDriverInput(CanDriverInputChan)
 
@@ -151,10 +229,10 @@ func initVehicleInterfaceMgr(fMap []FeederMap, inputChan chan DomainData, output
 		select {
 		case outData := <-outputChan:
 			utils.Info.Printf("Data to the vehicle interface: Name=%s, Value=%s", outData.Name, outData.Value)
-			CanDriverOutputChan <- outData
+			pipelineSend(CanDriverOutputChan, outData, "CanDriverOutputChan")
 		case inData := <-CanDriverInputChan:
 			utils.Info.Printf("Data from the vehicle interface: Name=%s, Value=%s", inData.Name, inData.Value)
-			inputChan <- inData
+			pipelineSend(inputChan, inData, "vehicleInputChan")
 		}
 	}
 }
@@ -162,30 +240,68 @@ func initVehicleInterfaceMgr(fMap []FeederMap, inputChan chan DomainData, output
 func initCanDriverOutput(outputChan chan DomainData) { // WS client
 	scheme := "ws"
 	portNum := "8002"
-	var addr = flag.String("addr", canDriverUrl+":"+portNum, "http service address")
-	dataSessionUrl := url.URL{Scheme: scheme, Host: *addr, Path: ""}
+	addr := canDriverUrl + ":" + portNum
+	dataSessionUrl := url.URL{Scheme: scheme, Host: addr, Path: ""}
 	dialer := websocket.Dialer{
 		HandshakeTimeout: time.Second,
 		ReadBufferSize:   1024,
 		WriteBufferSize:  1024,
 	}
-	conn := reDialer(dialer, dataSessionUrl)
-	go canDriverClient(conn, outputChan)
+	go canDriverClient(dialer, dataSessionUrl, outputChan)
 }
 
-func canDriverClient(conn *websocket.Conn, clientChan chan DomainData) {
-	defer conn.Close()
+// canDriverClient owns the lifetime of a single CAN-driver WebSocket
+// connection: it dials with retry, writes each DomainData from clientChan,
+// and on any write error it closes the conn and re-dials. This avoids the
+// previous bug where the goroutine exited on first error and clientChan
+// then filled and back-pressured the whole pipeline.
+func canDriverClient(dialer websocket.Dialer, sessionUrl url.URL, clientChan chan DomainData) {
 	for {
-		domainData := <-clientChan
+		conn := reDialer(dialer, sessionUrl)
+		if conn == nil {
+			utils.Error.Printf("canDriverClient: failed to dial %s after retries; drop-and-retry mode", sessionUrl.String())
+			// drain a few messages so back-pressure doesn't wedge the pipeline
+			drainStart := time.Now()
+			for time.Since(drainStart) < 5*time.Second {
+				select {
+				case dropped := <-clientChan:
+					utils.Error.Printf("canDriverClient: dropping %q while disconnected", dropped.Name)
+				case <-time.After(time.Second):
+				}
+			}
+			continue
+		}
+		writeLoopErr := writeCanDriverLoop(conn, clientChan)
+		conn.Close()
+		if writeLoopErr == errClientChanClosed {
+			return
+		}
+	}
+}
+
+var errClientChanClosed = errors.New("clientChan closed")
+
+func writeCanDriverLoop(conn *websocket.Conn, clientChan chan DomainData) error {
+	for {
+		domainData, ok := <-clientChan
+		if !ok {
+			return errClientChanClosed
+		}
 		if domainData.Name == "" || domainData.Value == "" {
 			utils.Error.Printf("canDriverClient:Invalid domain data - Name=%s, Value=%s", domainData.Name, domainData.Value)
 			continue
 		}
-		request := `{"path":"` + domainData.Name + `", "value":"` + domainData.Value + `"}`
-		err := conn.WriteMessage(websocket.TextMessage, []byte(request))
+		reqBytes, err := json.Marshal(map[string]string{
+			"path":  domainData.Name,
+			"value": domainData.Value,
+		})
 		if err != nil {
-			utils.Error.Printf("canDriverClient:Request write error:%s\n", err)
-			return
+			utils.Error.Printf("canDriverClient:Marshal error: %s", err)
+			continue
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, reqBytes); err != nil {
+			utils.Error.Printf("canDriverClient:Request write error:%s; reconnecting", err)
+			return err
 		}
 	}
 }
@@ -238,8 +354,15 @@ func serverSession(conn *websocket.Conn, serverChannel chan DomainData) {
 		payload := string(msg)
 		utils.Info.Printf("%s request: %s, len=%d", conn.RemoteAddr(), payload, len(payload))
 		domainData := convertToDomainData(payload)
-
-		serverChannel <- domainData
+		if domainData.Name == "" {
+			continue // parse failed; already logged
+		}
+		// non-blocking: a wedged downstream cannot back-pressure the WS reader
+		select {
+		case serverChannel <- domainData:
+		default:
+			utils.Error.Printf("serverSession: serverChannel full, dropping datapoint for %q", domainData.Name)
+		}
 	}
 }
 
@@ -249,57 +372,94 @@ func convertToDomainData(message string) DomainData { // {"path":"x.y.z", "value
 	err := json.Unmarshal([]byte(message), &messageMap)
 	if err != nil {
 		utils.Error.Printf("convertToDomainData:Unmarshal error=%s", err)
-		domainData.Name = ""
 		return domainData
 	}
-	domainData.Name = messageMap["path"].(string)
-	domainData.Value = messageMap["value"].(string)
+	name, ok := mapString(messageMap, "path")
+	if !ok {
+		utils.Error.Printf("convertToDomainData: missing/invalid 'path' in %q", message)
+		return domainData
+	}
+	value, ok := mapString(messageMap, "value")
+	if !ok {
+		utils.Error.Printf("convertToDomainData: missing/invalid 'value' in %q", message)
+		return domainData
+	}
+	domainData.Name = name
+	domainData.Value = value
 	return domainData
 }
 
 func convertDomainData(north2SouthConv bool, inData DomainData, feederMap []FeederMap) DomainData {
 	var outData DomainData
-	matchIndex := sort.Search(len(feederMap), func(i int) bool { return feederMap[i].Name >= inData.Name })
-	if matchIndex == len(feederMap) || feederMap[matchIndex].Name != inData.Name {
-		matchIndex = -1
+	matchIndex, ok := lookupFeederMap(inData.Name, feederMap)
+	if !ok {
+		utils.Error.Printf("convertDomainData: name %q not in feeder map", inData.Name)
+		return outData
 	}
-	outData.Name = feederMap[feederMap[matchIndex].MapIndex].Name
+	mapIdx := int(feederMap[matchIndex].MapIndex)
+	if mapIdx < 0 || mapIdx >= len(feederMap) {
+		utils.Error.Printf("convertDomainData: MapIndex %d for %q out of range [0,%d)", mapIdx, inData.Name, len(feederMap))
+		return outData
+	}
+	outData.Name = feederMap[mapIdx].Name
 	outData.Value = convertValue(inData.Value, feederMap[matchIndex].ConvertIndex,
-		feederMap[matchIndex].Datatype, feederMap[feederMap[matchIndex].MapIndex].Datatype, north2SouthConv)
+		feederMap[matchIndex].Datatype, feederMap[mapIdx].Datatype, north2SouthConv)
 	return outData
 }
 
-func convertValue(value string, convertIndex uint16, inDatatype int8, outDatatype int8, north2SouthConv bool) string {
-	switch convertIndex {
-	case 0: // no conversion
-		return value
-	default: // call to conversion method
-		var convertDataMap interface{}
-		err := json.Unmarshal([]byte(scalingDataList[convertIndex-1]), &convertDataMap)
-		if err != nil {
-			utils.Error.Printf("convertValue:Error unmarshal scalingDataList item=%s", scalingDataList[convertIndex-1])
-			return ""
-		}
-		switch vv := convertDataMap.(type) {
-		case map[string]interface{}:
-			return enumConversion(vv, north2SouthConv, value)
-		case interface{}:
-			return linearConversion(vv.([]interface{}), north2SouthConv, value)
-		default:
-			utils.Error.Printf("convertValue: convert data=%s has unknown format.", scalingDataList[convertIndex-1])
-		}
+// lookupFeederMap returns the index of the entry whose Name matches `name`.
+// The feeder map is required to be sorted by Name (see readFeederMap).
+// Returns (-1, false) when no entry matches.
+func lookupFeederMap(name string, feederMap []FeederMap) (int, bool) {
+	if len(feederMap) == 0 {
+		return -1, false
 	}
-	return ""
+	matchIndex := sort.Search(len(feederMap), func(i int) bool { return feederMap[i].Name >= name })
+	if matchIndex == len(feederMap) || feederMap[matchIndex].Name != name {
+		return -1, false
+	}
+	return matchIndex, true
+}
+
+func convertValue(value string, convertIndex uint16, inDatatype int8, outDatatype int8, north2SouthConv bool) string {
+	if convertIndex == 0 { // no conversion
+		return value
+	}
+	idx := int(convertIndex) - 1
+	if idx < 0 || idx >= len(scalingDataList) {
+		utils.Error.Printf("convertValue: convertIndex %d out of range for scalingDataList(len=%d)", convertIndex, len(scalingDataList))
+		return ""
+	}
+	var convertDataMap interface{}
+	err := json.Unmarshal([]byte(scalingDataList[idx]), &convertDataMap)
+	if err != nil {
+		utils.Error.Printf("convertValue:Error unmarshal scalingDataList item=%s", scalingDataList[idx])
+		return ""
+	}
+	switch vv := convertDataMap.(type) {
+	case map[string]interface{}:
+		return enumConversion(vv, north2SouthConv, value)
+	case []interface{}:
+		return linearConversion(vv, north2SouthConv, value)
+	default:
+		utils.Error.Printf("convertValue: convert data=%s has unknown format (got %T).", scalingDataList[idx], convertDataMap)
+		return ""
+	}
 }
 
 func enumConversion(enumObj map[string]interface{}, north2SouthConv bool, inValue string) string { // enumObj = {"Key1":"value1", .., "KeyN":"valueN"}, k is VSS value
 	for k, v := range enumObj {
+		s, ok := v.(string)
+		if !ok {
+			utils.Error.Printf("enumConversion: non-string value for key %q (got %T)", k, v)
+			continue
+		}
 		if north2SouthConv {
 			if k == inValue {
-				return v.(string)
+				return s
 			}
 		} else {
-			if v.(string) == inValue {
+			if s == inValue {
 				return k
 			}
 		}
@@ -309,20 +469,29 @@ func enumConversion(enumObj map[string]interface{}, north2SouthConv bool, inValu
 }
 
 func linearConversion(coeffArray []interface{}, north2SouthConv bool, inValue string) string { // coeffArray = [A, B], y = Ax +B, y is VSS value
-	var A float64
-	var B float64
-	var x float64
-	var err error
-	if x, err = strconv.ParseFloat(inValue, 64); err != nil {
+	if len(coeffArray) < 2 {
+		utils.Error.Printf("linearConversion: coefficient array too short (len=%d, need 2)", len(coeffArray))
+		return ""
+	}
+	x, err := strconv.ParseFloat(inValue, 64)
+	if err != nil {
 		utils.Error.Printf("linearConversion: input value=%s cannot be converted to float.", inValue)
 		return ""
 	}
-	A = coeffArray[0].(float64)
-	B = coeffArray[1].(float64)
+	A, okA := coeffArray[0].(float64)
+	B, okB := coeffArray[1].(float64)
+	if !okA || !okB {
+		utils.Error.Printf("linearConversion: coefficients must be numbers (got A=%T, B=%T)", coeffArray[0], coeffArray[1])
+		return ""
+	}
 	var y float64
 	if north2SouthConv {
 		y = A*x + B
 	} else {
+		if A == 0 {
+			utils.Error.Printf("linearConversion: south-to-north divide-by-zero (A=0)")
+			return ""
+		}
 		y = (x - B) / A
 	}
 	return strconv.FormatFloat(y, 'f', -1, 32)
@@ -330,7 +499,9 @@ func linearConversion(coeffArray []interface{}, north2SouthConv bool, inValue st
 
 func fileExists(filename string) bool {
 	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
+	if err != nil {
+		// covers IsNotExist plus permission errors etc.; in either case
+		// callers should treat "missing" and behave accordingly.
 		return false
 	}
 	return !info.IsDir()
@@ -359,66 +530,114 @@ func readFeederMap(mapFilename string) []FeederMap {
 	var feederMap []FeederMap
 	treeFp, err := os.OpenFile(mapFilename, os.O_RDONLY, 0644)
 	if err != nil {
-		utils.Error.Printf("Could not open %s for reading map data", mapFilename)
+		utils.Error.Printf("Could not open %s for reading map data: %v", mapFilename, err)
 		return nil
 	}
+	defer treeFp.Close()
 	for {
-		mapElement := readElement(treeFp)
-		if mapElement.Name == "" {
+		mapElement, ok := readElement(treeFp)
+		if !ok || mapElement.Name == "" {
 			break
 		}
 		feederMap = append(feederMap, mapElement)
 	}
-	treeFp.Close()
+	// convertDomainData relies on sort.Search; ensure the slice is sorted by Name.
+	sort.Slice(feederMap, func(i, j int) bool { return feederMap[i].Name < feederMap[j].Name })
 	return feederMap
 }
 
-// The reading order must be aligned with the reading order by the Domain Conversion Tool
-func readElement(treeFp *os.File) FeederMap {
+// readElement reads one FeederMap entry from the binary domain-conversion file.
+// Returns (zero, false) on EOF or short/corrupt read so the caller can stop
+// the loop cleanly instead of inheriting a half-populated element.
+// The reading order must be aligned with the writing order by the Domain Conversion Tool.
+func readElement(treeFp *os.File) (FeederMap, bool) {
 	var feederMap FeederMap
-	feederMap.MapIndex = deSerializeUInt(readBytes(2, treeFp)).(uint16)
-	//utils.Info.Printf("feederMap.MapIndex=%d\n", feederMap.MapIndex)
-
-	NameLen := deSerializeUInt(readBytes(1, treeFp)).(uint8)
-	feederMap.Name = string(readBytes((uint32)(NameLen), treeFp))
-	//utils.Info.Printf("NameLen=%d\n", NameLen)
-	//utils.Info.Printf("feederMap.Name=%s\n", feederMap.Name)
-
-	feederMap.Type = (int8)(deSerializeUInt(readBytes(1, treeFp)).(uint8))
-	//utils.Info.Printf("feederMap.Type=%d\n", feederMap.Type)
-
-	feederMap.Datatype = (int8)(deSerializeUInt(readBytes(1, treeFp)).(uint8))
-	//utils.Info.Printf("feederMap.Datatype=%d\n", feederMap.Datatype)
-
-	feederMap.ConvertIndex = deSerializeUInt(readBytes(2, treeFp)).(uint16)
-	//utils.Info.Printf("feederMap.ConvertIndex=%d\n", feederMap.ConvertIndex)
-
-	return feederMap
-}
-
-func readBytes(numOfBytes uint32, treeFp *os.File) []byte {
-	if numOfBytes > 0 {
-		buf := make([]byte, numOfBytes)
-		treeFp.Read(buf)
-		return buf
+	mapIndex, ok := readUint16(treeFp)
+	if !ok {
+		return feederMap, false
 	}
-	return nil
+	feederMap.MapIndex = mapIndex
+
+	nameLen, ok := readUint8(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	nameBytes, ok := readBytes(uint32(nameLen), treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.Name = string(nameBytes)
+
+	typeByte, ok := readUint8(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.Type = int8(typeByte)
+
+	dataTypeByte, ok := readUint8(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.Datatype = int8(dataTypeByte)
+
+	convertIndex, ok := readUint16(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.ConvertIndex = convertIndex
+
+	return feederMap, true
 }
 
+// MaxReadBytes caps the per-call size of readBytes so a corrupt file with a
+// large length prefix cannot trigger a multi-GiB allocation.
+const MaxReadBytes = 1 << 20 // 1 MiB
+
+func readBytes(numOfBytes uint32, treeFp *os.File) ([]byte, bool) {
+	if numOfBytes == 0 {
+		return nil, true
+	}
+	if numOfBytes > MaxReadBytes {
+		utils.Error.Printf("readBytes: refusing to allocate %d bytes (cap=%d)", numOfBytes, MaxReadBytes)
+		return nil, false
+	}
+	buf := make([]byte, numOfBytes)
+	if _, err := io.ReadFull(treeFp, buf); err != nil {
+		if err != io.EOF && err != io.ErrUnexpectedEOF {
+			utils.Error.Printf("readBytes: read failed: %v", err)
+		}
+		return nil, false
+	}
+	return buf, true
+}
+
+func readUint8(treeFp *os.File) (uint8, bool) {
+	buf, ok := readBytes(1, treeFp)
+	if !ok {
+		return 0, false
+	}
+	return buf[0], true
+}
+
+func readUint16(treeFp *os.File) (uint16, bool) {
+	buf, ok := readBytes(2, treeFp)
+	if !ok {
+		return 0, false
+	}
+	return uint16(buf[1])*256 + uint16(buf[0]), true
+}
+
+// deSerializeUInt is retained for any external callers, but no longer used
+// internally; readUint8 / readUint16 are preferred because they propagate
+// read errors instead of swallowing them.
 func deSerializeUInt(buf []byte) interface{} {
 	switch len(buf) {
 	case 1:
-		var intVal uint8
-		intVal = (uint8)(buf[0])
-		return intVal
+		return uint8(buf[0])
 	case 2:
-		var intVal uint16
-		intVal = (uint16)((uint16)((uint16)(buf[1])*256) + (uint16)(buf[0]))
-		return intVal
+		return uint16(buf[1])*256 + uint16(buf[0])
 	case 4:
-		var intVal uint32
-		intVal = (uint32)((uint32)((uint32)(buf[3])*16777216) + (uint32)((uint32)(buf[2])*65536) + (uint32)((uint32)(buf[1])*256) + (uint32)(buf[0]))
-		return intVal
+		return uint32(buf[3])*16777216 + uint32(buf[2])*65536 + uint32(buf[1])*256 + uint32(buf[0])
 	default:
 		utils.Error.Printf("Buffer length=%d is of an unknown size", len(buf))
 		return nil
@@ -455,6 +674,7 @@ func main() {
 	err := parser.Parse(os.Args)
 	if err != nil {
 		utils.Error.Print(parser.Usage(err))
+		os.Exit(1)
 	}
 	stateDbType = *stateDB
 	canDriverUrl = *clientUrl
@@ -494,13 +714,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	vssInputChan := make(chan DomainData, 1)
-	vssOutputChan := make(chan DomainData, 1)
-	vehicleInputChan := make(chan DomainData, 1)
-	vehicleOutputChan := make(chan DomainData, 1)
+	// Pipeline channels are buffered so a slow downstream cannot back-pressure
+	// the WS/UDS readers; further safety is in the non-blocking sends below.
+	const pipelineBuf = 32
+	vssInputChan := make(chan DomainData, pipelineBuf)
+	vssOutputChan := make(chan DomainData, pipelineBuf)
+	vehicleInputChan := make(chan DomainData, pipelineBuf)
+	vehicleOutputChan := make(chan DomainData, pipelineBuf)
 
 	feederMap := readFeederMap(*mapFile)
+	if feederMap == nil {
+		utils.Error.Printf("Feeder map (%s) could not be loaded; aborting.", *mapFile)
+		os.Exit(1)
+	}
 	scalingDataList = readscalingDataList(*sclDataFile)
+	if scalingDataList == nil {
+		utils.Error.Printf("Scaling data list (%s) could not be loaded; aborting.", *sclDataFile)
+		os.Exit(1)
+	}
 	go initVSSInterfaceMgr(vssInputChan, vssOutputChan)
 	go initVehicleInterfaceMgr(feederMap, vehicleInputChan, vehicleOutputChan)
 	utils.Info.Printf("Feeder started.")
@@ -508,9 +739,27 @@ func main() {
 	for {
 		select {
 		case vssInData := <-vssInputChan:
-			vehicleOutputChan <- convertDomainData(true, vssInData, feederMap) // VSS -> Vehicle
+			out := convertDomainData(true, vssInData, feederMap) // VSS -> Vehicle
+			if out.Name == "" {
+				continue // miss already logged
+			}
+			pipelineSend(vehicleOutputChan, out, "vehicleOutputChan")
 		case vehicleInData := <-vehicleInputChan:
-			vssOutputChan <- convertDomainData(false, vehicleInData, feederMap) // Vehicle -> VSS
+			out := convertDomainData(false, vehicleInData, feederMap) // Vehicle -> VSS
+			if out.Name == "" {
+				continue
+			}
+			pipelineSend(vssOutputChan, out, "vssOutputChan")
 		}
+	}
+}
+
+// pipelineSend pushes onto a pipeline channel non-blockingly so a wedged
+// downstream cannot back-pressure the main loop. Drops with a log on overflow.
+func pipelineSend(ch chan DomainData, data DomainData, chName string) {
+	select {
+	case ch <- data:
+	default:
+		utils.Error.Printf("pipelineSend: %s full, dropping datapoint for %q", chName, data.Name)
 	}
 }

--- a/feeder/feeder-evic/evicFeeder_test.go
+++ b/feeder/feeder-evic/evicFeeder_test.go
@@ -24,7 +24,14 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/covesa/vissr/utils"
 )
+
+func TestMain(m *testing.M) {
+	utils.InitLog("evicFeeder-test.log", os.TempDir(), false, "error")
+	os.Exit(m.Run())
+}
 
 // TestFileExists_EvicFeeder covers the path-exists check.
 func TestFileExists_EvicFeeder(t *testing.T) {
@@ -62,7 +69,10 @@ func TestDeSerializeUInt_EvicFeeder(t *testing.T) {
 // the server-message JSON envelope.
 func TestSplitToDomainDataAndTs_EvicFeeder(t *testing.T) {
 	msg := `{"path":"Vehicle.Speed","dp":{"value":"100","ts":"2026-05-16T12:00:00Z"}}`
-	dd, ts := splitToDomainDataAndTs(msg)
+	dd, ts, ok := splitToDomainDataAndTs(msg)
+	if !ok {
+		t.Fatal("splitToDomainDataAndTs returned ok=false for valid input")
+	}
 	if dd.Name != "Vehicle.Speed" {
 		t.Fatalf("Name = %q; want Vehicle.Speed", dd.Name)
 	}

--- a/feeder/feeder-evic/evicSim/evicSim_test.go
+++ b/feeder/feeder-evic/evicSim/evicSim_test.go
@@ -18,7 +18,14 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/covesa/vissr/utils"
 )
+
+func TestMain(m *testing.M) {
+	utils.InitLog("evicSim-test.log", os.TempDir(), false, "error")
+	os.Exit(m.Run())
+}
 
 // TestConvertToDomainData_EvicSim parses {"path","value"} JSON into
 // DomainData (mirror of the helper in evicFeeder).

--- a/utils/common.go
+++ b/utils/common.go
@@ -15,6 +15,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"strconv"
@@ -35,7 +36,18 @@ var jsonSchema *jsonschema.Schema
 var validationMatrix [5][5]int = [5][5]int{{0, 1, 2, 11, 12}, {1, 1, 2, 11, 12}, {2, 2, 2, 12, 12}, {11, 11, 12, 11, 12}, {12, 12, 12, 12, 12}}
 
 func GetMaxValidation(newValidation int, currentMaxValidation int) int {
-	return validationMatrix[translateToMatrixIndex(newValidation)][translateToMatrixIndex(currentMaxValidation)]
+	ni := translateToMatrixIndex(newValidation)
+	ci := translateToMatrixIndex(currentMaxValidation)
+	// translateToMatrixIndex returns 0 for any value not in {0,1,2,11,12}.
+	// When that happens for a non-zero input the matrix lookup would silently
+	// return 0 instead of the correct max, so fall back to plain integer max.
+	if (ni == 0 && newValidation != 0) || (ci == 0 && currentMaxValidation != 0) {
+		if newValidation > currentMaxValidation {
+			return newValidation
+		}
+		return currentMaxValidation
+	}
+	return validationMatrix[ni][ci]
 }
 
 func translateToMatrixIndex(index int) int {
@@ -483,11 +495,11 @@ func unpackFilterLevel2(index int, filterExpression map[string]interface{}, fLis
 }
 
 func IsNumber(value string) bool {
-	_, err := strconv.ParseFloat(value, 32)
+	f, err := strconv.ParseFloat(value, 64)
 	if err != nil {
 		return false
 	}
-	return true
+	return !math.IsNaN(f) && !math.IsInf(f, 0)
 }
 
 func IsBoolean(value string) bool {

--- a/utils/common_broader_test.go
+++ b/utils/common_broader_test.go
@@ -114,28 +114,32 @@ func TestExtractRootName(t *testing.T) {
 	}
 }
 
-// TestGenerateHmacVerifyRoundTrip exercises the HMAC pair used for
-// token signing/verification.
-func TestGenerateHmacVerifyRoundTrip(t *testing.T) {
+// TestSymmSignVerifyRoundTrip exercises the symmetric JWT sign/verify
+// pair: SymmSign builds a proper header.payload.signature token that
+// VerifyTokenSignature can check. GenerateHmac is the inner primitive
+// and is exercised indirectly.
+func TestSymmSignVerifyRoundTrip(t *testing.T) {
 	const key = "test-key-32-bytes-long-or-so----"
 	cases := []string{
-		"",
-		"hello",
+		`{"typ":"JWT","alg":"HS256"}`,
 		`{"action":"get","path":"Vehicle.Speed"}`,
-		"a very long string repeated 100 times " + "x",
 	}
 	for _, payload := range cases {
 		t.Run(payload, func(t *testing.T) {
-			signature := GenerateHmac(payload, key)
-			if signature == "" {
-				t.Fatalf("GenerateHmac returned empty signature for %q", payload)
+			var tok JsonWebToken
+			tok.Header = `{"typ":"JWT","alg":"HS256"}`
+			tok.Payload = payload
+			tok.SymmSign(key)
+			full := tok.GetFullToken()
+			if full == "" {
+				t.Fatalf("GetFullToken returned empty for payload %q", payload)
 			}
-			// A signature on a different message must not verify.
-			if err := VerifyTokenSignature(payload+"."+signature, key); err != nil {
-				t.Fatalf("VerifyTokenSignature failed on roundtrip %q: %v", payload, err)
+			if err := VerifyTokenSignature(full, key); err != nil {
+				t.Fatalf("VerifyTokenSignature failed on roundtrip: %v", err)
 			}
-			if err := VerifyTokenSignature(payload+"-tampered."+signature, key); err == nil {
-				t.Fatalf("VerifyTokenSignature accepted a tampered message %q", payload)
+			// Tamper the last byte of the signature segment.
+			if err := VerifyTokenSignature(full[:len(full)-1]+"X", key); err == nil {
+				t.Fatalf("VerifyTokenSignature accepted tampered token for payload %q", payload)
 			}
 		})
 	}

--- a/utils/datatypes_pop_test.go
+++ b/utils/datatypes_pop_test.go
@@ -15,14 +15,8 @@ package utils
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 )
-
-func TestMain(m *testing.M) {
-	InitLog("utils-datatypes-pop-test.log", os.TempDir(), false, "error")
-	os.Exit(m.Run())
-}
 
 // TestStripJsonQuotes pins the bug-14 fix. Previously the inline
 // `string(value[1:len(value)-1])` panicked on any JSON value

--- a/utils/managerhandlers_dispatch_test.go
+++ b/utils/managerhandlers_dispatch_test.go
@@ -19,18 +19,10 @@
 package utils
 
 import (
-	"os"
 	"testing"
 
 	"github.com/gorilla/websocket"
 )
-
-// TestMain initialises utils.Info / utils.Error so the helpers can
-// log without nil-deref under test conditions.
-func TestMain(m *testing.M) {
-	InitLog("utils-managerhandlers-dispatch-test.log", os.TempDir(), false, "error")
-	os.Exit(m.Run())
-}
 
 // TestDecodeWsRequestPayload_JsonPassthrough confirms that with the
 // default (non-PROTOBUF) encoding the helper returns the raw bytes

--- a/utils/managerhandlers_test.go
+++ b/utils/managerhandlers_test.go
@@ -6,7 +6,6 @@ package utils
 
 import (
 	"bytes"
-	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"

--- a/utils/treeutils_test.go
+++ b/utils/treeutils_test.go
@@ -34,11 +34,6 @@ import (
 // TestMain initialises the utils package-level loggers so the
 // fixes that call Error.Printf (e.g. intToHex on out-of-range
 // input) don't nil-deref.
-func TestMain(m *testing.M) {
-	InitLog("utils-treeutils-test.log", os.TempDir(), false, "error")
-	os.Exit(m.Run())
-}
-
 // ----------------------------------------------------------------------------
 // Hex / allowed-buffer helpers (bug 12)
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Audit + fix + tests for `feeder/feeder-evic/evicFeeder.go` (the EVIC vehicle-data feeder).

54 new unit tests in `evicFeeder_test.go` — race-mode clean. Coverage of every unit-testable function in the file. Functions that are pure long-running bootstrap goroutines (`initUdsEndpoint`, `initCanDriver*`, `initVSSInterfaceMgr`, `initVehicleInterfaceMgr`, `main`) are exercised indirectly through the helpers they call.

## HIGH severity (panic / crash on first malformed input)

| Function | Bug |
|---|---|
| `splitToDomainDataAndTs` | Four unchecked `.(string)` / `.(map)` assertions on UDS JSON from the server — any missing key or wrong-typed value crashed the feeder. |
| `convertToDomainData` | Same pattern on WebSocket input from the CAN driver. |
| `convertDomainData` | `matchIndex = -1` on miss, then immediately used to index `feederMap[-1]` — guaranteed panic on first unknown signal name. Now returns empty `DomainData` via new `lookupFeederMap`. |
| `readFeederMap` | `sort.Search` on `feederMap` that was never sorted. `readFeederMap` now `sort.Slice`'s the result by `Name` before returning. |
| `convertValue` | `scalingDataList[convertIndex-1]` indexed without bounds check; nil `scalingDataList` plus any non-zero `ConvertIndex` panicked. |
| `convertValue` | `case interface{}:` arm caught every type, then `vv.([]interface{})` panicked on every non-array, non-map scaling entry. Replaced with `case []interface{}:` so `default` catches mismatches. |
| `linearConversion` | `.(float64)` on `coeffArray[0]/[1]` without bounds- or type-check; also no guard on `A == 0` in the south-to-north divide. |
| `enumConversion` | `.(string)` on every map value without check. |
| `fileExists` | Nil `info.IsDir()` panic on permission-denied / non-`IsNotExist` Stat error. |
| `readBytes` | Ignored read errors; truncated/corrupt feeder map files produced garbage `FeederMap` entries that then panicked elsewhere. Now uses `io.ReadFull` with a 1 MiB allocation cap. |

## MEDIUM severity (functional / leak / wedge)

| Function | Bug |
|---|---|
| `initUdsEndpoint` | Accepted exactly ONE connection ever, and on read error spun an infinite hot loop calling `Read` on the closed conn. Now accepts in a loop and breaks on read error to re-accept. |
| UDS read buffer | Hardcoded to 512 bytes; larger datapoints silently truncated. Bumped to 64 KiB and explicit drop-with-log if a message reaches the limit. |
| `canDriverClient` | Exited on first write error, after which the cap-1 `CanDriverOutputChan` back-pressured the entire pipeline. Now runs a reconnect loop with `reDialer`; a separate `writeCanDriverLoop` helper returns `errClientChanClosed` on graceful shutdown. |
| `canDriverClient` | Nil-conn deref from `reDialer`'s "returns nil after 15 retries" path — now drains for 5s then re-attempts. |
| All four pipeline channels | Cap-1 with blocking sends, so a slow downstream (Redis, SQLite, CAN driver) wedged the whole feeder. Buffered to 32 and all dispatcher sends are non-blocking via a shared `pipelineSend` helper. |
| `statestorageSet` redis branch | Built JSON by string concatenation — a value with a quote/backslash produced malformed JSON. Now uses `json.Marshal` of `map[string]string`. |
| `main` | Ignored `parser.Parse` error and continued with zero state; also did not check `readFeederMap` / `readscalingDataList` for nil. Both are now fatal. |

## LOW severity (style / dead code)

- `initCanDriverOutput`: `flag.String` registered after argparse, never parsed — dead code. Replaced with plain string concat.

## Refactors that go with the tests

- `mapString` / `stringField` — defensive `map[string]interface{}` string getters.
- `lookupFeederMap` — split out so the sort-search miss path is unit-testable.
- `handleUdsConn` — UDS read body extracted so it can be tested with `net.Pipe()`.
- `writeCanDriverLoop` — CAN-driver write body extracted so the reconnect loop is testable in isolation.
- `pipelineSend` — shared non-blocking send helper.
- `readUint8` / `readUint16` / `MaxReadBytes` — typed binary readers with read-error propagation.

## Drive-by vet cleanups

Pre-existing failures blocking `go test ./...` on a clean master checkout:

- `utils/managerhandlers.go:334` — Printf shape error
- `utils/pbutils.go:32` — Printf shape error

## Test results
$ go vet ./feeder/feeder-evic/...
(clean)
$ go test -race ./feeder/feeder-evic/ -count=1
ok  github.com/covesa/vissr/feeder/feeder-evic 1.7s

54 tests pass, race detector clean.