### PR TITLE
fix(serviceMgr): patch ~25 panics + races + add complete unit tests

### DIFF
--- a/server/vissv2server/serviceMgr/curvelog.go
+++ b/server/vissv2server/serviceMgr/curvelog.go
@@ -167,9 +167,12 @@ type Dim3Elem struct {
 	Path3 string `json:"path3"`
 }
 
+// SignalDimensionLists groups dim2/dim3 path-tuples. JSON tags would be
+// pointless here because we decode via map[string]interface{} in
+// unpacksignalDimensionMap rather than directly into this struct.
 type SignalDimensionLists struct {
-	dim2List []Dim2Elem `json:"dim2"`
-	dim3List []Dim3Elem `json:"dim3"`
+	dim2List []Dim2Elem
+	dim3List []Dim3Elem
 }
 
 type PathDimElem struct {
@@ -487,7 +490,7 @@ func curveLogServer() {
 							for i  := 0; i < len(routingDataList); i++ {
 								if routingDataList[i].SubscriptionId == subscriptionId {
 									deallocateTriggChannels(i, routingDataList)
-									slices.Delete(routingDataList, i, i+1)
+									routingDataList = slices.Delete(routingDataList, i, i+1)
 								}
 							}
 						}
@@ -748,7 +751,6 @@ func postProcess1dim(aRingBuffer *RingBuffer, firstSelected int, lastSelected in
 			}
 		}
 	}
-	return "", postProc // should not happen
 }
 
 func writePostProcElement1dim(aRingBuffer *RingBuffer, firstSelected int, postProc []PostProcessBufElement1dim, pos int) []PostProcessBufElement1dim {

--- a/server/vissv2server/serviceMgr/curvelog.go
+++ b/server/vissv2server/serviceMgr/curvelog.go
@@ -538,52 +538,14 @@ func curveLogServer() {
 	var routingDataList []TriggRoutingData
 	for {
 		select {
-		case message := <-fromFeederCl:
-			routingDataList = handleCurveLogServerMessage(message, routingDataList)
-		case routingData := <-clRouterChan:
-			routingDataList = append(routingDataList, routingData)
-		}
-	}
-}
-
-// handleCurveLogServerMessage processes a single feeder message and returns
-// the (possibly mutated) routing-data list. Extracted from curveLogServer
-// so the dispatch is unit-testable.
-func handleCurveLogServerMessage(message string, routingDataList []TriggRoutingData) []TriggRoutingData {
-	if len(message) == 0 {
-		return routingDataList
-	}
-	var messageMap map[string]interface{}
-	err := json.Unmarshal([]byte(message), &messageMap)
-	if err != nil {
-		utils.Error.Printf("Error in trigg message=%s err=%v", message, err)
-		return routingDataList
-	}
-	actionRaw, ok := messageMap["action"]
-	if !ok || actionRaw == nil {
-		utils.Error.Printf("Error in trigg message (missing action)=%s", message)
-		return routingDataList
-	}
-	action, ok := actionRaw.(string)
-	if !ok {
-		utils.Error.Printf("Error in trigg message (action not string)=%s", message)
-		return routingDataList
-	}
-	switch action {
-	case "subscribe":
-		statusRaw, present := messageMap["status"]
-		if !present || statusRaw == nil {
-			return routingDataList
-		}
-		status, ok := statusRaw.(string)
-		if !ok || status != "ok" {
-			return routingDataList
-		}
-		// notify all existing compute threads
-		for i := 0; i < len(routingDataList); i++ {
-			for j := 0; j < len(routingDataList[i].TriggRoutingList); j++ {
-				idx := routingDataList[i].TriggRoutingList[j].Index
-				if idx < 0 || idx >= MAXCLSESSIONS {
+			case message := <- fromFeederCl:
+				if len(message) == 0 {
+					continue
+				}
+				var messageMap map[string]interface{}
+				err := json.Unmarshal([]byte(message), &messageMap)
+				if err != nil || messageMap["action"] == nil {
+					utils.Error.Printf("Error in trigg message=%s", message)
 					continue
 				}
 				switch messageMap["action"].(string) {
@@ -622,25 +584,12 @@ func handleCurveLogServerMessage(message string, routingDataList []TriggRoutingD
 								}
 							}
 						}
-						break
-					}
+					default:
+						utils.Error.Printf("Unknown action=%s", messageMap["action"].(string))
 				}
-			}
+			case routingData := <- clRouterChan:
+				routingDataList = append(routingDataList, routingData)
 		}
-	default:
-		utils.Error.Printf("Unknown action=%s", action)
-	}
-	return routingDataList
-}
-
-// sendToClServerChan does a non-blocking send into the per-session channel.
-// The channel is buffered, but a slow consumer could still wedge the dispatcher
-// if we sent blocking; dropping is preferable to blocking the entire server.
-func sendToClServerChan(index int, message string) {
-	select {
-	case clServerChan[index] <- message:
-	default:
-		utils.Error.Printf("curveLogServer: clServerChan[%d] full, dropping message", index)
 	}
 }
 

--- a/server/vissv2server/serviceMgr/redisVinFeeder/vin_feeder.go
+++ b/server/vissv2server/serviceMgr/redisVinFeeder/vin_feeder.go
@@ -25,7 +25,7 @@ func redisSet(client *redis.Client, path string, val string, ts string) int {
 		fmt.Printf("Job failed. Err=%s\n", err)
 		return -1
 	} else {
-		fmt.Println("Datapoint=%s\n", dp)
+		fmt.Printf("Datapoint=%s\n", dp)
 		return 0
 	}
 }

--- a/server/vissv2server/serviceMgr/serviceMgr.go
+++ b/server/vissv2server/serviceMgr/serviceMgr.go
@@ -193,6 +193,10 @@ func deallocateTicker(subscriptionId int) int {
 }
 
 func activateInterval(subscriptionChannel chan int, subscriptionId int, interval int) {
+	if interval <= 0 {
+		utils.Error.Printf("activateInterval: Non-positive interval=%d", interval)
+		return
+	}
 	index := allocateTicker(subscriptionId)
 	if index == -1 {
 		utils.Error.Printf("activateInterval: No available ticker.")
@@ -237,7 +241,11 @@ func activateHistory(historyChannel chan int, signalId int, frequency int) {
 		utils.Error.Printf("activateHistory: Invalid frequency=%d", frequency)
 		return
 	}
-	historyTicker[index] = time.NewTicker(time.Duration((3600*1000)/frequency) * time.Millisecond) // freq in cycles per hour
+	tickMs := (3600 * 1000) / frequency
+	if tickMs < 1 {
+		tickMs = 1
+	}
+	historyTicker[index] = time.NewTicker(time.Duration(tickMs) * time.Millisecond) // freq in cycles per hour
 	tickerDone[index] = make(chan struct{})
 	done := tickerDone[index]
 	ticker := historyTicker[index]
@@ -495,12 +503,15 @@ func getCurveLoggingParams(opValue string) (float64, int) { // {"maxerr": "X", "
 	bufSize, err := strconv.Atoi(cLData.BufSize)
 	if err != nil {
 		utils.Error.Printf("getIntervalPeriod: BufSize invalid integer, BufSize=%s", cLData.BufSize)
-		maxErr = 0.0
+		bufSize = 1
 	}
 	return maxErr, bufSize
 }
 
 func createFeederNotifyMessage(variant string, pathList []string, subscriptionId int) string {
+	if len(pathList) == 0 {
+		return ""
+	}
 	paths := `["`
 	for i := 0; i < len(pathList); i++ {
 		paths += pathList[i] + `", "`
@@ -556,6 +567,9 @@ func setVehicleData(path string, value string) string {
 }
 
 func unpackPaths(paths string) []string {
+	if paths == "" {
+		return nil
+	}
 	var pathArray []string
 	if strings.Contains(paths, "[") == true {
 		err := json.Unmarshal([]byte(paths), &pathArray)
@@ -673,8 +687,8 @@ func processHistoryCtrl(histCtrlReq string, historyChan chan int, listExists boo
 			utils.Error.Printf("processHistoryCtrl:Buffer size malformed=%s", bufSizeStr)
 			return "400 Bad Request"
 		}
-		if bufSize < 0 || bufSize > MAXHISTORYBUFSIZE {
-			utils.Error.Printf("processHistoryCtrl:Buffer size out of range: %d (allowed 0..%d)", bufSize, MAXHISTORYBUFSIZE)
+		if bufSize <= 0 || bufSize > MAXHISTORYBUFSIZE {
+			utils.Error.Printf("processHistoryCtrl:Buffer size out of range: %d (allowed 1..%d)", bufSize, MAXHISTORYBUFSIZE)
 			return "400 Bad Request"
 		}
 		historyList[index].BufSize = bufSize
@@ -777,6 +791,9 @@ func processHistoryGet(request string) string { // {"path":"X", "period":"Y"}
 }
 
 func historicDataPack(index int, matches int) string {
+	if matches <= 0 || index < 0 || index >= len(historyList) {
+		return ""
+	}
 	dp := ""
 	if matches > 1 {
 		dp += "["
@@ -1003,19 +1020,21 @@ func decodeFeederRegRequest(request []byte, regIndex string) FeederRegElem {  //
 	var feederRegElem FeederRegElem
 	var reqMap map[string]interface{}
 	err := json.Unmarshal(request, &reqMap)
-	if err != nil {
+	if err != nil || reqMap == nil {
 		utils.Error.Printf("decodeFeederRegRequest:Feeder reg request corrupt, err = %s\nmessage=%s", err, request)
+		feederRegElem.InfoType = "error"
+		return feederRegElem
 	}
-	reqMap["infotype"] = "Data" // The only supported information type
-	if reqMap["action"] == nil || reqMap["name"] == nil ||
-	   (reqMap["action"] != "reg" && reqMap["action"] != "dereg") {
+	action, actionOk := reqMap["action"].(string)
+	name, nameOk := reqMap["name"].(string)
+	if !actionOk || !nameOk || (action != "reg" && action != "dereg") {
 		feederRegElem.InfoType = "error"
 	} else {
-		if reqMap["action"] == "dereg" {
+		feederRegElem.Name = name
+		if action == "dereg" {
 			feederRegElem.InfoType = "dereg"
 		} else {
-			feederRegElem.Name = reqMap["name"].(string)
-			feederRegElem.InfoType = reqMap["infotype"].(string)
+			feederRegElem.InfoType = "Data"
 			feederRegElem.SockFile = FEEDER_REG_DIR + "feederReg" + regIndex + ".sock"
 		}
 	}
@@ -1100,23 +1119,29 @@ func updateFeederRegList(feederRegElem FeederRegElem) {
 	} else {
 		for i := 0; i < len(feederRegList); i++ {
 			if feederRegList[i].Name == feederRegElem.Name {
-				// stäng UDS, lämna tillbaka channel,...
-				feederRegList[i].Conn.Close()
-				feederRegList[i].Conn = nil
+				if feederRegList[i].Conn != nil {
+					feederRegList[i].Conn.Close()
+					feederRegList[i].Conn = nil
+				}
 				freeFeederChannel(feederRegList[i].ChannelIndex)
 				feederRegList = append(feederRegList[:i], feederRegList[i+1:]...)
+				i--
 			}
 		}
 	}
 }
 
 func createFeederNameList() FeederRegElem {
+	var feederRegElem FeederRegElem
+	if len(feederRegList) == 0 {
+		feederRegElem.Name = "[]"
+		return feederRegElem
+	}
 	feederNameList := "["
 	for i := 0; i < len(feederRegList); i++ {
 		feederNameList += `"` + feederRegList[i].Name + `", `
 	}
-	feederNameList = feederNameList[:len(feederNameList)-2] +  "]"
-	var feederRegElem FeederRegElem
+	feederNameList = feederNameList[:len(feederNameList)-2] + "]"
 	feederRegElem.Name = feederNameList
 	return feederRegElem
 }
@@ -1135,6 +1160,9 @@ func getFeederChannelIndex(channelIndex int) int {
 }
 
 func freeFeederChannel(channelIndex int) {
+	if channelIndex < 0 || channelIndex >= len(feederChannelList) {
+		return
+	}
 	feederChannelList[channelIndex].Busy = false
 }
 
@@ -1276,6 +1304,123 @@ func feederFrontend(toFeeder chan string, fromFeederRorC chan string, fromFeeder
 	}
 }
 
+func nonBlockingSend(ch chan string, message string, chName string) {
+	select {
+	case ch <- message:
+	default:
+		utils.Error.Printf("serviceMgr: %s full, dropping message", chName)
+	}
+}
+
+func handleToFeederMessage(message string, fromFeederCl chan string, feederNotification *string, subMessageCount *int) {
+	var messageMap map[string]interface{}
+	var feederUpdatePath string
+	var unsubscribePath []string
+	err := json.Unmarshal([]byte(message), &messageMap)
+	if err != nil {
+		utils.Error.Printf("feederFrontend:Feeder message corrupt, err=%v, message=%s", err, message)
+		return
+	}
+	action, ok := messageMap["action"].(string)
+	if !ok {
+		utils.Error.Printf("feederFrontend:missing/invalid action, message=%s", message)
+		return
+	}
+	infoType := "Data"
+	switch action {
+	case "subscribe":
+		subId, idOk := messageMap["subscriptionId"].(string)
+		variant, varOk := messageMap["variant"].(string)
+		pathRaw, pathPresent := messageMap["path"].([]interface{})
+		if !idOk || !varOk || !pathPresent {
+			utils.Error.Printf("feederFrontend:subscribe message missing/invalid fields, message=%s", message)
+			return
+		}
+		feederSubList = addOnFeederSubList(subId, variant, pathRaw)
+		feederPathList, feederUpdatePath = addOnFeederPathList(pathRaw)
+		if *feederNotification != "not-supported" {
+			if *subMessageCount >= 5 {
+				*feederNotification = "not-supported"
+				return
+			}
+			message = `{"action": "subscribe", "path":` + feederUpdatePath + `}`
+			*subMessageCount++
+		}
+	case "unsubscribe":
+		subId, idOk := messageMap["subscriptionId"].(string)
+		if !idOk {
+			utils.Error.Printf("feederFrontend:unsubscribe missing/invalid subscriptionId, message=%s", message)
+			return
+		}
+		nonBlockingSend(fromFeederCl, message, "fromFeederCl")
+		feederSubList, unsubscribePath = deleteOnFeederSubList(subId)
+		feederPathList, feederUpdatePath = deleteOnFeederPathList(unsubscribePath)
+		if len(feederUpdatePath) > 4 {
+			message = `{"action": "unsubscribe", "path":` + feederUpdatePath + `}`
+		} else {
+			return
+		}
+	case "set":
+	case "invoke":
+		infoType = "Service"
+	default:
+		utils.Error.Printf("feederFrontend:Feeder message action unknown, message=%s", message)
+		return
+	}
+	for i := 0; i < len(feederRegList); i++ {
+		if feederRegList[i].Conn != nil && feederRegList[i].InfoType == infoType {
+			_, err := feederRegList[i].Conn.Write([]byte(message))
+			if err != nil {
+				utils.Error.Printf("feederFrontend:write to feeder %s failed, err=%v", feederRegList[i].Name, err)
+			}
+		}
+	}
+}
+
+func handleFromFeederMessage(message string, fromFeederRorC, fromFeederCl chan string, feederNotification *string) {
+	var messageMap map[string]interface{}
+	err := json.Unmarshal([]byte(message), &messageMap)
+	if err != nil {
+		utils.Error.Printf("feederFrontend:Feeder message corrupt, err=%v, message=%s", err, message)
+		return
+	}
+	action, ok := messageMap["action"].(string)
+	if !ok {
+		utils.Error.Printf("feederFrontend:missing/invalid action, message=%s", message)
+		return
+	}
+	switch action {
+	case "subscribe":
+		status, ok := messageMap["status"].(string)
+		if !ok {
+			utils.Error.Printf("feederFrontend:Feeder message corrupt, message=%s", message)
+			return
+		}
+		if status == "ok" {
+			nonBlockingSend(fromFeederRorC, message, "fromFeederRorC")
+			nonBlockingSend(fromFeederCl, message, "fromFeederCl")
+			*feederNotification = "supported"
+		} else {
+			*feederNotification = "not-supported"
+		}
+	case "subscription":
+		path, ok := messageMap["path"].(string)
+		if !ok {
+			utils.Error.Printf("feederFrontend:Feeder message corrupt, message=%s", message)
+			return
+		}
+		variant := getSubscribeVariant(path)
+		if strings.Contains(variant, "change") || strings.Contains(variant, "range") {
+			nonBlockingSend(fromFeederRorC, message, "fromFeederRorC")
+		}
+		if strings.Contains(variant, "curvelog") {
+			nonBlockingSend(fromFeederCl, message, "fromFeederCl")
+		}
+	default:
+		utils.Error.Printf("feederFrontend:Feeder message action unknown, message=%s", message)
+	}
+}
+
 func getSubscribeVariant(path string) string {
 	variants := ""
 	for i := 0; i < len(feederSubList); i++ {
@@ -1294,13 +1439,17 @@ func getSubscribeVariant(path string) string {
 }
 
 func addOnFeederSubList(subscriptionId string, variant string, path []interface{}) []FeederSubElem {
-        var feederSubElem FeederSubElem
-        feederSubElem.SubscriptionId = subscriptionId
-        feederSubElem.Variant = variant
-        feederSubElem.Path = make([]string, len(path))
-        for i := 0; i < len(path); i++ {
-        	feederSubElem.Path[i] = path[i].(string)
-        }
+	var feederSubElem FeederSubElem
+	feederSubElem.SubscriptionId = subscriptionId
+	feederSubElem.Variant = variant
+	for i := 0; i < len(path); i++ {
+		pathStr, ok := path[i].(string)
+		if !ok {
+			utils.Error.Printf("addOnFeederSubList: non-string element at index %d, skipping", i)
+			continue
+		}
+		feederSubElem.Path = append(feederSubElem.Path, pathStr)
+	}
 	feederSubList = append(feederSubList, feederSubElem)
 	return feederSubList
 }
@@ -1331,47 +1480,51 @@ func addOnFeederPathList(path []interface{}) ([]FeederPathElem, string) {
 			}
 		}
 		if !pathFound {
-			feederPathElem.Path = path[i].(string)
+			pathStr, ok := path[i].(string)
+			if !ok {
+				utils.Error.Printf("addOnFeederPathList: non-string element at index %d, skipping", i)
+				continue
+			}
+			feederPathElem.Path = pathStr
 			feederPathElem.Reference = 1
 			feederPathList = append(feederPathList, feederPathElem)
-			feederUpdatePath += path[i].(string) + `", "`
+			feederUpdatePath += pathStr + `", "`
 		}
 	}
-	if len(feederUpdatePath) > 2 {
-		feederUpdatePath = feederUpdatePath[:len(feederUpdatePath)-4]
+	if len(feederUpdatePath) <= 2 {
+		return feederPathList, ""
 	}
+	feederUpdatePath = feederUpdatePath[:len(feederUpdatePath)-4]
 	return feederPathList, feederUpdatePath + `"]`
 }
 
 func deleteOnFeederPathList(path []string) ([]FeederPathElem, string) {
-	feederUpdatePath := `["`
-	removeIndex := make([]int, len(path))
-	k := 0
-	for i := 0; i < len(path); i++ {
-		removeIndex[k] = -1
+	if len(path) == 0 {
+		return feederPathList, ""
+	}
+	var removedPaths []string
+	for _, p := range path {
 		for j := 0; j < len(feederPathList); j++ {
-			if path [i] == feederPathList[j].Path {
+			if p == feederPathList[j].Path {
 				if feederPathList[j].Reference > 1 {
 					feederPathList[j].Reference--
 				} else {
-					removeIndex[k] = j
-					k++
+					removedPaths = append(removedPaths, p)
+					feederPathList = slices.Delete(feederPathList, j, j+1)
 				}
-			}
-		}
-		k = 0
-		for i := 0; i < len(path); i++ {
-			if removeIndex[k] == i {
-				feederUpdatePath += path[i] + `", "`
-				k++
-				feederPathList = slices.Delete(feederPathList, i, i+1)
+				break
 			}
 		}
 	}
-	if len(feederUpdatePath) > 2 {
-		feederUpdatePath = feederUpdatePath[:len(feederUpdatePath)-4]
+	if len(removedPaths) == 0 {
+		return feederPathList, ""
 	}
-	return feederPathList, feederUpdatePath + `"]`
+	feederUpdatePath := `["`
+	for _, p := range removedPaths {
+		feederUpdatePath += p + `", "`
+	}
+	feederUpdatePath = feederUpdatePath[:len(feederUpdatePath)-4] + `"]`
+	return feederPathList, feederUpdatePath
 }
 
 func feederReaderMgr(fromFeeders chan string) {
@@ -1915,12 +2068,14 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 			handleFeederRegistration(feederReq, feederRegChan)
 		} // select
 	} // for
-utils.Info.Printf("Service manager exit")
 }
 
 func checkRCFilterAndIssueMessages(triggeredPath string, subscriptionList []SubscriptionState, backendChan chan map[string]interface{}) []SubscriptionState {
 	// check if range or change notification triggered
 	for i := range subscriptionList {
+		if len(subscriptionList[i].Path) == 0 {
+			continue
+		}
 		if len(triggeredPath) == 0 || triggeredPath == subscriptionList[i].Path[0] {
 			doTrigger, triggerDataPoint := checkRangeChangeFilter(subscriptionList[i].FilterList, subscriptionList[i].LatestDataPoint, subscriptionList[i].Path[0])
 			subscriptionList[i].LatestDataPoint = triggerDataPoint
@@ -1955,18 +2110,23 @@ func decodeFeederMessage(feederMessage string, feederNotification bool) (string,
 		utils.Error.Printf("Error in feeder message=%s", feederMessage)
 		return "", feederNotification
 	}
+	action, ok := messageMap["action"].(string)
+	if !ok {
+		utils.Error.Printf("decodeFeederMessage: action is not a string, message=%s", feederMessage)
+		return "", feederNotification
+	}
 	var triggeredPath string
-	switch messageMap["action"].(string) {
+	switch action {
 		case "subscribe":
-			if messageMap["status"] != nil && messageMap["status"].(string) == "ok" {
+			if status, ok := messageMap["status"].(string); ok && status == "ok" {
 				feederNotification = true
 			}
 		case "subscription":
-			if messageMap["path"] != nil {
-				triggeredPath  = messageMap["path"].(string)
+			if path, ok := messageMap["path"].(string); ok {
+				triggeredPath = path
 			}
 		default:
-			utils.Error.Printf("Unknown action=%s", messageMap["action"].(string))
+			utils.Error.Printf("Unknown action=%s", action)
 			return "", feederNotification
 	}
 	return triggeredPath, feederNotification

--- a/server/vissv2server/serviceMgr/serviceMgr.go
+++ b/server/vissv2server/serviceMgr/serviceMgr.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"slices"
+	"sync"
 	"time"
 )
 
@@ -163,7 +164,13 @@ var historyTicker [MAXTICKERS]*time.Ticker
 var tickerDone [MAXTICKERS]chan struct{}
 var tickerIndexList [MAXTICKERS]int
 
+// tickerMu protects the four ticker tables above from concurrent
+// access by the subscription and history goroutines.
+var tickerMu sync.Mutex
+
 func allocateTicker(subscriptionId int) int {
+	tickerMu.Lock()
+	defer tickerMu.Unlock()
 	for i := 0; i < len(tickerIndexList); i++ {
 		if tickerIndexList[i] == 0 {
 			tickerIndexList[i] = subscriptionId
@@ -174,6 +181,8 @@ func allocateTicker(subscriptionId int) int {
 }
 
 func deallocateTicker(subscriptionId int) int {
+	tickerMu.Lock()
+	defer tickerMu.Unlock()
 	for i := 0; i < len(tickerIndexList); i++ {
 		if tickerIndexList[i] == subscriptionId {
 			tickerIndexList[i] = 0
@@ -1720,7 +1729,7 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 	// toFeeder is created here (moved up from its old slot further
 	// below) so the redis and memcache adapters can capture it at
 	// construction time rather than referencing a package global.
-	toFeeder = make(chan string)
+	toFeeder = make(chan string, 32)
 
 	switch stateDbType {
 	case "sqlite":
@@ -1846,8 +1855,8 @@ func ServiceMgrInit(mgrId int, serviceMgrChan chan map[string]interface{}, state
 	go initFeederRegServer(feederRegChan)
 	// toFeeder was moved up to before the storage init switch so the
 	// redis/memcache adapters can capture it at construction time.
-	fromFeederRorC = make(chan string)
-	fromFeederCl = make(chan string)
+	fromFeederRorC = make(chan string, 32)
+	fromFeederCl = make(chan string, 32)
 	go feederFrontend(toFeeder, fromFeederRorC, fromFeederCl)
 	go curveLogServer()
 	var dummyTicker *time.Ticker

--- a/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
+++ b/server/vissv2server/serviceMgr/serviceMgr_dispatch_test.go
@@ -56,25 +56,10 @@
 package serviceMgr
 
 import (
-	"os"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/covesa/vissr/utils"
 )
-
-// TestMain initialises utils.Info / utils.Error so the helpers can
-// log without nil-deref under test conditions. We deliberately do
-// NOT set stateDbType here — the empty value falls through to the
-// default arm in setVehicleData/getVehicleData, returning "" without
-// touching the live storage backends. That keeps these tests
-// self-contained and exercises the service_unavailable / empty-data
-// paths.
-func TestMain(m *testing.M) {
-	utils.InitLog("serviceMgr-dispatch-test.log", os.TempDir(), false, "error")
-	os.Exit(m.Run())
-}
 
 // resetErrorResponseMap clears the shared package-level
 // errorResponseMap between tests. The production code mutates it in

--- a/server/vissv2server/serviceMgr/serviceMgr_test.go
+++ b/server/vissv2server/serviceMgr/serviceMgr_test.go
@@ -670,14 +670,6 @@ func TestGetFeederNotifyType(t *testing.T) {
 	}
 }
 
-// --------------------------------------------------------------------------
-// processHistoryCtrl — index -1 fix (#5)
-// --------------------------------------------------------------------------
-
-	if got != "500 Internal Server Error" {
-		t.Errorf("got %q", got)
-	}
-}
 
 func TestProcessHistoryCtrl_UnknownPathReturns404(t *testing.T) {
 	historyList = nil

--- a/server/vissv2server/serviceMgr/serviceMgr_test.go
+++ b/server/vissv2server/serviceMgr/serviceMgr_test.go
@@ -7,7 +7,9 @@ package serviceMgr
 import (
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -279,4 +281,1131 @@ func FuzzProcessHistoryGet(f *testing.F) {
 			t.Fatalf("response contained \"panic\" substring: %q", got)
 		}
 	})
+}
+func resetFeederGlobals() {
+	feederPathList = nil
+	feederSubList = nil
+	feederRegList = nil
+	feederChannelList = make([]FeederChannelElem, MAXFEEDERS)
+}
+
+func resetTickerGlobals() {
+	tickerMu.Lock()
+	for i := range tickerIndexList {
+		tickerIndexList[i] = 0
+	}
+	for i := range subscriptionTicker {
+		subscriptionTicker[i] = nil
+	}
+	for i := range historyTicker {
+		historyTicker[i] = nil
+	}
+	for i := range tickerDone {
+		tickerDone[i] = nil
+	}
+	tickerMu.Unlock()
+}
+
+// --------------------------------------------------------------------------
+// Bug #1 — deleteOnFeederPathList: full rewrite. Was structurally broken.
+// --------------------------------------------------------------------------
+
+func TestDeleteOnFeederPathList_EmptyInputIsNoop(t *testing.T) {
+	resetFeederGlobals()
+	feederPathList = append(feederPathList, FeederPathElem{Path: "A", Reference: 2})
+	out, json := deleteOnFeederPathList(nil)
+	if len(out) != 1 || out[0].Path != "A" || out[0].Reference != 2 {
+		t.Errorf("empty input mutated list: %+v", out)
+	}
+	if json != "" {
+		t.Errorf("expected empty JSON; got %q", json)
+	}
+}
+
+func TestDeleteOnFeederPathList_DecrementsRefAboveOne(t *testing.T) {
+	resetFeederGlobals()
+	feederPathList = []FeederPathElem{{Path: "A", Reference: 3}}
+	out, dropped := deleteOnFeederPathList([]string{"A"})
+	if len(out) != 1 || out[0].Reference != 2 {
+		t.Errorf("ref should drop to 2; got %+v", out)
+	}
+	if dropped != "" {
+		t.Errorf("nothing should be dropped; got %q", dropped)
+	}
+}
+
+func TestDeleteOnFeederPathList_RemovesAtRefOne(t *testing.T) {
+	resetFeederGlobals()
+	feederPathList = []FeederPathElem{
+		{Path: "A", Reference: 1},
+		{Path: "B", Reference: 2},
+	}
+	out, dropped := deleteOnFeederPathList([]string{"A"})
+	if len(out) != 1 || out[0].Path != "B" {
+		t.Fatalf("A should be removed; got %+v", out)
+	}
+	if !strings.Contains(dropped, "A") {
+		t.Errorf("dropped JSON should mention A; got %q", dropped)
+	}
+}
+
+func TestDeleteOnFeederPathList_MultipleRemovalsCorrectIndices(t *testing.T) {
+	// Pre-fix this corrupted the list because the inner loop reset k=0
+	// and used the wrong index space. With this fix multiple removals
+	// in a single call must keep remaining entries intact.
+	resetFeederGlobals()
+	feederPathList = []FeederPathElem{
+		{Path: "A", Reference: 1},
+		{Path: "B", Reference: 1},
+		{Path: "C", Reference: 1},
+		{Path: "D", Reference: 2},
+	}
+	out, _ := deleteOnFeederPathList([]string{"A", "B", "C", "D"})
+	if len(out) != 1 || out[0].Path != "D" || out[0].Reference != 1 {
+		t.Errorf("expected only D remaining with ref=1; got %+v", out)
+	}
+}
+
+func TestDeleteOnFeederPathList_UnknownPathIsNoop(t *testing.T) {
+	resetFeederGlobals()
+	feederPathList = []FeederPathElem{{Path: "A", Reference: 1}}
+	out, dropped := deleteOnFeederPathList([]string{"missing"})
+	if len(out) != 1 || dropped != "" {
+		t.Errorf("unknown path should be noop; got list=%+v, dropped=%q", out, dropped)
+	}
+}
+
+// --------------------------------------------------------------------------
+// addOnFeederPathList — defensive type asserts, empty input, ref increment
+// --------------------------------------------------------------------------
+
+func TestAddOnFeederPathList_NewEntries(t *testing.T) {
+	resetFeederGlobals()
+	out, added := addOnFeederPathList([]interface{}{"A", "B"})
+	if len(out) != 2 {
+		t.Errorf("expected 2 entries; got %+v", out)
+	}
+	if !strings.Contains(added, "A") || !strings.Contains(added, "B") {
+		t.Errorf("added JSON should list both; got %q", added)
+	}
+}
+
+func TestAddOnFeederPathList_IncrementsExistingRef(t *testing.T) {
+	resetFeederGlobals()
+	addOnFeederPathList([]interface{}{"A"})
+	out, added := addOnFeederPathList([]interface{}{"A"})
+	if len(out) != 1 || out[0].Reference != 2 {
+		t.Errorf("ref should be 2 after second add; got %+v", out)
+	}
+	if added != "" {
+		t.Errorf("no new entry added; expected empty JSON; got %q", added)
+	}
+}
+
+func TestAddOnFeederPathList_EmptyInputIsNoop(t *testing.T) {
+	resetFeederGlobals()
+	out, added := addOnFeederPathList(nil)
+	if len(out) != 0 || added != "" {
+		t.Errorf("expected noop; got list=%+v, added=%q", out, added)
+	}
+}
+
+func TestAddOnFeederPathList_NonStringElementSkipped(t *testing.T) {
+	resetFeederGlobals()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("non-string element panicked: %v", r)
+		}
+	}()
+	out, _ := addOnFeederPathList([]interface{}{"A", 42, "B"})
+	if len(out) != 2 {
+		t.Errorf("expected 2 valid entries; got %+v", out)
+	}
+}
+
+// --------------------------------------------------------------------------
+// addOnFeederSubList / deleteOnFeederSubList
+// --------------------------------------------------------------------------
+
+func TestAddOnFeederSubList_DefensiveAssertions(t *testing.T) {
+	resetFeederGlobals()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("non-string element panicked: %v", r)
+		}
+	}()
+	out := addOnFeederSubList("sub-1", "change", []interface{}{"path-a", 42, "path-b"})
+	if len(out) != 1 || len(out[0].Path) != 2 {
+		t.Errorf("expected 1 sub with 2 valid paths; got %+v", out)
+	}
+}
+
+func TestDeleteOnFeederSubList(t *testing.T) {
+	resetFeederGlobals()
+	feederSubList = []FeederSubElem{
+		{SubscriptionId: "1", Path: []string{"A"}},
+		{SubscriptionId: "2", Path: []string{"B"}},
+	}
+	out, removed := deleteOnFeederSubList("1")
+	if len(out) != 1 || out[0].SubscriptionId != "2" {
+		t.Errorf("expected sub-2 remaining; got %+v", out)
+	}
+	if len(removed) != 1 || removed[0] != "A" {
+		t.Errorf("expected removed path [A]; got %v", removed)
+	}
+	// Missing id
+	if _, p := deleteOnFeederSubList("999"); p != nil {
+		t.Errorf("missing id should return nil path; got %v", p)
+	}
+}
+
+// --------------------------------------------------------------------------
+// updateFeederRegList — loop-after-deletion fix (#8)
+// --------------------------------------------------------------------------
+
+func TestUpdateFeederRegList_AppendOnReg(t *testing.T) {
+	resetFeederGlobals()
+	updateFeederRegList(FeederRegElem{Name: "f1", InfoType: "Data", ChannelIndex: -1})
+	if len(feederRegList) != 1 || feederRegList[0].Name != "f1" {
+		t.Errorf("expected one entry; got %+v", feederRegList)
+	}
+}
+
+func TestUpdateFeederRegList_RemovesAllMatchingOnDereg(t *testing.T) {
+	resetFeederGlobals()
+	// Two entries with the same name (best-effort uniqueness only); pre-fix
+	// only the first would be removed.
+	feederRegList = []FeederRegElem{
+		{Name: "f1", InfoType: "Data", ChannelIndex: -1},
+		{Name: "f1", InfoType: "Data", ChannelIndex: -1},
+		{Name: "other", InfoType: "Data", ChannelIndex: -1},
+	}
+	updateFeederRegList(FeederRegElem{Name: "f1", InfoType: "dereg"})
+	if len(feederRegList) != 1 || feederRegList[0].Name != "other" {
+		t.Errorf("expected only 'other' remaining; got %+v", feederRegList)
+	}
+}
+
+// --------------------------------------------------------------------------
+// createFeederNameList — empty-list panic fix (#15)
+// --------------------------------------------------------------------------
+
+func TestCreateFeederNameList_EmptyList(t *testing.T) {
+	resetFeederGlobals()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("empty list panicked: %v", r)
+		}
+	}()
+	got := createFeederNameList()
+	if got.Name != "[]" {
+		t.Errorf("expected '[]'; got %q", got.Name)
+	}
+}
+
+func TestCreateFeederNameList_PopulatedList(t *testing.T) {
+	resetFeederGlobals()
+	feederRegList = []FeederRegElem{
+		{Name: "f1"},
+		{Name: "f2"},
+	}
+	got := createFeederNameList()
+	if !strings.Contains(got.Name, "f1") || !strings.Contains(got.Name, "f2") {
+		t.Errorf("expected both names; got %q", got.Name)
+	}
+	if got.Name[0] != '[' || got.Name[len(got.Name)-1] != ']' {
+		t.Errorf("expected JSON array; got %q", got.Name)
+	}
+}
+
+// --------------------------------------------------------------------------
+// feederNameClash
+// --------------------------------------------------------------------------
+
+func TestFeederNameClash(t *testing.T) {
+	list := []string{"a", "b", "c"}
+	if !feederNameClash(list, "b") {
+		t.Errorf("b should clash")
+	}
+	if feederNameClash(list, "missing") {
+		t.Errorf("missing should not clash")
+	}
+}
+
+// --------------------------------------------------------------------------
+// getFeederChannelIndex / freeFeederChannel
+// --------------------------------------------------------------------------
+
+func TestGetFeederChannelIndex_AllocateAndRelease(t *testing.T) {
+	resetFeederGlobals()
+	idx := getFeederChannelIndex(-1)
+	if idx < 0 {
+		t.Fatalf("first alloc failed; got %d", idx)
+	}
+	if !feederChannelList[idx].Busy {
+		t.Errorf("slot should be marked busy")
+	}
+	freeFeederChannel(idx)
+	if feederChannelList[idx].Busy {
+		t.Errorf("slot should be free after release")
+	}
+}
+
+func TestGetFeederChannelIndex_ReuseExistingIndex(t *testing.T) {
+	resetFeederGlobals()
+	if got := getFeederChannelIndex(3); got != 3 {
+		t.Errorf("expected reuse of provided index; got %d", got)
+	}
+}
+
+func TestGetFeederChannelIndex_AllSlotsBusy(t *testing.T) {
+	resetFeederGlobals()
+	for i := 0; i < MAXFEEDERS; i++ {
+		feederChannelList[i].Busy = true
+	}
+	if got := getFeederChannelIndex(-1); got != -1 {
+		t.Errorf("expected -1 when all busy; got %d", got)
+	}
+}
+
+func TestFreeFeederChannel_OutOfRangeIsSafe(t *testing.T) {
+	resetFeederGlobals()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	freeFeederChannel(-1)
+	freeFeederChannel(9999)
+}
+
+// --------------------------------------------------------------------------
+// getCurveLoggingParams — bufSize fix (#2)
+// --------------------------------------------------------------------------
+
+func TestGetCurveLoggingParams_HappyPath(t *testing.T) {
+	maxErr, bufSize := getCurveLoggingParams(`{"maxerr":"0.5","bufsize":"10"}`)
+	if maxErr != 0.5 || bufSize != 10 {
+		t.Errorf("got %v, %d; want 0.5, 10", maxErr, bufSize)
+	}
+}
+
+func TestGetCurveLoggingParams_BadJSON(t *testing.T) {
+	maxErr, bufSize := getCurveLoggingParams(`not json`)
+	if maxErr != 0.0 || bufSize != 0 {
+		t.Errorf("expected zero values; got %v, %d", maxErr, bufSize)
+	}
+}
+
+func TestGetCurveLoggingParams_BadBufSizeDoesNotZeroMaxErr(t *testing.T) {
+	// Bug-2 fix: previously this zeroed maxErr when bufSize parse failed.
+	maxErr, bufSize := getCurveLoggingParams(`{"maxerr":"0.5","bufsize":"oops"}`)
+	if maxErr != 0.5 {
+		t.Errorf("maxErr should survive bad bufSize parse; got %v", maxErr)
+	}
+	if bufSize < 1 {
+		t.Errorf("bufSize should default to >=1; got %d", bufSize)
+	}
+}
+
+// --------------------------------------------------------------------------
+// getIntervalPeriod — Printf format fix (#25)
+// --------------------------------------------------------------------------
+
+func TestGetIntervalPeriod_HappyPath(t *testing.T) {
+	if got := getIntervalPeriod(`{"period":"100"}`); got != 100 {
+		t.Errorf("got %d; want 100", got)
+	}
+}
+
+func TestGetIntervalPeriod_BadJSON(t *testing.T) {
+	if got := getIntervalPeriod(`not json`); got != -1 {
+		t.Errorf("got %d; want -1", got)
+	}
+}
+
+func TestGetIntervalPeriod_NonNumericPeriod(t *testing.T) {
+	// Pre-fix this triggered a Printf %s with int argument (vet error).
+	if got := getIntervalPeriod(`{"period":"oops"}`); got != -1 {
+		t.Errorf("got %d; want -1", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// createFeederNotifyMessage — empty list panic guard (#13)
+// --------------------------------------------------------------------------
+
+func TestCreateFeederNotifyMessage_EmptyListReturnsEmpty(t *testing.T) {
+	if got := createFeederNotifyMessage("change", nil, 1); got != "" {
+		t.Errorf("expected empty; got %q", got)
+	}
+}
+
+func TestCreateFeederNotifyMessage_HappyPath(t *testing.T) {
+	got := createFeederNotifyMessage("change", []string{"a", "b"}, 7)
+	if !strings.Contains(got, `"variant": "change"`) || !strings.Contains(got, `"subscriptionId": "7"`) {
+		t.Errorf("missing fields: %q", got)
+	}
+	if !strings.Contains(got, `"a"`) || !strings.Contains(got, `"b"`) {
+		t.Errorf("missing paths: %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// getFeederNotifyType
+// --------------------------------------------------------------------------
+
+func TestGetFeederNotifyType(t *testing.T) {
+	if got := getFeederNotifyType([]utils.FilterObject{{Type: "curvelog"}}); got != "curvelog" {
+		t.Errorf("got %q", got)
+	}
+	if got := getFeederNotifyType([]utils.FilterObject{{Type: "change"}}); got != "change" {
+		t.Errorf("got %q", got)
+	}
+	if got := getFeederNotifyType([]utils.FilterObject{{Type: "range"}}); got != "range" {
+		t.Errorf("got %q", got)
+	}
+	if got := getFeederNotifyType([]utils.FilterObject{{Type: "history"}}); got != "" {
+		t.Errorf("got %q; want empty (history is not a feeder notify type)", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// processHistoryCtrl — index -1 fix (#5)
+// --------------------------------------------------------------------------
+
+	if got != "500 Internal Server Error" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestProcessHistoryCtrl_UnknownPathReturns404(t *testing.T) {
+	historyList = nil
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	got := processHistoryCtrl(`{"action":"create","path":"Unknown","buf-size":"5"}`, nil, true)
+	if got != "404 Not Found" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestProcessHistoryCtrl_MissingAction(t *testing.T) {
+	historyList = []HistoryList{{Path: "X"}}
+	got := processHistoryCtrl(`{"path":"X"}`, nil, true)
+	if got != "400 Bad Request" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestProcessHistoryCtrl_CreateThenDelete(t *testing.T) {
+	historyList = []HistoryList{{Path: "X"}}
+	if got := processHistoryCtrl(`{"action":"create","path":"X","buf-size":"5"}`, nil, true); got != "200 OK" {
+		t.Fatalf("create: %q", got)
+	}
+	if historyList[0].BufSize != 5 || len(historyList[0].Buffer) != 5 {
+		t.Errorf("buffer not allocated correctly: %+v", historyList[0])
+	}
+	if got := processHistoryCtrl(`{"action":"delete","path":"X"}`, nil, true); got != "200 OK" {
+		t.Errorf("delete: %q", got)
+	}
+}
+
+func TestProcessHistoryCtrl_BadBufSize(t *testing.T) {
+	historyList = []HistoryList{{Path: "X"}}
+	if got := processHistoryCtrl(`{"action":"create","path":"X","buf-size":"oops"}`, nil, true); got != "400 Bad Request" {
+		t.Errorf("got %q", got)
+	}
+	if got := processHistoryCtrl(`{"action":"create","path":"X","buf-size":"0"}`, nil, true); got != "400 Bad Request" {
+		t.Errorf("zero bufsize should be rejected; got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// getHistoryListIndex
+// --------------------------------------------------------------------------
+
+func TestGetHistoryListIndex(t *testing.T) {
+	historyList = []HistoryList{{Path: "A"}, {Path: "B"}}
+	if got := getHistoryListIndex("B"); got != 1 {
+		t.Errorf("got %d; want 1", got)
+	}
+	if got := getHistoryListIndex("missing"); got != -1 {
+		t.Errorf("got %d; want -1", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// historicDataPack — empty-list / negative-matches guard
+// --------------------------------------------------------------------------
+
+func TestHistoricDataPack_NegativeMatchesIsSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if got := historicDataPack(0, 0); got != "" {
+		t.Errorf("got %q", got)
+	}
+	if got := historicDataPack(-1, 5); got != "" {
+		t.Errorf("got %q", got)
+	}
+	if got := historicDataPack(99, 5); got != "" {
+		t.Errorf("out-of-range index: got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// convertFromIsoTime + processHistoryGet bad-time guard (#6)
+// --------------------------------------------------------------------------
+
+func TestConvertFromIsoTime(t *testing.T) {
+	if _, err := convertFromIsoTime("2026-05-17T12:00:00Z"); err != nil {
+		t.Errorf("happy path: %v", err)
+	}
+	if _, err := convertFromIsoTime("not a time"); err == nil {
+		t.Errorf("expected error on bad input")
+	}
+}
+
+func TestProcessHistoryGet_MissingPathReturnsEmpty(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if got := processHistoryGet(`{}`); got != "" {
+		t.Errorf("missing path: got %q", got)
+	}
+	if got := processHistoryGet(`{"path":42,"period":"2026-05-17T12:00:00Z"}`); got != "" {
+		t.Errorf("non-string path: got %q", got)
+	}
+}
+
+func TestProcessHistoryGet_UnknownPathReturnsEmpty(t *testing.T) {
+	historyList = nil
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	got := processHistoryGet(`{"path":"Unknown","period":"2026-05-17T12:00:00Z"}`)
+	if got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// getSubcriptionStateIndex / setSubscriptionListThreads
+// --------------------------------------------------------------------------
+
+func TestGetSubcriptionStateIndex(t *testing.T) {
+	list := []SubscriptionState{
+		{SubscriptionId: 1},
+		{SubscriptionId: 5},
+	}
+	if got := getSubcriptionStateIndex(5, list); got != 1 {
+		t.Errorf("got %d; want 1", got)
+	}
+	if got := getSubcriptionStateIndex(99, list); got != -1 {
+		t.Errorf("got %d; want -1", got)
+	}
+}
+
+func TestSetSubscriptionListThreads(t *testing.T) {
+	list := []SubscriptionState{
+		{SubscriptionId: 1, SubscriptionThreads: 0},
+	}
+	out := setSubscriptionListThreads(list, SubThreads{SubscriptionId: 1, NumofThreads: 3})
+	if out[0].SubscriptionThreads != 3 {
+		t.Errorf("got %d; want 3", out[0].SubscriptionThreads)
+	}
+}
+
+// --------------------------------------------------------------------------
+// unpackPaths
+// --------------------------------------------------------------------------
+
+func TestUnpackPaths(t *testing.T) {
+	if got := unpackPaths(""); got != nil {
+		t.Errorf("empty should return nil; got %v", got)
+	}
+	got := unpackPaths("single.path")
+	if len(got) != 1 || got[0] != "single.path" {
+		t.Errorf("single path: got %v", got)
+	}
+	got = unpackPaths(`["a","b","c"]`)
+	if len(got) != 3 {
+		t.Errorf("array: got %v", got)
+	}
+	if got := unpackPaths(`["bad`); got != nil {
+		t.Errorf("malformed array should return nil; got %v", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// scanAndRemoveListItem — clean rewrite (#35)
+// --------------------------------------------------------------------------
+
+func TestScanAndRemoveListItem_RemovesFirstMatch(t *testing.T) {
+	list := []SubscriptionState{
+		{SubscriptionId: 1, RouterId: "r1"},
+		{SubscriptionId: 2, RouterId: "r2"},
+		{SubscriptionId: 3, RouterId: "r1"},
+	}
+	removed, out := scanAndRemoveListItem(list, "r1")
+	if !removed {
+		t.Errorf("expected removal")
+	}
+	if len(out) != 2 {
+		t.Errorf("expected 2 remaining; got %d", len(out))
+	}
+}
+
+func TestScanAndRemoveListItem_NoMatch(t *testing.T) {
+	list := []SubscriptionState{{SubscriptionId: 1, RouterId: "r1"}}
+	removed, out := scanAndRemoveListItem(list, "r999")
+	if removed {
+		t.Errorf("no match should return false")
+	}
+	if len(out) != 1 {
+		t.Errorf("list should be unchanged")
+	}
+}
+
+// --------------------------------------------------------------------------
+// getSubscriptionData
+// --------------------------------------------------------------------------
+
+func TestGetSubscriptionData_Found(t *testing.T) {
+	list := []SubscriptionState{
+		{SubscriptionId: 5, RouterId: "r1", GatingId: "g1"},
+	}
+	rid, sid := getSubscriptionData(list, "g1")
+	if rid != "r1" || sid != "5" {
+		t.Errorf("got rid=%q sid=%q; want r1,5", rid, sid)
+	}
+}
+
+func TestGetSubscriptionData_NotFound(t *testing.T) {
+	rid, sid := getSubscriptionData(nil, "g1")
+	if rid != "" || sid != "" {
+		t.Errorf("expected empty; got %q,%q", rid, sid)
+	}
+}
+
+// --------------------------------------------------------------------------
+// decodeFeederMessage — defensive type assertions
+// --------------------------------------------------------------------------
+
+func TestDecodeFeederMessage_HappyPath(t *testing.T) {
+	path, notif := decodeFeederMessage(`{"action":"subscription","path":"Vehicle.Speed"}`, false)
+	if path != "Vehicle.Speed" {
+		t.Errorf("got path=%q", path)
+	}
+	_ = notif
+
+	_, notif = decodeFeederMessage(`{"action":"subscribe","status":"ok"}`, false)
+	if !notif {
+		t.Errorf("subscribe-ok should set notif=true")
+	}
+}
+
+func TestDecodeFeederMessage_MalformedInputDoesNotPanic(t *testing.T) {
+	cases := []string{
+		``,
+		`not json`,
+		`{}`,
+		`{"action":42}`,
+		`{"action":"subscription","path":42}`,
+		`{"action":"subscribe","status":42}`,
+		`{"action":"foo"}`,
+	}
+	for _, in := range cases {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("panicked on %q: %v", in, r)
+				}
+			}()
+			_, _ = decodeFeederMessage(in, false)
+		}()
+	}
+}
+
+// --------------------------------------------------------------------------
+// decodeFeederRegRequest — defensive assertions (#31)
+// --------------------------------------------------------------------------
+
+func TestDecodeFeederRegRequest_HappyPath(t *testing.T) {
+	got := decodeFeederRegRequest([]byte(`{"action":"reg","name":"myfeeder"}`), "1")
+	if got.Name != "myfeeder" || got.InfoType != "Data" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestDecodeFeederRegRequest_Dereg(t *testing.T) {
+	got := decodeFeederRegRequest([]byte(`{"action":"dereg","name":"myfeeder"}`), "1")
+	if got.InfoType != "dereg" || got.Name != "myfeeder" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestDecodeFeederRegRequest_MalformedDoesNotPanic(t *testing.T) {
+	cases := [][]byte{
+		[]byte(``),
+		[]byte(`not json`),
+		[]byte(`{}`),
+		[]byte(`{"action":42,"name":"a"}`),
+		[]byte(`{"action":"reg","name":42}`),
+		[]byte(`{"action":"unknown","name":"a"}`),
+	}
+	for _, in := range cases {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("panicked on %q: %v", in, r)
+				}
+			}()
+			got := decodeFeederRegRequest(in, "1")
+			if got.InfoType != "error" {
+				t.Errorf("expected InfoType=error for %q; got %q", in, got.InfoType)
+			}
+		}()
+	}
+}
+
+// --------------------------------------------------------------------------
+// allocateTicker / deallocateTicker — mutex protection
+// --------------------------------------------------------------------------
+
+func TestTickerAllocate_HappyPath(t *testing.T) {
+	resetTickerGlobals()
+	idx := allocateTicker(42)
+	if idx < 0 {
+		t.Fatalf("expected non-negative index")
+	}
+	if dx := deallocateTicker(42); dx != idx {
+		t.Errorf("deallocate index mismatch: got %d, want %d", dx, idx)
+	}
+}
+
+func TestTickerAllocate_NoFreeSlots(t *testing.T) {
+	resetTickerGlobals()
+	for i := 0; i < MAXTICKERS; i++ {
+		tickerIndexList[i] = i + 1
+	}
+	if got := allocateTicker(99999); got != -1 {
+		t.Errorf("expected -1; got %d", got)
+	}
+}
+
+func TestTickerAllocate_ConcurrentSafe(t *testing.T) {
+	resetTickerGlobals()
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	seen := make(map[int]int)
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			idx := allocateTicker(id)
+			mu.Lock()
+			seen[idx]++
+			mu.Unlock()
+		}(i + 1)
+	}
+	wg.Wait()
+	for idx, count := range seen {
+		if idx == -1 {
+			continue
+		}
+		if count > 1 {
+			t.Errorf("ticker slot %d allocated %d times (race)", idx, count)
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
+// activateInterval / activateHistory — non-positive duration guards
+// --------------------------------------------------------------------------
+
+func TestActivateInterval_ZeroIntervalDoesNotPanic(t *testing.T) {
+	resetTickerGlobals()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("zero interval panicked: %v", r)
+		}
+	}()
+	ch := make(chan int, 1)
+	activateInterval(ch, 1, 0)
+}
+
+func TestActivateHistory_ExtremeFrequencyDoesNotPanic(t *testing.T) {
+	resetTickerGlobals()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("extreme frequency panicked: %v", r)
+		}
+	}()
+	ch := make(chan int, 1)
+	activateHistory(ch, 1, 100_000_000) // 100M cycles/hour → 0ms tick
+}
+
+func TestActivateHistory_ZeroFrequencyRejected(t *testing.T) {
+	resetTickerGlobals()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("zero frequency panicked: %v", r)
+		}
+	}()
+	ch := make(chan int, 1)
+	activateHistory(ch, 1, 0)
+}
+
+func TestActivateInterval_HappyPath(t *testing.T) {
+	resetTickerGlobals()
+	ch := make(chan int, 1)
+	activateInterval(ch, 7, 50)
+	select {
+	case got := <-ch:
+		if got != 7 {
+			t.Errorf("got %d; want 7", got)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Errorf("did not fire in time")
+	}
+	deactivateInterval(7)
+}
+
+// --------------------------------------------------------------------------
+// string2Map
+// --------------------------------------------------------------------------
+
+func TestString2Map(t *testing.T) {
+	got := string2Map(`{"x":"y"}`)
+	if got["s2m"] == nil {
+		t.Fatalf("missing s2m wrapper")
+	}
+	m, ok := got["s2m"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("s2m not a map; got %T", got["s2m"])
+	}
+	if m["x"] != "y" {
+		t.Errorf("got %+v", m)
+	}
+}
+
+// --------------------------------------------------------------------------
+// nonBlockingSend
+// --------------------------------------------------------------------------
+
+func TestNonBlockingSend_DeliversWhenSpace(t *testing.T) {
+	ch := make(chan string, 1)
+	nonBlockingSend(ch, "hello", "test")
+	select {
+	case got := <-ch:
+		if got != "hello" {
+			t.Errorf("got %q", got)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("nothing delivered")
+	}
+}
+
+func TestNonBlockingSend_DropsOnFull(t *testing.T) {
+	ch := make(chan string, 1)
+	ch <- "filler"
+	done := make(chan struct{})
+	go func() {
+		nonBlockingSend(ch, "extra", "test")
+		close(done)
+	}()
+	select {
+	case <-done:
+		// good
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("nonBlockingSend blocked on full channel")
+	}
+}
+
+// --------------------------------------------------------------------------
+// handleToFeederMessage / handleFromFeederMessage — malformed input safety
+// --------------------------------------------------------------------------
+
+func TestHandleToFeederMessage_MalformedDoesNotPanic(t *testing.T) {
+	cases := []string{
+		``,
+		`not json`,
+		`{}`,
+		`{"action":42}`,
+		`{"action":"subscribe"}`,
+		`{"action":"subscribe","subscriptionId":42,"variant":"x","path":[]}`,
+		`{"action":"unsubscribe"}`,
+		`{"action":"unknown"}`,
+	}
+	fromFeederCl := make(chan string, 4)
+	notif := "not-verified"
+	count := 0
+	for _, in := range cases {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("panicked on %q: %v", in, r)
+				}
+			}()
+			handleToFeederMessage(in, fromFeederCl, &notif, &count)
+		}()
+	}
+}
+
+func TestHandleFromFeederMessage_MalformedDoesNotPanic(t *testing.T) {
+	cases := []string{
+		``,
+		`not json`,
+		`{}`,
+		`{"action":42}`,
+		`{"action":"subscribe"}`,
+		`{"action":"subscribe","status":42}`,
+		`{"action":"subscription"}`,
+		`{"action":"subscription","path":42}`,
+		`{"action":"unknown"}`,
+	}
+	rorc := make(chan string, 4)
+	cl := make(chan string, 4)
+	notif := "not-verified"
+	for _, in := range cases {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("panicked on %q: %v", in, r)
+				}
+			}()
+			handleFromFeederMessage(in, rorc, cl, &notif)
+		}()
+	}
+}
+
+func TestHandleFromFeederMessage_SubscribeOkSetsNotification(t *testing.T) {
+	rorc := make(chan string, 4)
+	cl := make(chan string, 4)
+	notif := "not-verified"
+	handleFromFeederMessage(`{"action":"subscribe","status":"ok"}`, rorc, cl, &notif)
+	if notif != "supported" {
+		t.Errorf("got %q; want supported", notif)
+	}
+}
+
+func TestHandleFromFeederMessage_SubscriptionDispatchesByVariant(t *testing.T) {
+	resetFeederGlobals()
+	feederSubList = []FeederSubElem{
+		{SubscriptionId: "1", Variant: "change", Path: []string{"Vehicle.Speed"}},
+	}
+	rorc := make(chan string, 4)
+	cl := make(chan string, 4)
+	notif := "supported"
+	handleFromFeederMessage(`{"action":"subscription","path":"Vehicle.Speed"}`, rorc, cl, &notif)
+	select {
+	case <-rorc:
+		// good
+	case <-time.After(200 * time.Millisecond):
+		t.Errorf("change variant should route to fromFeederRorC")
+	}
+}
+
+// --------------------------------------------------------------------------
+// checkRCFilterAndIssueMessages — empty Path guard (#36)
+// --------------------------------------------------------------------------
+
+func TestCheckRCFilterAndIssueMessages_EmptyPathDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on empty Path: %v", r)
+		}
+	}()
+	list := []SubscriptionState{
+		{SubscriptionId: 1, Path: nil},
+		{SubscriptionId: 2, Path: []string{}},
+	}
+	backendChan := make(chan map[string]interface{}, 1)
+	out := checkRCFilterAndIssueMessages("Vehicle.Speed", list, backendChan)
+	if len(out) != 2 {
+		t.Errorf("entries dropped: got %d; want 2", len(out))
+	}
+}
+
+// --------------------------------------------------------------------------
+// getSubscribeVariant — variants accumulation
+// --------------------------------------------------------------------------
+
+func TestGetSubscribeVariant(t *testing.T) {
+	resetFeederGlobals()
+	feederSubList = []FeederSubElem{
+		{SubscriptionId: "1", Variant: "change", Path: []string{"X"}},
+		{SubscriptionId: "2", Variant: "range", Path: []string{"X"}},
+		{SubscriptionId: "3", Variant: "curvelog", Path: []string{"Y"}},
+	}
+	got := getSubscribeVariant("X")
+	if !strings.Contains(got, "change") || !strings.Contains(got, "range") {
+		t.Errorf("X variants: got %q", got)
+	}
+	if strings.Contains(got, "curvelog") {
+		t.Errorf("curvelog should not appear in X variants: got %q", got)
+	}
+	if got := getSubscribeVariant("Y"); got != "curvelog" {
+		t.Errorf("Y variants: got %q", got)
+	}
+	if got := getSubscribeVariant("missing"); got != "" {
+		t.Errorf("missing path: got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// getDPValue / getDPTs (string helpers for data-point JSON)
+// --------------------------------------------------------------------------
+
+func TestGetDPValue(t *testing.T) {
+	in := `{"value":"42", "ts":"2026-05-17T12:00:00Z"}`
+	if got := getDPValue(in); got != "42" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestGetDPTs(t *testing.T) {
+	in := `{"value":"42", "ts":"2026-05-17T12:00:00Z"}`
+	if got := getDPTs(in); got != "2026-05-17T12:00:00Z" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// captureHistoryValue — round-trip via stateDbType="none" backend
+// --------------------------------------------------------------------------
+
+func TestCaptureHistoryValue_NoneBackend(t *testing.T) {
+	savedDb := stateDbType
+	defer func() { stateDbType = savedDb }()
+	stateDbType = "none"
+	historyList = []HistoryList{{Path: "X", BufSize: 4, Buffer: make([]string, 4)}}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	captureHistoryValue(0)
+	if historyList[0].BufIndex == 0 {
+		t.Errorf("buffer index should have advanced")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Bonus: empty inputs to addOnFeederPathList / deleteOnFeederPathList do
+// not produce malformed JSON like "[]" + closing quote.
+// --------------------------------------------------------------------------
+
+func TestAddOnFeederPathList_NoNewEntriesReturnsEmptyJSON(t *testing.T) {
+	resetFeederGlobals()
+	feederPathList = []FeederPathElem{{Path: "A", Reference: 1}}
+	_, added := addOnFeederPathList([]interface{}{"A"}) // already present, no new
+	if added != "" {
+		t.Errorf("expected empty JSON; got %q", added)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Drive-by smoke: deactivateInterval / deactivateHistory handle missing id.
+// --------------------------------------------------------------------------
+
+func TestDeactivateInterval_UnknownId(t *testing.T) {
+	resetTickerGlobals()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	deactivateInterval(99999)
+}
+
+func TestDeactivateHistory_UnknownId(t *testing.T) {
+	resetTickerGlobals()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	deactivateHistory(99999)
+}
+
+// --------------------------------------------------------------------------
+// removeFromsubscriptionList sanity
+// --------------------------------------------------------------------------
+
+func TestRemoveFromsubscriptionList(t *testing.T) {
+	list := []SubscriptionState{
+		{SubscriptionId: 1},
+		{SubscriptionId: 2},
+		{SubscriptionId: 3},
+	}
+	out := removeFromsubscriptionList(list, 1) // index 1 = subscription 2
+	if len(out) != 2 {
+		t.Errorf("got len=%d; want 2", len(out))
+	}
+	for _, s := range out {
+		if s.SubscriptionId == 2 {
+			t.Errorf("subscription 2 should have been removed: %+v", out)
+			return
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
+// Sanity: subscriptionId monotonic in a single goroutine
+// --------------------------------------------------------------------------
+
+func TestSubscriptionIdMonotonic(t *testing.T) {
+	subscriptionId = 1
+	saved := subscriptionId
+	subscriptionId++
+	if subscriptionId != saved+1 {
+		t.Errorf("monotonic increment failed")
+	}
+}
+
+// --------------------------------------------------------------------------
+// FeederPathElem JSON helpers — verify addOnFeederPathList output round-trips.
+// --------------------------------------------------------------------------
+
+func TestAddOnFeederPathList_OutputIsValidJSON(t *testing.T) {
+	resetFeederGlobals()
+	_, added := addOnFeederPathList([]interface{}{"Vehicle.Speed", "Vehicle.Direction"})
+	// Should be a JSON array like ["Vehicle.Speed", "Vehicle.Direction"]
+	if !strings.HasPrefix(added, `["`) || !strings.HasSuffix(added, `"]`) {
+		t.Errorf("invalid JSON shape: %q", added)
+	}
+	if got := strings.Count(added, `", "`); got != 1 {
+		t.Errorf("expected single separator; got %d in %q", got, added)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Smoke test: createFeederNameList format
+// --------------------------------------------------------------------------
+
+func TestCreateFeederNameList_FormatIsValid(t *testing.T) {
+	resetFeederGlobals()
+	for i := 0; i < 3; i++ {
+		feederRegList = append(feederRegList, FeederRegElem{Name: "f" + strconv.Itoa(i)})
+	}
+	got := createFeederNameList()
+	if !strings.HasPrefix(got.Name, "[") || !strings.HasSuffix(got.Name, "]") {
+		t.Errorf("invalid JSON: %q", got.Name)
+	}
+	for i := 0; i < 3; i++ {
+		if !strings.Contains(got.Name, "f"+strconv.Itoa(i)) {
+			t.Errorf("missing f%d in %q", i, got.Name)
+		}
+	}
 }

--- a/server/vissv2server/serviceMgr/storage_backend.go
+++ b/server/vissv2server/serviceMgr/storage_backend.go
@@ -73,11 +73,15 @@ func (s *sqliteBackend) Get(path string) string {
 		return `{"value":"Data-error", "ts":"` + utils.GetRfcTime() + `"}`
 	}
 	defer rows.Close()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			utils.Warning.Printf("sqliteBackend.Get: rows.Err for path=%s err=%v", path, err)
+		}
+		return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
+	}
 	value := ""
 	timestamp := ""
-	rows.Next()
-	err = rows.Scan(&value, &timestamp)
-	if err != nil {
+	if err := rows.Scan(&value, &timestamp); err != nil {
 		utils.Warning.Printf("Data not found: %s for path=%s", err, path)
 		return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
 	}
@@ -92,7 +96,11 @@ func (s *sqliteBackend) Set(path, value string) string {
 		return ""
 	}
 	defer stmt.Close()
-	_, err = stmt.Exec(value, ts, path[1:len(path)-1]) // remove quotes surrounding path
+	trimmedPath := path
+	if len(path) >= 2 && path[0] == '"' && path[len(path)-1] == '"' {
+		trimmedPath = path[1 : len(path)-1]
+	}
+	_, err = stmt.Exec(value, ts, trimmedPath)
 	if err != nil {
 		utils.Error.Printf("Could not update statestorage, err = %s", err)
 		return ""


### PR DESCRIPTION
Title:
fix(serviceMgr): patch ~25 panics + races + add complete unit tests
Body:
markdown## Summary

`serviceMgr.go` is the central feeder / subscription / history hub. After the recent refactor PRs extracted the per-message handlers, the remaining original logic still had a long list of latent panics, concurrency races, and silent-corruption bugs. This PR fixes them all and adds 77 race-mode-clean unit tests.

## HIGH severity (panic / crash / data corruption)

| Function | Bug |
|---|---|
| `deleteOnFeederPathList` (THE SMOKING GUN) | Inner deletion loop shadowed the outer loop var, reset `k=0` mid-stream, compared input-path indices against `feederPathList` indices, and called `slices.Delete` with the wrong index space. Full rewrite: collect list indices in one pass, then delete in descending order so earlier indices stay valid. |
| `addOnFeederPathList` | `path[i].(string)` bare assertion panicked on non-string elements; empty input produced an invalid JSON accumulator. Now uses comma-ok asserts and returns `""` cleanly when nothing was added. |
| `addOnFeederSubList` | Same pattern — non-string path elements panicked. |
| `decodeFeederRegRequest` / `decodeFeederMessage` / `handleToFeederMessage` / `handleFromFeederMessage` | Dozens of bare `.(string)` / `.([]interface{})` / `.(map[string]interface{})` assertions on attacker-controlled feeder/UDS JSON. Every one is now comma-ok with explicit error logging and an early return. |
| `feederFrontend` pipeline channels (`toFeeder`, `fromFeederRorC`, `fromFeederCl`, `fromFeeders`, per-feeder channels) | All unbuffered. Buffered to 32 and dispatcher sends are now non-blocking via a new `nonBlockingSend` helper, so a slow consumer cannot wedge the whole serviceMgr. |
| `processHistoryCtrl` / `processHistoryGet` | `getHistoryListIndex` returned `-1` for unknown paths and the result was then used to index `historyList[-1]` — guaranteed panic. Both functions now check for `-1` and return `404` / `""`. |
| `processHistoryGet` | `convertFromIsoTime` error was discarded; the zero-time fallthrough produced wildly wrong lookback windows. Now returns `""` on parse failure. |
| `historicDataPack` | `dp[:len(dp)-2]` panicked on empty input. Now guarded by `matches <= 0` and index bounds. |
| `createFeederNameList` | Empty `feederRegList` produced an invalid JSON accumulator that then panicked in the truncation step. Now returns `"[]"` on empty. |
| `createFeederNotifyMessage` | Same shape — empty `pathList` produced invalid JSON. Returns `""` on empty. |
| subscribe arm in `ServiceMgrInit` | Unchecked `.(string)` on every request-map field plus no guard on `len(Path)==0` before `Path[0]`. Both fixed. |
| `checkRCFilterAndIssueMessages` | Same `len(Path)==0` → `Path[0]` panic; now skips degenerate subscriptions. |
| `activateInterval` | `time.NewTicker` panics on `interval <= 0`; was only checked in callers, not here. |
| `activateHistory` | `(3600*1000)/frequency` could divide to `0 ms` for huge frequency values, panicking the ticker. Now checks the resulting duration is `> 0`. |

## Concurrency

| Function | Bug |
|---|---|
| `allocateTicker` / `deallocateTicker` | Added a `sync.Mutex` around the ticker tables. Previously concurrent allocate/deallocate from different goroutines raced. |
| `mcloseClSubId` | Main loop writes `closeClSubId = -1` must hold the mutex (concurrent readers in `clCapture{1,2,3}dim` race). |

## Logic / functional / leak

| Function | Bug |
|---|---|
| `getCurveLoggingParams` | On `bufSize` parse failure the code wrote `maxErr = 0.0` (zeroed the wrong variable). Now defaults `bufSize` to `1` and leaves `maxErr` alone. |
| `updateFeederRegList` | `append(...[:i], ...[i+1:]...)` with `i++` in the for-clause skipped elements shifted into position `i`. Now decrement `i` after deletion. |
| `scanAndRemoveListItem` | Dead `doRemove = false` reset; rewritten to be obviously single-pass. |
| `getVehicleData` (sqlite) | `rows.Next()` return ignored, `rows.Err()` never checked. Now explicit. |
| `setVehicleData` (sqlite) | `path[1:len(path)-1]` panicked on short paths. Now only strips quotes if present. |
| `historyControlServer` | 512-byte read buffer silently truncated long requests; `defer conn.Close` was missing. Now 64 KiB with drop-on-fill and deferred close. |
| `feederConnectRetry` | `break` after first attempt starved later feeders if the first reconnect failed. Drop the break. |
| `decodeFeederRegRequest` `dereg` response | Name was inserted unquoted, producing invalid JSON. |
| `unpackPaths` | Defensive handling of empty input and bad JSON. |
| `dummyTicker` | Previously fired when `stateDbType != "none"`; the documented intent (dummy values only when no real backend) is `stateDbType == "none"`. Inverted the condition. |

## Style / vet

- `getIntervalPeriod` — Printf `%s` for `int period` (go vet error).
- Defensive `len(feederChannelList)` bounds-check in `freeFeederChannel`.

## Test coverage

`serviceMgr_test.go` (new): **77 tests, race-mode clean**. Coverage of every unit-testable function:

- `feederPathList` add/delete with refcount, empty input, non-string element, multiple-removal index correctness.
- `feederSubList` / `feederRegList` add/delete with name uniqueness.
- `createFeederNameList` / `createFeederNotifyMessage` empty-list panic guards.
- `getCurveLoggingParams` / `getIntervalPeriod` with malformed JSON.
- `processHistoryCtrl` every action + unknown path + bad bufSize.
- `processHistoryGet` missing/invalid path + period.
- `historicDataPack` OOB / empty.
- `allocateTicker` / `deallocateTicker` concurrent-safe (50 parallel goroutines) + `activateInterval` / `activateHistory` with non-positive values.
- `decodeFeederMessage` / `decodeFeederRegRequest` / `handleToFeederMessage` / `handleFromFeederMessage` with every malformed-input shape we could think of.
- `nonBlockingSend` deliver + drop.
- `scanAndRemoveListItem`, `getSubscriptionData`, `unpackPaths`, `string2Map`, `getSubscribeVariant`, `captureHistoryValue`.

## Drive-by vet cleanups

Pre-existing failures blocking `go test ./...` on a clean master checkout:

- `curvelog.go:490` — `slices.Delete` return ignored
- `curvelog.go:751` — unreachable code
- `curvelog.go:171` / `172` — JSON tags on unexported fields
- `redisVinFeeder/vin_feeder.go:28` — `fmt.Println` with `%s` directive
- `utils/managerhandlers.go:334` — Printf shape error
- `utils/pbutils.go:32` — Printf shape error

## Test results
$ go vet ./server/vissv2server/serviceMgr/...
(clean)
$ go test -race ./server/vissv2server/serviceMgr/ -count=1
ok  github.com/covesa/vissr/server/vissv2server/serviceMgr 1.448s

77 tests pass, race detector clean.