### PR TITLE
fix(utils/grcputils): patch ~60 panic-on-input bugs + complete unit t…

### DIFF
--- a/utils/grcputils.go
+++ b/utils/grcputils.go
@@ -10,9 +10,80 @@ package utils
 
 import (
 	"encoding/json"
+	"strings"
+
 	pb "github.com/covesa/vissr/grpc_pb"
-//	"strconv"
 )
+
+// -- Defensive helpers --------------------------------------------------
+// Every JSON map access in this file flows through these so a malformed
+// request never panics the gRPC server. Pre-fix, ~60 bare type assertions
+// (e.g. `messageMap["path"].(string)`) panicked on any missing or
+// wrong-typed field, turning malformed input into a crash-DoS.
+
+// mapString returns m[key] as a string. Returns "", false when the key
+// is absent, nil, or the wrong type.
+func mapString(m map[string]interface{}, key string) (string, bool) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
+}
+
+// mapStringOrEmpty is the convenience form for fields where a missing
+// value is equivalent to "".
+func mapStringOrEmpty(m map[string]interface{}, key string) string {
+	s, _ := mapString(m, key)
+	return s
+}
+
+// mapAsMap returns m[key] as a nested map; ok=false on missing or wrong type.
+func mapAsMap(m map[string]interface{}, key string) (map[string]interface{}, bool) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return nil, false
+	}
+	mm, ok := v.(map[string]interface{})
+	return mm, ok
+}
+
+// asMap converts an interface to a map[string]interface{}, ok=false if
+// it's a different type.
+func asMap(v interface{}) (map[string]interface{}, bool) {
+	if v == nil {
+		return nil, false
+	}
+	m, ok := v.(map[string]interface{})
+	return m, ok
+}
+
+// asString converts an interface to a string, ok=false otherwise.
+func asString(v interface{}) (string, bool) {
+	if v == nil {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+// trimTrailingComma returns s with the final byte stripped iff that byte
+// is a ','. The previous code unconditionally did `s[:len(s)-1]` which
+// panicked on an empty accumulator (e.g. an ERROR response with no data
+// fields, or an empty FilterExp slice).
+func trimTrailingComma(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	if s[len(s)-1] == ',' {
+		return s[:len(s)-1]
+	}
+	return s
+}
 
 func GetRequestPbToJson(pbGetReq *pb.GetRequestMessage) string {
 	jsonMessage := populateJsonFromProtoGetReq(pbGetReq)
@@ -157,92 +228,121 @@ func ExtractSubscriptionId(jsonSubResponse string) string {
 		Error.Printf("ExtractSubscriptionId:Unmarshal error response=%s, err=%s", jsonSubResponse, err)
 		return ""
 	}
-	return subResponseMap["subscriptionId"].(string)
+	return mapStringOrEmpty(subResponseMap, "subscriptionId")
+}
+
+// applyFilterFromMessage parses messageMap["filter"] into a *pb.FilterExpressions.
+// Returns nil if no filter is present or the shape is invalid - the caller
+// leaves the proto's Filter field nil.
+func applyFilterFromMessage(messageMap map[string]interface{}) *pb.FilterExpressions {
+	filter, ok := messageMap["filter"]
+	if !ok || filter == nil {
+		return nil
+	}
+	switch vv := filter.(type) {
+	case []interface{}:
+		if len(vv) != 2 {
+			Error.Printf("Max two filter expressions are allowed.")
+			return nil
+		}
+		m0, ok0 := asMap(vv[0])
+		m1, ok1 := asMap(vv[1])
+		if !ok0 || !ok1 {
+			Error.Printf("applyFilterFromMessage: filter array elements must be objects")
+			return nil
+		}
+		out := &pb.FilterExpressions{
+			FilterExp: []*pb.FilterExpressions_FilterExpression{
+				{}, {},
+			},
+		}
+		createPbFilter(0, m0, out)
+		createPbFilter(1, m1, out)
+		return out
+	case map[string]interface{}:
+		out := &pb.FilterExpressions{
+			FilterExp: []*pb.FilterExpressions_FilterExpression{{}},
+		}
+		createPbFilter(0, vv, out)
+		return out
+	default:
+		Info.Println(filter, "is of an unknown type")
+		return nil
+	}
 }
 
 func createGetRequestPb(protoMessage *pb.GetRequestMessage, messageMap map[string]interface{}) {
-	path := messageMap["path"].(string)
-	protoMessage.Path = path
-	if messageMap["filter"] != nil {
-		filter := messageMap["filter"]
-		switch vv := filter.(type) {
-		case []interface{}:
-//			Info.Println(filter, "is an array:, len=", strconv.Itoa(len(vv)))
-			if len(vv) != 2 {
-				Error.Printf("Max two filter expressions are allowed.")
-				break
-			}
-			protoMessage.Filter = &pb.FilterExpressions{}
-			protoMessage.Filter.FilterExp = make([]*pb.FilterExpressions_FilterExpression, 2)
-			protoMessage.Filter.FilterExp[0] = &pb.FilterExpressions_FilterExpression{}
-			protoMessage.Filter.FilterExp[1] = &pb.FilterExpressions_FilterExpression{}
-			createPbFilter(0, vv[0].(map[string]interface{}), protoMessage.Filter)
-			createPbFilter(1, vv[1].(map[string]interface{}), protoMessage.Filter)
-		case map[string]interface{}:
-//			Info.Println(vv, "is a map:")
-			protoMessage.Filter = &pb.FilterExpressions{}
-			protoMessage.Filter.FilterExp = make([]*pb.FilterExpressions_FilterExpression, 1)
-			protoMessage.Filter.FilterExp[0] = &pb.FilterExpressions_FilterExpression{}
-			createPbFilter(0, vv, protoMessage.Filter)
-		default:
-			Info.Println(filter, "is of an unknown type")
-		}
+	if path, ok := mapString(messageMap, "path"); ok {
+		protoMessage.Path = path
 	}
-	if messageMap["authorization"] != nil {
-		auth := messageMap["authorization"].(string)
+	if f := applyFilterFromMessage(messageMap); f != nil {
+		protoMessage.Filter = f
+	}
+	if auth, ok := mapString(messageMap, "authorization"); ok {
 		protoMessage.Authorization = &auth
 	}
-	if messageMap["dc"] != nil {
-		dataCompression := messageMap["dc"].(string)
-		protoMessage.DC = &dataCompression
+	if dc, ok := mapString(messageMap, "dc"); ok {
+		protoMessage.DC = &dc
 	}
-	reqId := messageMap["requestId"].(string)
-	protoMessage.RequestId = reqId
+	if reqId, ok := mapString(messageMap, "requestId"); ok {
+		protoMessage.RequestId = reqId
+	}
 }
 
 func createGetResponsePb(protoMessage *pb.GetResponseMessage, messageMap map[string]interface{}) {
-	requestId := messageMap["requestId"].(string)
-	protoMessage.RequestId = requestId
-	ts := messageMap["ts"].(string)
-	protoMessage.Ts = ts
-	if messageMap["authorization"] != nil {
-		auth := messageMap["authorization"].(string)
+	if reqId, ok := mapString(messageMap, "requestId"); ok {
+		protoMessage.RequestId = reqId
+	}
+	if ts, ok := mapString(messageMap, "ts"); ok {
+		protoMessage.Ts = ts
+	}
+	if auth, ok := mapString(messageMap, "authorization"); ok {
 		protoMessage.Authorization = &auth
 	}
-	if messageMap["error"] == nil {
-		protoMessage.Status = pb.ResponseStatus_SUCCESS
-		protoMessage.SuccessResponse = &pb.GetResponseMessage_SuccessResponseMessage{}
-		numOfDataElements := getNumOfDataElements(messageMap["data"])
-		if numOfDataElements > 0 {
-			protoMessage.SuccessResponse.DataPack = &pb.DataPackages{}
-			protoMessage.SuccessResponse.DataPack.Data = make([]*pb.DataPackages_DataPackage, numOfDataElements)
-			for i := 0; i < numOfDataElements; i++ {
-				protoMessage.SuccessResponse.DataPack.Data[i] = createDataElement(i, messageMap["data"])
+	if errMap, isErr := mapAsMap(messageMap, "error"); isErr {
+		protoMessage.Status = pb.ResponseStatus_ERROR
+		protoMessage.ErrorResponse = getProtoErrorMessage(errMap)
+		return
+	}
+	if _, present := messageMap["error"]; present {
+		// Present but not a map — treat as a generic error to avoid silent success.
+		protoMessage.Status = pb.ResponseStatus_ERROR
+		protoMessage.ErrorResponse = &pb.ErrorResponseMessage{}
+		return
+	}
+	protoMessage.Status = pb.ResponseStatus_SUCCESS
+	protoMessage.SuccessResponse = &pb.GetResponseMessage_SuccessResponseMessage{}
+	numOfDataElements := getNumOfDataElements(messageMap["data"])
+	if numOfDataElements > 0 {
+		protoMessage.SuccessResponse.DataPack = &pb.DataPackages{}
+		protoMessage.SuccessResponse.DataPack.Data = make([]*pb.DataPackages_DataPackage, 0, numOfDataElements)
+		for i := 0; i < numOfDataElements; i++ {
+			if elem := createDataElement(i, messageMap["data"]); elem != nil {
+				protoMessage.SuccessResponse.DataPack.Data = append(protoMessage.SuccessResponse.DataPack.Data, elem)
 			}
-		} else {
-			metadata, _ := json.Marshal(messageMap["metadata"])
-			metadataStr := string(metadata)
-			protoMessage.SuccessResponse.Metadata = &metadataStr
 		}
 	} else {
-		protoMessage.Status = pb.ResponseStatus_ERROR
-		protoMessage.ErrorResponse = getProtoErrorMessage(messageMap["error"].(map[string]interface{}))
+		metadata, _ := json.Marshal(messageMap["metadata"])
+		metadataStr := string(metadata)
+		protoMessage.SuccessResponse.Metadata = &metadataStr
 	}
 }
 
+// getProtoErrorMessage extracts an error sub-message defensively. Non-string
+// field values are skipped rather than panicking.
 func getProtoErrorMessage(messageErrorMap map[string]interface{}) *pb.ErrorResponseMessage {
 	protoErrorMessage := &pb.ErrorResponseMessage{}
-	for k, v := range messageErrorMap {
-//		Info.Println("key=",k, "v=", v)
-		if k == "number" {
-			protoErrorMessage.Number = v.(string)
-		}
-		if k == "reason" {
-			protoErrorMessage.Reason = v.(string)
-		}
-		if k == "description" {
-			protoErrorMessage.Description = v.(string)
-		}
+	if messageErrorMap == nil {
+		return protoErrorMessage
+	}
+	if v, ok := mapString(messageErrorMap, "number"); ok {
+		protoErrorMessage.Number = v
+	}
+	if v, ok := mapString(messageErrorMap, "reason"); ok {
+		protoErrorMessage.Reason = v
+	}
+	if v, ok := mapString(messageErrorMap, "description"); ok {
+		protoErrorMessage.Description = v
 	}
 	return protoErrorMessage
 }
@@ -258,22 +358,39 @@ func getNumOfDataElements(messageDataMap interface{}) int {
 	return 1
 }
 
+// createDataElement extracts the i'th data element from messageDataMap.
+// Returns nil if the input shape is invalid (not an object, missing fields,
+// or wrong types) so a malformed client payload no longer panics.
 func createDataElement(index int, messageDataMap interface{}) *pb.DataPackages_DataPackage {
-
 	var dataObject map[string]interface{}
 	switch vv := messageDataMap.(type) {
 	case []interface{}:
-		dataObject = vv[index].(map[string]interface{})
+		if index < 0 || index >= len(vv) {
+			return nil
+		}
+		m, ok := asMap(vv[index])
+		if !ok {
+			return nil
+		}
+		dataObject = m
 	default:
-		dataObject = vv.(map[string]interface{})
+		m, ok := asMap(vv)
+		if !ok {
+			return nil
+		}
+		dataObject = m
 	}
 	var protoDataElement pb.DataPackages_DataPackage
-	path := dataObject["path"].(string)
-	protoDataElement.Path = path
-	numOfDataPointElements := getNumOfDataPointElements(dataObject["dp"])
-	protoDataElement.Dp = make([]*pb.DataPackages_DataPackage_DataPoint, numOfDataPointElements)
+	if p, ok := mapString(dataObject, "path"); ok {
+		protoDataElement.Path = p
+	}
+	dpRaw := dataObject["dp"]
+	numOfDataPointElements := getNumOfDataPointElements(dpRaw)
+	protoDataElement.Dp = make([]*pb.DataPackages_DataPackage_DataPoint, 0, numOfDataPointElements)
 	for i := 0; i < numOfDataPointElements; i++ {
-		protoDataElement.Dp[i] = createDataPointElement(i, dataObject["dp"])
+		if dp := createDataPointElement(i, dpRaw); dp != nil {
+			protoDataElement.Dp = append(protoDataElement.Dp, dp)
+		}
 	}
 	return &protoDataElement
 }
@@ -289,51 +406,85 @@ func getNumOfDataPointElements(messageDataPointMap interface{}) int {
 	return 1
 }
 
+// createDataPointElement extracts the i'th data-point. Returns nil for any
+// shape mismatch (not an object, missing fields, etc.) so malformed input
+// doesn't panic.
 func createDataPointElement(index int, messageDataPointMap any) *pb.DataPackages_DataPackage_DataPoint {
 	var dataPointObject map[string]any
 	switch vv := messageDataPointMap.(type) {
 	case []any:
-		dataPointObject = vv[index].(map[string]any)
+		if index < 0 || index >= len(vv) {
+			return nil
+		}
+		m, ok := asMap(vv[index])
+		if !ok {
+			return nil
+		}
+		dataPointObject = m
 	default:
-		dataPointObject = vv.(map[string]any)
+		m, ok := asMap(vv)
+		if !ok {
+			return nil
+		}
+		dataPointObject = m
 	}
 	var protoDataPointElement pb.DataPackages_DataPackage_DataPoint
-	protoDataPointElement.Value = dataPointObject["value"].(string)
-	ts := dataPointObject["ts"].(string)
-	protoDataPointElement.Ts = ts
+	if v, ok := mapString(dataPointObject, "value"); ok {
+		protoDataPointElement.Value = v
+	}
+	if ts, ok := mapString(dataPointObject, "ts"); ok {
+		protoDataPointElement.Ts = ts
+	}
 	return &protoDataPointElement
 }
 
+// createPbFilter populates filter.FilterExp[index] from a JSON filter
+// expression. Defensive: invalid variant or wrong-typed parameter logs
+// and leaves the entry's Value sub-fields nil rather than panicking.
 func createPbFilter(index int, filterExpression map[string]interface{}, filter *pb.FilterExpressions) {
-	filterVariant := getFilterVariant(filterExpression["variant"].(string))
+	if index < 0 || index >= len(filter.FilterExp) {
+		return
+	}
+	variantStr, ok := mapString(filterExpression, "variant")
+	if !ok {
+		Error.Printf("createPbFilter: missing/invalid variant field")
+		return
+	}
+	filterVariant := getFilterVariant(variantStr)
 	filter.FilterExp[index].Variant = filterVariant
 	filter.FilterExp[index].Value = &pb.FilterExpressions_FilterExpression_FilterValue{}
+	parameter := filterExpression["parameter"]
 	switch filterVariant {
 	case pb.FilterExpressions_FilterExpression_PATHS:
-		filter.FilterExp[index].Value.ValuePaths = &pb.FilterExpressions_FilterExpression_FilterValue_PathsValue{}
-		filter.FilterExp[index].Value.ValuePaths = getPbPathsFilterValue(filterExpression["parameter"])
+		filter.FilterExp[index].Value.ValuePaths = getPbPathsFilterValue(parameter)
 	case pb.FilterExpressions_FilterExpression_TIMEBASED:
-		filter.FilterExp[index].Value.ValueTimebased = &pb.FilterExpressions_FilterExpression_FilterValue_TimebasedValue{}
-		filter.FilterExp[index].Value.ValueTimebased = getPbTimebasedFilterValue(filterExpression["parameter"].(map[string]interface{}))
+		if m, ok := asMap(parameter); ok {
+			filter.FilterExp[index].Value.ValueTimebased = getPbTimebasedFilterValue(m)
+		}
 	case pb.FilterExpressions_FilterExpression_RANGE:
-		rangeLen := getNumOfRangeExpressions(filterExpression["parameter"])
-		filter.FilterExp[index].Value.ValueRange = make([]*pb.FilterExpressions_FilterExpression_FilterValue_RangeValue, rangeLen)
+		rangeLen := getNumOfRangeExpressions(parameter)
+		filter.FilterExp[index].Value.ValueRange = make([]*pb.FilterExpressions_FilterExpression_FilterValue_RangeValue, 0, rangeLen)
 		for i := 0; i < rangeLen; i++ {
-			filter.FilterExp[index].Value.ValueRange[i] = getPbRangeFilterValue(i, filterExpression["parameter"])
+			if rv := getPbRangeFilterValue(i, parameter); rv != nil {
+				filter.FilterExp[index].Value.ValueRange = append(filter.FilterExp[index].Value.ValueRange, rv)
+			}
 		}
 	case pb.FilterExpressions_FilterExpression_CHANGE:
-		filter.FilterExp[index].Value.ValueChange = &pb.FilterExpressions_FilterExpression_FilterValue_ChangeValue{}
-		filter.FilterExp[index].Value.ValueChange = getPbChangeFilterValue(filterExpression["parameter"].(map[string]interface{}))
+		if m, ok := asMap(parameter); ok {
+			filter.FilterExp[index].Value.ValueChange = getPbChangeFilterValue(m)
+		}
 	case pb.FilterExpressions_FilterExpression_CURVELOG:
-		filter.FilterExp[index].Value.ValueCurvelog = &pb.FilterExpressions_FilterExpression_FilterValue_CurvelogValue{}
-		filter.FilterExp[index].Value.ValueCurvelog = getPbCurvelogFilterValue(filterExpression["parameter"].(map[string]interface{}))
+		if m, ok := asMap(parameter); ok {
+			filter.FilterExp[index].Value.ValueCurvelog = getPbCurvelogFilterValue(m)
+		}
 	case pb.FilterExpressions_FilterExpression_HISTORY:
-		filter.FilterExp[index].Value.ValueHistory = &pb.FilterExpressions_FilterExpression_FilterValue_HistoryValue{}
-		filter.FilterExp[index].Value.ValueHistory.TimePeriod = filterExpression["parameter"].(string)
+		if period, ok := asString(parameter); ok {
+			filter.FilterExp[index].Value.ValueHistory = &pb.FilterExpressions_FilterExpression_FilterValue_HistoryValue{TimePeriod: period}
+		}
 	case pb.FilterExpressions_FilterExpression_METADATA:
 		Warning.Printf("Filter variant is not supported by protobuf encoding.")
 	default:
-		Error.Printf("Filter variant is unknown.")
+		Error.Printf("Filter variant is unknown: %q", variantStr)
 	}
 }
 
@@ -350,15 +501,17 @@ func getPbPathsFilterValue(filterValueExpression interface{}) *pb.FilterExpressi
 	var protoPathsValue pb.FilterExpressions_FilterExpression_FilterValue_PathsValue
 	switch vv := filterValueExpression.(type) {
 	case []interface{}:
-//		Info.Println(filterValueExpression, "is a string array:, len=", strconv.Itoa(len(vv)))
-		protoPathsValue.RelativePath = make([]string, len(vv))
+		protoPathsValue.RelativePath = make([]string, 0, len(vv))
 		for i := 0; i < len(vv); i++ {
-			protoPathsValue.RelativePath[i] = vv[i].(string)
+			s, ok := asString(vv[i])
+			if !ok {
+				Error.Printf("getPbPathsFilterValue: element %d not a string", i)
+				continue
+			}
+			protoPathsValue.RelativePath = append(protoPathsValue.RelativePath, s)
 		}
 	case string:
-//		Info.Println(filterValueExpression, "is a string:")
-		protoPathsValue.RelativePath = make([]string, 1)
-		protoPathsValue.RelativePath[0] = vv
+		protoPathsValue.RelativePath = []string{vv}
 	default:
 		Info.Println(filterValueExpression, "is of an unknown type")
 	}
@@ -366,39 +519,51 @@ func getPbPathsFilterValue(filterValueExpression interface{}) *pb.FilterExpressi
 }
 
 func getPbTimebasedFilterValue(filterExpression map[string]interface{}) *pb.FilterExpressions_FilterExpression_FilterValue_TimebasedValue {
-	var protoTimebasedValue pb.FilterExpressions_FilterExpression_FilterValue_TimebasedValue
-	protoTimebasedValue.Period = filterExpression["period"].(string)
-	return &protoTimebasedValue
+	period, _ := mapString(filterExpression, "period")
+	return &pb.FilterExpressions_FilterExpression_FilterValue_TimebasedValue{Period: period}
 }
 
 func getPbRangeFilterValue(index int, valueMap interface{}) *pb.FilterExpressions_FilterExpression_FilterValue_RangeValue {
-	var protoRangeValue pb.FilterExpressions_FilterExpression_FilterValue_RangeValue
+	var rangeObject map[string]interface{}
 	switch vv := valueMap.(type) {
 	case []interface{}:
-		rangeObject := vv[index].(map[string]interface{})
-		protoRangeValue.LogicOperator = rangeObject["logic-op"].(string)
-		protoRangeValue.Boundary = rangeObject["boundary"].(string)
+		if index < 0 || index >= len(vv) {
+			return nil
+		}
+		m, ok := asMap(vv[index])
+		if !ok {
+			return nil
+		}
+		rangeObject = m
 	case map[string]interface{}:
-		protoRangeValue.LogicOperator = vv["logic-op"].(string)
-		protoRangeValue.Boundary = vv["boundary"].(string)
+		rangeObject = vv
 	default:
 		return nil
 	}
-	return &protoRangeValue
+	logicOp, _ := mapString(rangeObject, "logic-op")
+	boundary, _ := mapString(rangeObject, "boundary")
+	return &pb.FilterExpressions_FilterExpression_FilterValue_RangeValue{
+		LogicOperator: logicOp,
+		Boundary:      boundary,
+	}
 }
 
 func getPbChangeFilterValue(filterExpression map[string]interface{}) *pb.FilterExpressions_FilterExpression_FilterValue_ChangeValue {
-	var protoChangeValue pb.FilterExpressions_FilterExpression_FilterValue_ChangeValue
-	protoChangeValue.LogicOperator = filterExpression["logic-op"].(string)
-	protoChangeValue.Diff = filterExpression["diff"].(string)
-	return &protoChangeValue
+	logicOp, _ := mapString(filterExpression, "logic-op")
+	diff, _ := mapString(filterExpression, "diff")
+	return &pb.FilterExpressions_FilterExpression_FilterValue_ChangeValue{
+		LogicOperator: logicOp,
+		Diff:          diff,
+	}
 }
 
 func getPbCurvelogFilterValue(filterExpression map[string]interface{}) *pb.FilterExpressions_FilterExpression_FilterValue_CurvelogValue {
-	var protoCurvelogValue pb.FilterExpressions_FilterExpression_FilterValue_CurvelogValue
-	protoCurvelogValue.MaxErr = filterExpression["maxerr"].(string)
-	protoCurvelogValue.BufSize = filterExpression["bufsize"].(string)
-	return &protoCurvelogValue
+	maxErr, _ := mapString(filterExpression, "maxerr")
+	bufSize, _ := mapString(filterExpression, "bufsize")
+	return &pb.FilterExpressions_FilterExpression_FilterValue_CurvelogValue{
+		MaxErr:  maxErr,
+		BufSize: bufSize,
+	}
 }
 
 func getFilterVariant(filterVariant string) pb.FilterExpressions_FilterExpression_FilterVariant {
@@ -422,128 +587,144 @@ func getFilterVariant(filterVariant string) pb.FilterExpressions_FilterExpressio
 }
 
 func createSubscribeRequestPb(protoMessage *pb.SubscribeRequestMessage, messageMap map[string]interface{}) {
-	protoMessage.Path = messageMap["path"].(string)
-	if messageMap["filter"] != nil {
-		filter := messageMap["filter"]
-		switch vv := filter.(type) {
-		case []interface{}:
-//			Info.Println(filter, "is an array:, len=", strconv.Itoa(len(vv)))
-			if len(vv) != 2 {
-				Error.Printf("Max two filter expressions are allowed.")
-				break
-			}
-			protoMessage.Filter = &pb.FilterExpressions{}
-			protoMessage.Filter.FilterExp = make([]*pb.FilterExpressions_FilterExpression, 2)
-			protoMessage.Filter.FilterExp[0] = &pb.FilterExpressions_FilterExpression{}
-			protoMessage.Filter.FilterExp[1] = &pb.FilterExpressions_FilterExpression{}
-			createPbFilter(0, vv[0].(map[string]interface{}), protoMessage.Filter)
-			createPbFilter(1, vv[1].(map[string]interface{}), protoMessage.Filter)
-		case map[string]interface{}:
-//			Info.Println(filter, "is a map:")
-			protoMessage.Filter = &pb.FilterExpressions{}
-			protoMessage.Filter.FilterExp = make([]*pb.FilterExpressions_FilterExpression, 1)
-			protoMessage.Filter.FilterExp[0] = &pb.FilterExpressions_FilterExpression{}
-			createPbFilter(0, vv, protoMessage.Filter)
-		default:
-			Info.Println(filter, "is of an unknown type")
-		}
+	if path, ok := mapString(messageMap, "path"); ok {
+		protoMessage.Path = path
 	}
-	if messageMap["authorization"] != nil {
-		auth := messageMap["authorization"].(string)
+	if f := applyFilterFromMessage(messageMap); f != nil {
+		protoMessage.Filter = f
+	}
+	if auth, ok := mapString(messageMap, "authorization"); ok {
 		protoMessage.Authorization = &auth
 	}
-	if messageMap["dc"] != nil {
-		dataCompression := messageMap["dc"].(string)
-		protoMessage.DC = &dataCompression
+	if dc, ok := mapString(messageMap, "dc"); ok {
+		protoMessage.DC = &dc
 	}
-	reqId := messageMap["requestId"].(string)
-	protoMessage.RequestId = reqId
+	if reqId, ok := mapString(messageMap, "requestId"); ok {
+		protoMessage.RequestId = reqId
+	}
 }
 
 func createSubscribeStreamPb(protoMessage *pb.SubscribeStreamMessage, messageMap map[string]interface{}) {
-	if messageMap["action"] == "subscribe" { // RESPONSE
+	action, _ := mapString(messageMap, "action")
+	errMap, isErr := mapAsMap(messageMap, "error")
+	_, errPresent := messageMap["error"]
+	if action == "subscribe" { // RESPONSE
 		protoMessage.MType = pb.SubscribeResponseType_SUB_RESPONSE
 		protoMessage.Response = &pb.SubscribeStreamMessage_SubscribeResponseMessage{}
-		protoMessage.Response.RequestId = messageMap["requestId"].(string)
-		protoMessage.Response.Ts = messageMap["ts"].(string)
-		if messageMap["authorization"] != nil {
-			auth := messageMap["authorization"].(string)
+		if reqId, ok := mapString(messageMap, "requestId"); ok {
+			protoMessage.Response.RequestId = reqId
+		}
+		if ts, ok := mapString(messageMap, "ts"); ok {
+			protoMessage.Response.Ts = ts
+		}
+		if auth, ok := mapString(messageMap, "authorization"); ok {
 			protoMessage.Response.Authorization = &auth
 		}
-		if messageMap["error"] == nil {
-			if messageMap["subscriptionId"] != nil {
-				subId := messageMap["subscriptionId"].(string)
+		if !errPresent {
+			if subId, ok := mapString(messageMap, "subscriptionId"); ok {
 				protoMessage.Response.SubscriptionId = &subId
 			}
 			protoMessage.Status = pb.ResponseStatus_SUCCESS
 		} else {
 			protoMessage.Status = pb.ResponseStatus_ERROR
-			protoMessage.Response.ErrorResponse = getProtoErrorMessage(messageMap["error"].(map[string]interface{}))
-		}
-	} else { //EVENT
-		protoMessage.MType = pb.SubscribeResponseType_SUB_EVENT
-		protoMessage.Event = &pb.SubscribeStreamMessage_SubscribeEventMessage{}
-		protoMessage.Event.SubscriptionId = messageMap["subscriptionId"].(string)
-		ts := messageMap["ts"].(string)
-		protoMessage.Event.Ts = ts
-		if messageMap["error"] == nil {
-			protoMessage.Status = pb.ResponseStatus_SUCCESS
-			protoMessage.Event.SuccessResponse = &pb.SubscribeStreamMessage_SubscribeEventMessage_SuccessResponseMessage{}
-			numOfDataElements := getNumOfDataElements(messageMap["data"])
-			protoMessage.Event.SuccessResponse.DataPack = &pb.DataPackages{}
-			protoMessage.Event.SuccessResponse.DataPack.Data = make([]*pb.DataPackages_DataPackage, numOfDataElements)
-			for i := 0; i < numOfDataElements; i++ {
-				protoMessage.Event.SuccessResponse.DataPack.Data[i] = createDataElement(i, messageMap["data"])
+			if isErr {
+				protoMessage.Response.ErrorResponse = getProtoErrorMessage(errMap)
+			} else {
+				protoMessage.Response.ErrorResponse = &pb.ErrorResponseMessage{}
 			}
+		}
+		return
+	}
+	// EVENT
+	protoMessage.MType = pb.SubscribeResponseType_SUB_EVENT
+	protoMessage.Event = &pb.SubscribeStreamMessage_SubscribeEventMessage{}
+	if subId, ok := mapString(messageMap, "subscriptionId"); ok {
+		protoMessage.Event.SubscriptionId = subId
+	}
+	if ts, ok := mapString(messageMap, "ts"); ok {
+		protoMessage.Event.Ts = ts
+	}
+	if !errPresent {
+		protoMessage.Status = pb.ResponseStatus_SUCCESS
+		protoMessage.Event.SuccessResponse = &pb.SubscribeStreamMessage_SubscribeEventMessage_SuccessResponseMessage{}
+		numOfDataElements := getNumOfDataElements(messageMap["data"])
+		protoMessage.Event.SuccessResponse.DataPack = &pb.DataPackages{}
+		protoMessage.Event.SuccessResponse.DataPack.Data = make([]*pb.DataPackages_DataPackage, 0, numOfDataElements)
+		for i := 0; i < numOfDataElements; i++ {
+			if elem := createDataElement(i, messageMap["data"]); elem != nil {
+				protoMessage.Event.SuccessResponse.DataPack.Data = append(protoMessage.Event.SuccessResponse.DataPack.Data, elem)
+			}
+		}
+	} else {
+		protoMessage.Status = pb.ResponseStatus_ERROR
+		if isErr {
+			protoMessage.Event.ErrorResponse = getProtoErrorMessage(errMap)
 		} else {
-			protoMessage.Status = pb.ResponseStatus_ERROR
-			protoMessage.Event.ErrorResponse = getProtoErrorMessage(messageMap["error"].(map[string]interface{}))
+			protoMessage.Event.ErrorResponse = &pb.ErrorResponseMessage{}
 		}
 	}
 }
 
 func createSetRequestPb(protoMessage *pb.SetRequestMessage, messageMap map[string]interface{}) {
-	protoMessage.Path = messageMap["path"].(string)
-	protoMessage.Value = messageMap["value"].(string)
-	if messageMap["authorization"] != nil {
-		auth := messageMap["authorization"].(string)
+	if path, ok := mapString(messageMap, "path"); ok {
+		protoMessage.Path = path
+	}
+	if val, ok := mapString(messageMap, "value"); ok {
+		protoMessage.Value = val
+	}
+	if auth, ok := mapString(messageMap, "authorization"); ok {
 		protoMessage.Authorization = &auth
 	}
-	reqId := messageMap["requestId"].(string)
-	protoMessage.RequestId = reqId
+	if reqId, ok := mapString(messageMap, "requestId"); ok {
+		protoMessage.RequestId = reqId
+	}
 }
 
 func createSetResponsePb(protoMessage *pb.SetResponseMessage, messageMap map[string]interface{}) {
-	requestId := messageMap["requestId"].(string)
-	protoMessage.RequestId = requestId
-	protoMessage.Ts = messageMap["ts"].(string)
-	if messageMap["authorization"] != nil {
-		auth := messageMap["authorization"].(string)
+	if reqId, ok := mapString(messageMap, "requestId"); ok {
+		protoMessage.RequestId = reqId
+	}
+	if ts, ok := mapString(messageMap, "ts"); ok {
+		protoMessage.Ts = ts
+	}
+	if auth, ok := mapString(messageMap, "authorization"); ok {
 		protoMessage.Authorization = &auth
 	}
-	if messageMap["error"] == nil {
-		protoMessage.Status = pb.ResponseStatus_SUCCESS
-	} else {
+	if errMap, isErr := mapAsMap(messageMap, "error"); isErr {
 		protoMessage.Status = pb.ResponseStatus_ERROR
-		protoMessage.ErrorResponse = getProtoErrorMessage(messageMap["error"].(map[string]interface{}))
+		protoMessage.ErrorResponse = getProtoErrorMessage(errMap)
+	} else if _, present := messageMap["error"]; present {
+		protoMessage.Status = pb.ResponseStatus_ERROR
+		protoMessage.ErrorResponse = &pb.ErrorResponseMessage{}
+	} else {
+		protoMessage.Status = pb.ResponseStatus_SUCCESS
 	}
 }
 
 func createUnsubscribeRequestPb(protoMessage *pb.UnsubscribeRequestMessage, messageMap map[string]interface{}) {
-	protoMessage.SubscriptionId = messageMap["subscriptionId"].(string)
-	reqId := messageMap["requestId"].(string)
-	protoMessage.RequestId = reqId
+	if subId, ok := mapString(messageMap, "subscriptionId"); ok {
+		protoMessage.SubscriptionId = subId
+	}
+	if reqId, ok := mapString(messageMap, "requestId"); ok {
+		protoMessage.RequestId = reqId
+	}
 }
 
 func createUnsubscribeResponsePb(protoMessage *pb.UnsubscribeResponseMessage, messageMap map[string]interface{}) {
-	reqId := messageMap["requestId"].(string)
-	protoMessage.RequestId = reqId
-	protoMessage.Ts = messageMap["ts"].(string)
-	if messageMap["error"] == nil {
-		protoMessage.Status = pb.ResponseStatus_SUCCESS
-	} else {
+	if reqId, ok := mapString(messageMap, "requestId"); ok {
+		protoMessage.RequestId = reqId
+	}
+	if ts, ok := mapString(messageMap, "ts"); ok {
+		protoMessage.Ts = ts
+	}
+	if errMap, isErr := mapAsMap(messageMap, "error"); isErr {
 		protoMessage.Status = pb.ResponseStatus_ERROR
-		protoMessage.ErrorResponse = getProtoErrorMessage(messageMap["error"].(map[string]interface{}))
+		protoMessage.ErrorResponse = getProtoErrorMessage(errMap)
+	} else if _, present := messageMap["error"]; present {
+		protoMessage.Status = pb.ResponseStatus_ERROR
+		protoMessage.ErrorResponse = &pb.ErrorResponseMessage{}
+	} else {
+		protoMessage.Status = pb.ResponseStatus_SUCCESS
 	}
 }
 
@@ -561,8 +742,14 @@ func populateJsonFromProtoGetResp(protoMessage *pb.GetResponseMessage) string {
 	jsonMessage := "{"
 	jsonMessage += `"action":"get"`
 	if protoMessage.GetStatus() == 0 { //SUCCESSFUL
-		jsonMessage += createJsonData(protoMessage.SuccessResponse.GetDataPack().GetData())
-
+		// Defensive: SuccessResponse may be nil for a metadata-only response,
+		// or if the proto was incompletely populated. GetDataPack() / GetData()
+		// are nil-safe but only when SuccessResponse itself is non-nil.
+		var data []*pb.DataPackages_DataPackage
+		if sr := protoMessage.GetSuccessResponse(); sr != nil {
+			data = sr.GetDataPack().GetData()
+		}
+		jsonMessage += createJsonData(data)
 	} else { // ERROR
 		jsonMessage += getJsonError(protoMessage.GetErrorResponse())
 	}
@@ -602,19 +789,50 @@ func populateJsonFromProtoSubscribeStream(protoMessage *pb.SubscribeStreamMessag
 	switch protoMessage.GetMType() {
 	case pb.SubscribeResponseType_SUB_RESPONSE:
 		jsonMessage += `"action":"subscribe"`
+		// Defensive: Response sub-message may be nil if the proto was
+		// incompletely populated.
+		resp := protoMessage.GetResponse()
 		if protoMessage.GetStatus() != 0 { //ERROR
-			jsonMessage += getJsonError(protoMessage.Response.GetErrorResponse())
+			var errResp *pb.ErrorResponseMessage
+			if resp != nil {
+				errResp = resp.GetErrorResponse()
+			}
+			jsonMessage += getJsonError(errResp)
 		}
-		jsonMessage += `,"ts":"` + protoMessage.Response.GetTs() + `"` + createJSON(protoMessage.Response.GetSubscriptionId(), "subscriptionId") +
-			createJSON(protoMessage.Response.GetRequestId(), "requestId") + createJSON(protoMessage.Response.GetAuthorization(), "authorization")
+		var ts, subId, reqId, auth string
+		if resp != nil {
+			ts = resp.GetTs()
+			subId = resp.GetSubscriptionId()
+			reqId = resp.GetRequestId()
+			auth = resp.GetAuthorization()
+		}
+		jsonMessage += `,"ts":"` + ts + `"` + createJSON(subId, "subscriptionId") +
+			createJSON(reqId, "requestId") + createJSON(auth, "authorization")
 	case pb.SubscribeResponseType_SUB_EVENT:
 		jsonMessage += `"action":"subscription"`
+		// Defensive: Event sub-message may be nil.
+		ev := protoMessage.GetEvent()
 		if protoMessage.GetStatus() == 0 { //SUCCESSFUL
-			jsonMessage += createJsonData(protoMessage.Event.SuccessResponse.GetDataPack().GetData())
+			var data []*pb.DataPackages_DataPackage
+			if ev != nil {
+				if sr := ev.GetSuccessResponse(); sr != nil {
+					data = sr.GetDataPack().GetData()
+				}
+			}
+			jsonMessage += createJsonData(data)
 		} else { // ERROR
-			jsonMessage += getJsonError(protoMessage.Event.GetErrorResponse())
+			var errResp *pb.ErrorResponseMessage
+			if ev != nil {
+				errResp = ev.GetErrorResponse()
+			}
+			jsonMessage += getJsonError(errResp)
 		}
-		jsonMessage += `,"ts":"` + protoMessage.Event.GetTs() + `"` + createJSON(protoMessage.Event.GetSubscriptionId(), "subscriptionId")
+		var ts, subId string
+		if ev != nil {
+			ts = ev.GetTs()
+			subId = ev.GetSubscriptionId()
+		}
+		jsonMessage += `,"ts":"` + ts + `"` + createJSON(subId, "subscriptionId")
 	}
 	return jsonMessage + "}"
 }
@@ -637,11 +855,13 @@ func populateJsonFromProtoUnsubscribeResp(protoMessage *pb.UnsubscribeResponseMe
 }
 
 func getJsonFilter(filter *pb.FilterExpressions) string {
-	var filterExp []*pb.FilterExpressions_FilterExpression
 	if filter == nil {
 		return ""
 	}
-	filterExp = filter.GetFilterExp()
+	filterExp := filter.GetFilterExp()
+	if len(filterExp) == 0 {
+		return ""
+	}
 	jsonFilter := ""
 	if len(filterExp) > 1 {
 		jsonFilter = "["
@@ -649,7 +869,7 @@ func getJsonFilter(filter *pb.FilterExpressions) string {
 	for i := 0; i < len(filterExp); i++ {
 		jsonFilter += synthesizeFilter(filterExp[i]) + ","
 	}
-	jsonFilter = jsonFilter[:len(jsonFilter)-1]
+	jsonFilter = trimTrailingComma(jsonFilter)
 	if len(filterExp) > 1 {
 		jsonFilter += "]"
 	}
@@ -687,14 +907,17 @@ func synthesizeFilter(filterExp *pb.FilterExpressions_FilterExpression) string {
 
 func getJsonFilterValuePaths(filterExp *pb.FilterExpressions_FilterExpression) string {
 	relativePaths := filterExp.GetValue().GetValuePaths().GetRelativePath()
+	if len(relativePaths) == 0 {
+		return `""`
+	}
 	value := ""
 	if len(relativePaths) > 1 {
 		value = "["
 	}
 	for i := 0; i < len(relativePaths); i++ {
-		value += `"` + relativePaths[i] + `",`
+		value += `"` + jsonEscape(relativePaths[i]) + `",`
 	}
-	value = value[:len(value)-1]
+	value = trimTrailingComma(value)
 	if len(relativePaths) > 1 {
 		value += "]"
 	}
@@ -708,6 +931,9 @@ func getJsonFilterValueTimebased(filterExp *pb.FilterExpressions_FilterExpressio
 
 func getJsonFilterValueRange(filterExp *pb.FilterExpressions_FilterExpression) string {
 	rangeValue := filterExp.GetValue().GetValueRange()
+	if len(rangeValue) == 0 {
+		return `{}`
+	}
 	value := ""
 	if len(rangeValue) > 1 {
 		value = "["
@@ -715,9 +941,9 @@ func getJsonFilterValueRange(filterExp *pb.FilterExpressions_FilterExpression) s
 	for i := 0; i < len(rangeValue); i++ {
 		logicOperator := rangeValue[i].GetLogicOperator()
 		boundary := rangeValue[i].GetBoundary()
-		value += `{"logic-op":"` + logicOperator + `","boundary":"` + boundary + `"},`
+		value += `{"logic-op":"` + jsonEscape(logicOperator) + `","boundary":"` + jsonEscape(boundary) + `"},`
 	}
-	value = value[:len(value)-1]
+	value = trimTrailingComma(value)
 	if len(rangeValue) > 1 {
 		value += "]"
 	}
@@ -754,17 +980,23 @@ func createJSON(value string, key string) string {
 }
 
 func createJsonData(dataPack []*pb.DataPackages_DataPackage) string {
+	// Defensive: empty dataPack must not produce malformed JSON.
+	if len(dataPack) == 0 {
+		return ""
+	}
 	data := ""
 	if len(dataPack) > 1 {
 		data += "["
 	}
 	for i := 0; i < len(dataPack); i++ {
-		var path string
-		path = dataPack[i].GetPath()
+		if dataPack[i] == nil {
+			continue
+		}
+		path := dataPack[i].GetPath()
 		dp := getJsonDp(dataPack[i])
-		data += `{"path":"` + path + `","dp":` + dp + `},`
+		data += `{"path":"` + jsonEscape(path) + `","dp":` + dp + `},`
 	}
-	data = data[:len(data)-1]
+	data = trimTrailingComma(data)
 	if len(dataPack) > 1 {
 		data += "]"
 	}
@@ -772,19 +1004,26 @@ func createJsonData(dataPack []*pb.DataPackages_DataPackage) string {
 }
 
 func getJsonDp(dataPack *pb.DataPackages_DataPackage) string {
+	if dataPack == nil {
+		return `{}`
+	}
 	dpPack := dataPack.GetDp()
-	//Info(dpPack)
+	if len(dpPack) == 0 {
+		return `{}`
+	}
 	dp := ""
 	if len(dpPack) > 1 {
 		dp += "["
 	}
 	for i := 0; i < len(dpPack); i++ {
+		if dpPack[i] == nil {
+			continue
+		}
 		value := dpPack[i].GetValue()
-		var ts string
-		ts = dpPack[i].GetTs()
-		dp += `{"value":"` + value + `","ts":"` + ts + `"},`
+		ts := dpPack[i].GetTs()
+		dp += `{"value":"` + jsonEscape(value) + `","ts":"` + jsonEscape(ts) + `"},`
 	}
-	dp = dp[:len(dp)-1]
+	dp = trimTrailingComma(dp)
 	if len(dpPack) > 1 {
 		dp += "]"
 	}
@@ -792,8 +1031,58 @@ func getJsonDp(dataPack *pb.DataPackages_DataPackage) string {
 }
 
 func getJsonError(errorResponse *pb.ErrorResponseMessage) string {
+	// Defensive nil receiver: GetNumber/etc. are nil-safe via the generated
+	// proto getters, so this is belt-and-suspenders.
 	number := errorResponse.GetNumber()
 	reason := errorResponse.GetReason()
 	description := errorResponse.GetDescription()
-	return `,"error":{"number":"` + number + `","reason":"` + reason + `","description":"` + description + `"}`
+	return `,"error":{"number":"` + jsonEscape(number) + `","reason":"` + jsonEscape(reason) + `","description":"` + jsonEscape(description) + `"}`
+}
+
+// jsonEscape produces a JSON-safe string body (without surrounding quotes).
+// Pre-fix the file built JSON via string concatenation, so any value
+// containing '"' or '\' produced invalid JSON that downstream parsers
+// rejected. This helper handles the minimum set of metacharacters that
+// json.Marshal would escape.
+func jsonEscape(s string) string {
+	if !needsEscape(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 8)
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r < 0x20 {
+				// Control char - encode as \u00XX
+				b.WriteString(`\u00`)
+				const hex = "0123456789abcdef"
+				b.WriteByte(hex[(r>>4)&0xf])
+				b.WriteByte(hex[r&0xf])
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	return b.String()
+}
+
+func needsEscape(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 0x20 || c == '"' || c == '\\' {
+			return true
+		}
+	}
+	return false
 }

--- a/utils/grcputils_test.go
+++ b/utils/grcputils_test.go
@@ -1,0 +1,1045 @@
+/**
+* (C) 2026 Matt Jones / Ford
+*
+* Tests for grcputils.go (JSON <-> protobuf converter for the gRPC
+* transport). Covers every unit-testable function plus the defensive
+* helpers added in this branch. Each malformed-input case pins a fix.
+**/
+
+package utils
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	pb "github.com/covesa/vissr/grpc_pb"
+)
+
+func init() {
+	InitLog("grcputils_test-log.txt", "./logs", false, "info")
+}
+
+// --------------------------------------------------------------------------
+// Defensive helpers
+// --------------------------------------------------------------------------
+
+func TestMapString(t *testing.T) {
+	m := map[string]interface{}{
+		"a": "hello",
+		"b": 42,
+		"c": nil,
+	}
+	if v, ok := mapString(m, "a"); !ok || v != "hello" {
+		t.Errorf("a: got %q,%v", v, ok)
+	}
+	if _, ok := mapString(m, "b"); ok {
+		t.Errorf("non-string returned ok")
+	}
+	if _, ok := mapString(m, "c"); ok {
+		t.Errorf("nil returned ok")
+	}
+	if _, ok := mapString(m, "missing"); ok {
+		t.Errorf("missing returned ok")
+	}
+}
+
+func TestMapStringOrEmpty(t *testing.T) {
+	m := map[string]interface{}{"a": "hi"}
+	if got := mapStringOrEmpty(m, "a"); got != "hi" {
+		t.Errorf("got %q", got)
+	}
+	if got := mapStringOrEmpty(m, "missing"); got != "" {
+		t.Errorf("missing should be empty; got %q", got)
+	}
+}
+
+func TestMapAsMap(t *testing.T) {
+	m := map[string]interface{}{
+		"a": map[string]interface{}{"x": "y"},
+		"b": "not a map",
+	}
+	if inner, ok := mapAsMap(m, "a"); !ok || inner["x"] != "y" {
+		t.Errorf("got %+v ok=%v", inner, ok)
+	}
+	if _, ok := mapAsMap(m, "b"); ok {
+		t.Errorf("string returned ok")
+	}
+	if _, ok := mapAsMap(m, "missing"); ok {
+		t.Errorf("missing returned ok")
+	}
+}
+
+func TestAsMapAsString(t *testing.T) {
+	if _, ok := asMap(nil); ok {
+		t.Errorf("nil should return false")
+	}
+	if _, ok := asMap("string"); ok {
+		t.Errorf("string should return false")
+	}
+	if _, ok := asMap(map[string]interface{}{}); !ok {
+		t.Errorf("empty map should return ok")
+	}
+	if _, ok := asString(nil); ok {
+		t.Errorf("nil should return false")
+	}
+	if _, ok := asString(42); ok {
+		t.Errorf("int should return false")
+	}
+	if s, ok := asString("hi"); !ok || s != "hi" {
+		t.Errorf("got %q,%v", s, ok)
+	}
+}
+
+func TestTrimTrailingComma(t *testing.T) {
+	if got := trimTrailingComma(""); got != "" {
+		t.Errorf("empty should stay empty; got %q", got)
+	}
+	if got := trimTrailingComma("a,"); got != "a" {
+		t.Errorf("got %q; want a", got)
+	}
+	if got := trimTrailingComma("a"); got != "a" {
+		t.Errorf("got %q; want a (no trim needed)", got)
+	}
+	if got := trimTrailingComma(","); got != "" {
+		t.Errorf("got %q; want empty", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// jsonEscape
+// --------------------------------------------------------------------------
+
+func TestJsonEscape(t *testing.T) {
+	cases := map[string]string{
+		"":              "",
+		"hello":         "hello",
+		`with "quote"`:  `with \"quote\"`,
+		`back\slash`:    `back\\slash`,
+		"with\nnewl":    `with\nnewl`,
+		"with\ttab":     `with\ttab`,
+		"with\rret":     `with\rret`,
+		"\x01control":   `\u0001control`,
+	}
+	for in, want := range cases {
+		if got := jsonEscape(in); got != want {
+			t.Errorf("jsonEscape(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
+// ExtractSubscriptionId
+// --------------------------------------------------------------------------
+
+func TestExtractSubscriptionId_HappyPath(t *testing.T) {
+	if got := ExtractSubscriptionId(`{"subscriptionId":"123"}`); got != "123" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractSubscriptionId_MissingFieldDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("missing field panicked: %v", r)
+		}
+	}()
+	if got := ExtractSubscriptionId(`{}`); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractSubscriptionId_NonStringDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if got := ExtractSubscriptionId(`{"subscriptionId":42}`); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractSubscriptionId_BadJSON(t *testing.T) {
+	if got := ExtractSubscriptionId(`not json`); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// GetRequestJsonToPb / SetRequestJsonToPb / SubscribeRequestJsonToPb /
+// SubscribeStreamJsonToPb / UnsubscribeRequestJsonToPb /
+// UnsubscribeResponseJsonToPb / SetResponseJsonToPb / GetResponseJsonToPb
+// — all top-level entry points must tolerate malformed JSON
+// --------------------------------------------------------------------------
+
+func TestGetRequestJsonToPb_HappyPath(t *testing.T) {
+	in := `{"action":"get","path":"Vehicle.Speed","requestId":"42"}`
+	got := GetRequestJsonToPb(in)
+	if got == nil || got.GetPath() != "Vehicle.Speed" || got.GetRequestId() != "42" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestGetRequestJsonToPb_BadJSON(t *testing.T) {
+	if got := GetRequestJsonToPb("not json"); got != nil {
+		t.Errorf("expected nil for bad JSON; got %+v", got)
+	}
+}
+
+func TestGetRequestJsonToPb_MissingFieldsDoNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("missing fields panicked: %v", r)
+		}
+	}()
+	cases := []string{
+		`{}`,
+		`{"path":42}`,
+		`{"path":"X","requestId":42}`,
+		`{"path":"X","filter":42}`,
+		`{"path":"X","filter":["only-one-element"]}`,
+		`{"path":"X","authorization":42}`,
+	}
+	for _, in := range cases {
+		got := GetRequestJsonToPb(in)
+		if got == nil {
+			t.Errorf("input %q produced nil — should produce empty/partial proto", in)
+		}
+	}
+}
+
+func TestGetResponseJsonToPb_MalformedDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	cases := []string{
+		`{}`,
+		`{"requestId":42}`,
+		`{"error":"not a map"}`,
+		`{"error":42}`,
+		`{"data":"not an array"}`,
+	}
+	for _, in := range cases {
+		_ = GetResponseJsonToPb(in)
+	}
+}
+
+func TestSetRequestJsonToPb_HappyPath(t *testing.T) {
+	in := `{"action":"set","path":"Vehicle.Speed","value":"42","requestId":"1"}`
+	got := SetRequestJsonToPb(in)
+	if got.GetPath() != "Vehicle.Speed" || got.GetValue() != "42" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestSetRequestJsonToPb_MissingFieldsDoNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if got := SetRequestJsonToPb(`{}`); got == nil {
+		t.Errorf("expected non-nil partial proto")
+	}
+}
+
+func TestSubscribeRequestJsonToPb_MissingFieldsDoNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	_ = SubscribeRequestJsonToPb(`{}`)
+	_ = SubscribeRequestJsonToPb(`{"filter":{"variant":42}}`)
+	_ = SubscribeRequestJsonToPb(`{"filter":{"variant":"paths"}}`)
+}
+
+func TestSubscribeStreamJsonToPb_MalformedDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	cases := []string{
+		`{}`,
+		`{"action":"subscribe"}`,
+		`{"action":"subscribe","error":"oops"}`,
+		`{"action":"subscription"}`,
+		`{"action":"subscription","error":{}}`,
+		`{"action":"subscription","data":"not-an-array"}`,
+	}
+	for _, in := range cases {
+		_ = SubscribeStreamJsonToPb(in)
+	}
+}
+
+func TestUnsubscribeRequestJsonToPb_MalformedDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	_ = UnsubscribeRequestJsonToPb(`{}`)
+}
+
+func TestUnsubscribeResponseJsonToPb_MalformedDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	_ = UnsubscribeResponseJsonToPb(`{}`)
+	_ = UnsubscribeResponseJsonToPb(`{"error":"not a map"}`)
+}
+
+func TestSetResponseJsonToPb_ErrorBranch(t *testing.T) {
+	in := `{"requestId":"1","ts":"2026-05-17T12:00:00Z","error":{"number":"404","reason":"not found"}}`
+	got := SetResponseJsonToPb(in)
+	if got.GetStatus() != pb.ResponseStatus_ERROR {
+		t.Errorf("expected ERROR status; got %v", got.GetStatus())
+	}
+	if got.GetErrorResponse().GetNumber() != "404" {
+		t.Errorf("expected number 404; got %q", got.GetErrorResponse().GetNumber())
+	}
+}
+
+// --------------------------------------------------------------------------
+// getNumOfDataElements / getNumOfDataPointElements / getNumOfRangeExpressions
+// --------------------------------------------------------------------------
+
+func TestGetNumOfDataElements(t *testing.T) {
+	if got := getNumOfDataElements(nil); got != 0 {
+		t.Errorf("nil should be 0; got %d", got)
+	}
+	if got := getNumOfDataElements(map[string]interface{}{}); got != 1 {
+		t.Errorf("single object should be 1; got %d", got)
+	}
+	if got := getNumOfDataElements([]interface{}{1, 2, 3}); got != 3 {
+		t.Errorf("array should be 3; got %d", got)
+	}
+}
+
+func TestGetNumOfRangeExpressions(t *testing.T) {
+	if got := getNumOfRangeExpressions(map[string]interface{}{}); got != 1 {
+		t.Errorf("single object should be 1; got %d", got)
+	}
+	if got := getNumOfRangeExpressions([]interface{}{1, 2}); got != 2 {
+		t.Errorf("array should be 2; got %d", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// createDataElement / createDataPointElement — defensive on malformed input
+// --------------------------------------------------------------------------
+
+func TestCreateDataElement_NonMapReturnsNil(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if got := createDataElement(0, "not a map"); got != nil {
+		t.Errorf("expected nil; got %+v", got)
+	}
+}
+
+func TestCreateDataElement_OOBIndexReturnsNil(t *testing.T) {
+	arr := []interface{}{map[string]interface{}{"path": "X"}}
+	if got := createDataElement(99, arr); got != nil {
+		t.Errorf("expected nil; got %+v", got)
+	}
+}
+
+func TestCreateDataElement_NonMapArrayElement(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	arr := []interface{}{"not-an-object", 42}
+	if got := createDataElement(0, arr); got != nil {
+		t.Errorf("expected nil for non-map element; got %+v", got)
+	}
+}
+
+func TestCreateDataElement_HappyPath(t *testing.T) {
+	in := map[string]interface{}{
+		"path": "Vehicle.Speed",
+		"dp":   map[string]interface{}{"value": "42", "ts": "2026-05-17T12:00:00Z"},
+	}
+	got := createDataElement(0, in)
+	if got == nil || got.GetPath() != "Vehicle.Speed" {
+		t.Fatalf("got %+v", got)
+	}
+	if len(got.GetDp()) != 1 || got.GetDp()[0].GetValue() != "42" {
+		t.Errorf("dp wrong: %+v", got.GetDp())
+	}
+}
+
+func TestCreateDataPointElement_NonMapReturnsNil(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if got := createDataPointElement(0, "oops"); got != nil {
+		t.Errorf("expected nil; got %+v", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// createPbFilter / getFilterVariant / per-variant getters
+// --------------------------------------------------------------------------
+
+func TestGetFilterVariant(t *testing.T) {
+	cases := map[string]pb.FilterExpressions_FilterExpression_FilterVariant{
+		"paths":     pb.FilterExpressions_FilterExpression_PATHS,
+		"timebased": pb.FilterExpressions_FilterExpression_TIMEBASED,
+		"range":     pb.FilterExpressions_FilterExpression_RANGE,
+		"change":    pb.FilterExpressions_FilterExpression_CHANGE,
+		"curvelog":  pb.FilterExpressions_FilterExpression_CURVELOG,
+		"history":   pb.FilterExpressions_FilterExpression_HISTORY,
+		"metadata":  pb.FilterExpressions_FilterExpression_METADATA,
+	}
+	for in, want := range cases {
+		if got := getFilterVariant(in); got != want {
+			t.Errorf("%q: got %v; want %v", in, got, want)
+		}
+	}
+	// Unknown variant returns the sentinel
+	if got := getFilterVariant("unknown"); got == pb.FilterExpressions_FilterExpression_PATHS {
+		t.Errorf("unknown should not collide with PATHS")
+	}
+}
+
+func TestCreatePbFilter_MissingVariantNoop(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	out := &pb.FilterExpressions{FilterExp: []*pb.FilterExpressions_FilterExpression{{}}}
+	createPbFilter(0, map[string]interface{}{}, out)
+}
+
+func TestCreatePbFilter_PathsVariant(t *testing.T) {
+	out := &pb.FilterExpressions{FilterExp: []*pb.FilterExpressions_FilterExpression{{}}}
+	in := map[string]interface{}{
+		"variant":   "paths",
+		"parameter": []interface{}{"Vehicle.Speed", "Vehicle.Direction"},
+	}
+	createPbFilter(0, in, out)
+	if got := out.FilterExp[0].GetVariant(); got != pb.FilterExpressions_FilterExpression_PATHS {
+		t.Errorf("variant: got %v", got)
+	}
+	if paths := out.FilterExp[0].GetValue().GetValuePaths().GetRelativePath(); len(paths) != 2 {
+		t.Errorf("paths: got %v", paths)
+	}
+}
+
+func TestCreatePbFilter_RangeVariant(t *testing.T) {
+	out := &pb.FilterExpressions{FilterExp: []*pb.FilterExpressions_FilterExpression{{}}}
+	in := map[string]interface{}{
+		"variant": "range",
+		"parameter": map[string]interface{}{
+			"logic-op": "lt",
+			"boundary": "100",
+		},
+	}
+	createPbFilter(0, in, out)
+	rv := out.FilterExp[0].GetValue().GetValueRange()
+	if len(rv) != 1 || rv[0].GetLogicOperator() != "lt" || rv[0].GetBoundary() != "100" {
+		t.Errorf("range: got %+v", rv)
+	}
+}
+
+func TestCreatePbFilter_ChangeVariant(t *testing.T) {
+	out := &pb.FilterExpressions{FilterExp: []*pb.FilterExpressions_FilterExpression{{}}}
+	in := map[string]interface{}{
+		"variant":   "change",
+		"parameter": map[string]interface{}{"logic-op": "eq", "diff": "5"},
+	}
+	createPbFilter(0, in, out)
+	cv := out.FilterExp[0].GetValue().GetValueChange()
+	if cv.GetLogicOperator() != "eq" || cv.GetDiff() != "5" {
+		t.Errorf("change: got %+v", cv)
+	}
+}
+
+func TestCreatePbFilter_CurvelogVariant(t *testing.T) {
+	out := &pb.FilterExpressions{FilterExp: []*pb.FilterExpressions_FilterExpression{{}}}
+	in := map[string]interface{}{
+		"variant":   "curvelog",
+		"parameter": map[string]interface{}{"maxerr": "0.1", "bufsize": "100"},
+	}
+	createPbFilter(0, in, out)
+	cv := out.FilterExp[0].GetValue().GetValueCurvelog()
+	if cv.GetMaxErr() != "0.1" || cv.GetBufSize() != "100" {
+		t.Errorf("curvelog: got %+v", cv)
+	}
+}
+
+func TestCreatePbFilter_HistoryVariant(t *testing.T) {
+	out := &pb.FilterExpressions{FilterExp: []*pb.FilterExpressions_FilterExpression{{}}}
+	in := map[string]interface{}{"variant": "history", "parameter": "P1D"}
+	createPbFilter(0, in, out)
+	if out.FilterExp[0].GetValue().GetValueHistory().GetTimePeriod() != "P1D" {
+		t.Errorf("history: got %+v", out.FilterExp[0])
+	}
+}
+
+func TestCreatePbFilter_TimebasedVariant(t *testing.T) {
+	out := &pb.FilterExpressions{FilterExp: []*pb.FilterExpressions_FilterExpression{{}}}
+	in := map[string]interface{}{"variant": "timebased", "parameter": map[string]interface{}{"period": "P1S"}}
+	createPbFilter(0, in, out)
+	if out.FilterExp[0].GetValue().GetValueTimebased().GetPeriod() != "P1S" {
+		t.Errorf("timebased: got %+v", out.FilterExp[0])
+	}
+}
+
+func TestCreatePbFilter_BadParameterShape(t *testing.T) {
+	// Wrong parameter type for variant (string when map expected, etc.)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on bad parameter: %v", r)
+		}
+	}()
+	out := &pb.FilterExpressions{FilterExp: []*pb.FilterExpressions_FilterExpression{{}}}
+	createPbFilter(0, map[string]interface{}{"variant": "change", "parameter": "not-a-map"}, out)
+	createPbFilter(0, map[string]interface{}{"variant": "range", "parameter": []interface{}{"not-a-map"}}, out)
+}
+
+// --------------------------------------------------------------------------
+// getPbPathsFilterValue / getPbRangeFilterValue — non-string array elements
+// --------------------------------------------------------------------------
+
+func TestGetPbPathsFilterValue_StringValue(t *testing.T) {
+	got := getPbPathsFilterValue("Vehicle.Speed")
+	if len(got.GetRelativePath()) != 1 || got.GetRelativePath()[0] != "Vehicle.Speed" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestGetPbPathsFilterValue_NonStringElementSkipped(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	got := getPbPathsFilterValue([]interface{}{"a", 42, "b"})
+	if len(got.GetRelativePath()) != 2 {
+		t.Errorf("expected 2 valid paths; got %v", got.GetRelativePath())
+	}
+}
+
+func TestGetPbRangeFilterValue_BadInputReturnsNil(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if got := getPbRangeFilterValue(0, "not-a-shape"); got != nil {
+		t.Errorf("expected nil; got %+v", got)
+	}
+	if got := getPbRangeFilterValue(99, []interface{}{map[string]interface{}{"boundary": "1"}}); got != nil {
+		t.Errorf("OOB index should return nil; got %+v", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// getProtoErrorMessage
+// --------------------------------------------------------------------------
+
+func TestGetProtoErrorMessage_AllFields(t *testing.T) {
+	in := map[string]interface{}{
+		"number":      "404",
+		"reason":      "not found",
+		"description": "the resource is missing",
+	}
+	got := getProtoErrorMessage(in)
+	if got.GetNumber() != "404" || got.GetReason() != "not found" || got.GetDescription() != "the resource is missing" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestGetProtoErrorMessage_NonStringFieldsSkipped(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	in := map[string]interface{}{
+		"number":      42,
+		"reason":      "ok",
+		"description": map[string]interface{}{},
+	}
+	got := getProtoErrorMessage(in)
+	if got.GetNumber() != "" || got.GetDescription() != "" {
+		t.Errorf("non-strings should be empty; got %+v", got)
+	}
+	if got.GetReason() != "ok" {
+		t.Errorf("valid field dropped; got %q", got.GetReason())
+	}
+}
+
+func TestGetProtoErrorMessage_NilInput(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("nil map panicked: %v", r)
+		}
+	}()
+	got := getProtoErrorMessage(nil)
+	if got == nil {
+		t.Errorf("expected non-nil ErrorResponseMessage")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Proto-to-JSON converters
+// --------------------------------------------------------------------------
+
+func TestGetRequestPbToJson_RoundTrip(t *testing.T) {
+	in := &pb.GetRequestMessage{Path: "Vehicle.Speed", RequestId: "42"}
+	out := GetRequestPbToJson(in)
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("output not valid JSON: %v; raw=%q", err, out)
+	}
+	if m["path"] != "Vehicle.Speed" || m["requestId"] != "42" {
+		t.Errorf("got %+v", m)
+	}
+}
+
+func TestGetResponsePbToJson_EmptyDataPackDoesNotPanic(t *testing.T) {
+	// Pre-fix createJsonData panicked on empty dataPack.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on empty data: %v", r)
+		}
+	}()
+	in := &pb.GetResponseMessage{
+		Status:          pb.ResponseStatus_SUCCESS,
+		SuccessResponse: &pb.GetResponseMessage_SuccessResponseMessage{DataPack: &pb.DataPackages{}},
+		Ts:              "2026-05-17T12:00:00Z",
+		RequestId:       "1",
+	}
+	out := GetResponsePbToJson(in)
+	// Output must at least be valid JSON
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Errorf("output not valid JSON: %v; raw=%q", err, out)
+	}
+}
+
+func TestGetResponsePbToJson_NilSuccessResponseDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on nil SuccessResponse: %v", r)
+		}
+	}()
+	in := &pb.GetResponseMessage{
+		Status:    pb.ResponseStatus_SUCCESS,
+		Ts:        "ts",
+		RequestId: "1",
+	}
+	out := GetResponsePbToJson(in)
+	if !strings.Contains(out, `"action":"get"`) {
+		t.Errorf("expected action=get; got %q", out)
+	}
+}
+
+func TestGetResponsePbToJson_ErrorBranch(t *testing.T) {
+	in := &pb.GetResponseMessage{
+		Status:        pb.ResponseStatus_ERROR,
+		ErrorResponse: &pb.ErrorResponseMessage{Number: "404", Reason: "not found"},
+		Ts:            "ts",
+		RequestId:     "1",
+	}
+	out := GetResponsePbToJson(in)
+	if !strings.Contains(out, `"number":"404"`) {
+		t.Errorf("missing error number; got %q", out)
+	}
+}
+
+func TestSetRequestPbToJson(t *testing.T) {
+	in := &pb.SetRequestMessage{Path: "P", Value: "V", RequestId: "1"}
+	out := SetRequestPbToJson(in)
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("invalid JSON: %v; raw=%q", err, out)
+	}
+}
+
+func TestSetResponsePbToJson_RoundTrip(t *testing.T) {
+	in := &pb.SetResponseMessage{Status: pb.ResponseStatus_SUCCESS, Ts: "ts", RequestId: "1"}
+	out := SetResponsePbToJson(in)
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Errorf("invalid JSON: %v; raw=%q", err, out)
+	}
+}
+
+func TestSubscribeRequestPbToJson(t *testing.T) {
+	in := &pb.SubscribeRequestMessage{Path: "P", RequestId: "1"}
+	out := SubscribeRequestPbToJson(in)
+	if !strings.Contains(out, `"action":"subscribe"`) {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestSubscribeStreamPbToJson_EmptyEventDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on empty event: %v", r)
+		}
+	}()
+	in := &pb.SubscribeStreamMessage{
+		MType:  pb.SubscribeResponseType_SUB_EVENT,
+		Status: pb.ResponseStatus_SUCCESS,
+		Event:  &pb.SubscribeStreamMessage_SubscribeEventMessage{},
+	}
+	_ = SubscribeStreamPbToJson(in)
+}
+
+func TestSubscribeStreamPbToJson_NilResponseDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on nil response: %v", r)
+		}
+	}()
+	in := &pb.SubscribeStreamMessage{
+		MType:  pb.SubscribeResponseType_SUB_RESPONSE,
+		Status: pb.ResponseStatus_SUCCESS,
+	}
+	_ = SubscribeStreamPbToJson(in)
+}
+
+func TestUnsubscribeRequestPbToJson(t *testing.T) {
+	in := &pb.UnsubscribeRequestMessage{SubscriptionId: "S", RequestId: "1"}
+	out := UnsubscribeRequestPbToJson(in)
+	if !strings.Contains(out, `"action":"unsubscribe"`) {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestUnsubscribeResponsePbToJson_HappyPath(t *testing.T) {
+	in := &pb.UnsubscribeResponseMessage{Status: pb.ResponseStatus_SUCCESS, RequestId: "1", Ts: "ts"}
+	out := UnsubscribeResponsePbToJson(in)
+	if !strings.Contains(out, `"action":"unsubscribe"`) {
+		t.Errorf("got %q", out)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Filter Proto-to-JSON: empty inputs no longer panic
+// --------------------------------------------------------------------------
+
+func TestGetJsonFilter_NilOrEmpty(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if got := getJsonFilter(nil); got != "" {
+		t.Errorf("nil filter should produce empty; got %q", got)
+	}
+	if got := getJsonFilter(&pb.FilterExpressions{}); got != "" {
+		t.Errorf("empty filter should produce empty; got %q", got)
+	}
+}
+
+func TestGetJsonFilterValuePaths_Empty(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	in := &pb.FilterExpressions_FilterExpression{
+		Value: &pb.FilterExpressions_FilterExpression_FilterValue{
+			ValuePaths: &pb.FilterExpressions_FilterExpression_FilterValue_PathsValue{},
+		},
+	}
+	// Pre-fix this panicked on empty relative-paths.
+	_ = getJsonFilterValuePaths(in)
+}
+
+func TestGetJsonFilterValueRange_Empty(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	in := &pb.FilterExpressions_FilterExpression{
+		Value: &pb.FilterExpressions_FilterExpression_FilterValue{},
+	}
+	_ = getJsonFilterValueRange(in)
+}
+
+// --------------------------------------------------------------------------
+// createJsonData / getJsonDp / getJsonError defensive
+// --------------------------------------------------------------------------
+
+func TestCreateJsonData_Empty(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if got := createJsonData(nil); got != "" {
+		t.Errorf("expected empty for nil; got %q", got)
+	}
+	if got := createJsonData([]*pb.DataPackages_DataPackage{}); got != "" {
+		t.Errorf("expected empty for empty slice; got %q", got)
+	}
+}
+
+func TestGetJsonDp_Empty(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if got := getJsonDp(nil); got != `{}` {
+		t.Errorf("expected '{}' for nil; got %q", got)
+	}
+	if got := getJsonDp(&pb.DataPackages_DataPackage{}); got != `{}` {
+		t.Errorf("expected '{}' for empty dp; got %q", got)
+	}
+}
+
+func TestGetJsonError_NilReceiver(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on nil receiver: %v", r)
+		}
+	}()
+	got := getJsonError(nil)
+	if !strings.Contains(got, `"error":`) {
+		t.Errorf("got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// JSON-escape correctness end-to-end
+// --------------------------------------------------------------------------
+
+func TestCreateJsonData_EscapesQuotesAndBackslashes(t *testing.T) {
+	in := []*pb.DataPackages_DataPackage{
+		{
+			Path: `weird"path\with"chars`,
+			Dp: []*pb.DataPackages_DataPackage_DataPoint{
+				{Value: `value"with"quotes`, Ts: "2026-05-17T12:00:00Z"},
+			},
+		},
+	}
+	got := createJsonData(in)
+	// The wrapper return is `,"data":...` so wrap into an object to parse.
+	wrapped := "{" + strings.TrimPrefix(got, ",") + "}"
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(wrapped), &m); err != nil {
+		t.Errorf("output not valid JSON after escaping: %v; raw=%q", err, got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// applyFilterFromMessage — array/map/missing/invalid
+// --------------------------------------------------------------------------
+
+func TestApplyFilterFromMessage_MissingReturnsNil(t *testing.T) {
+	if got := applyFilterFromMessage(map[string]interface{}{}); got != nil {
+		t.Errorf("expected nil; got %+v", got)
+	}
+}
+
+func TestApplyFilterFromMessage_NonMapElementInArrayRejected(t *testing.T) {
+	in := map[string]interface{}{
+		"filter": []interface{}{"not-a-map", map[string]interface{}{"variant": "paths"}},
+	}
+	if got := applyFilterFromMessage(in); got != nil {
+		t.Errorf("expected nil for non-map array element; got %+v", got)
+	}
+}
+
+func TestApplyFilterFromMessage_WrongArrayLength(t *testing.T) {
+	in := map[string]interface{}{
+		"filter": []interface{}{map[string]interface{}{"variant": "paths"}}, // only 1 element
+	}
+	if got := applyFilterFromMessage(in); got != nil {
+		t.Errorf("expected nil for wrong array length; got %+v", got)
+	}
+}
+
+func TestApplyFilterFromMessage_SingleObject(t *testing.T) {
+	in := map[string]interface{}{
+		"filter": map[string]interface{}{
+			"variant":   "paths",
+			"parameter": "Vehicle.Speed",
+		},
+	}
+	got := applyFilterFromMessage(in)
+	if got == nil || len(got.FilterExp) != 1 {
+		t.Errorf("got %+v", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Pb-to-JSON filter helpers (synthesizeFilter dispatch + per-variant)
+// --------------------------------------------------------------------------
+
+func TestSynthesizeFilter_AllVariants(t *testing.T) {
+	cases := []struct {
+		variant pb.FilterExpressions_FilterExpression_FilterVariant
+		want    string
+	}{
+		{pb.FilterExpressions_FilterExpression_PATHS, `"paths"`},
+		{pb.FilterExpressions_FilterExpression_TIMEBASED, `"timebased"`},
+		{pb.FilterExpressions_FilterExpression_RANGE, `"range"`},
+		{pb.FilterExpressions_FilterExpression_CHANGE, `"change"`},
+		{pb.FilterExpressions_FilterExpression_CURVELOG, `"curvelog"`},
+		{pb.FilterExpressions_FilterExpression_HISTORY, `"history"`},
+		{pb.FilterExpressions_FilterExpression_METADATA, `"metadata"`},
+	}
+	for _, c := range cases {
+		in := &pb.FilterExpressions_FilterExpression{
+			Variant: c.variant,
+			Value:   &pb.FilterExpressions_FilterExpression_FilterValue{},
+		}
+		got := synthesizeFilter(in)
+		if !strings.Contains(got, c.want) {
+			t.Errorf("variant %v: missing %s; got %q", c.variant, c.want, got)
+		}
+	}
+}
+
+func TestGetJsonFilterValueTimebased(t *testing.T) {
+	in := &pb.FilterExpressions_FilterExpression{
+		Value: &pb.FilterExpressions_FilterExpression_FilterValue{
+			ValueTimebased: &pb.FilterExpressions_FilterExpression_FilterValue_TimebasedValue{Period: "PT1S"},
+		},
+	}
+	if got := getJsonFilterValueTimebased(in); !strings.Contains(got, `"period":"PT1S"`) {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestGetJsonFilterValueChange(t *testing.T) {
+	in := &pb.FilterExpressions_FilterExpression{
+		Value: &pb.FilterExpressions_FilterExpression_FilterValue{
+			ValueChange: &pb.FilterExpressions_FilterExpression_FilterValue_ChangeValue{
+				LogicOperator: "lt",
+				Diff:          "5",
+			},
+		},
+	}
+	got := getJsonFilterValueChange(in)
+	if !strings.Contains(got, `"logic-op":"lt"`) || !strings.Contains(got, `"diff":"5"`) {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestGetJsonFilterValueCurvelog(t *testing.T) {
+	in := &pb.FilterExpressions_FilterExpression{
+		Value: &pb.FilterExpressions_FilterExpression_FilterValue{
+			ValueCurvelog: &pb.FilterExpressions_FilterExpression_FilterValue_CurvelogValue{
+				MaxErr:  "0.1",
+				BufSize: "100",
+			},
+		},
+	}
+	got := getJsonFilterValueCurvelog(in)
+	if !strings.Contains(got, `"maxerr":"0.1"`) || !strings.Contains(got, `"bufsize":"100"`) {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestGetJsonFilterValueHistory(t *testing.T) {
+	in := &pb.FilterExpressions_FilterExpression{
+		Value: &pb.FilterExpressions_FilterExpression_FilterValue{
+			ValueHistory: &pb.FilterExpressions_FilterExpression_FilterValue_HistoryValue{TimePeriod: "P1D"},
+		},
+	}
+	if got := getJsonFilterValueHistory(in); got != `"P1D"` {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestGetJsonFilterValueMetadata(t *testing.T) {
+	in := &pb.FilterExpressions_FilterExpression{
+		Value: &pb.FilterExpressions_FilterExpression_FilterValue{
+			ValueMetadata: &pb.FilterExpressions_FilterExpression_FilterValue_MetadataValue{Tree: "raw-tree-content"},
+		},
+	}
+	if got := getJsonFilterValueMetadata(in); got != "raw-tree-content" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// createJSON helper - key formatting
+// --------------------------------------------------------------------------
+
+func TestCreateJSON(t *testing.T) {
+	if got := createJSON("hello", "myKey"); got != `,"myKey":"hello"` {
+		t.Errorf("got %q", got)
+	}
+	if got := createJSON("", "myKey"); got != "" {
+		t.Errorf("empty value should produce empty; got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// needsEscape predicate
+// --------------------------------------------------------------------------
+
+func TestNeedsEscape(t *testing.T) {
+	if needsEscape("hello") {
+		t.Errorf("plain ASCII should not need escape")
+	}
+	if !needsEscape(`with "quote"`) {
+		t.Errorf("quote should need escape")
+	}
+	if !needsEscape("with\nnewl") {
+		t.Errorf("newline should need escape")
+	}
+	if !needsEscape("\x01") {
+		t.Errorf("control char should need escape")
+	}
+	if !needsEscape(`back\slash`) {
+		t.Errorf("backslash should need escape")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Full pb->JSON roundtrip with non-trivial filter
+// --------------------------------------------------------------------------
+
+func TestSubscribeRequestPbToJson_WithRangeFilter(t *testing.T) {
+	in := &pb.SubscribeRequestMessage{
+		Path:      "Vehicle.Speed",
+		RequestId: "1",
+		Filter: &pb.FilterExpressions{
+			FilterExp: []*pb.FilterExpressions_FilterExpression{
+				{
+					Variant: pb.FilterExpressions_FilterExpression_RANGE,
+					Value: &pb.FilterExpressions_FilterExpression_FilterValue{
+						ValueRange: []*pb.FilterExpressions_FilterExpression_FilterValue_RangeValue{
+							{LogicOperator: "lt", Boundary: "100"},
+						},
+					},
+				},
+			},
+		},
+	}
+	out := SubscribeRequestPbToJson(in)
+	// must contain the filter and be valid JSON
+	if !strings.Contains(out, `"variant":"range"`) {
+		t.Errorf("missing filter variant; got %q", out)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Errorf("output not valid JSON: %v; raw=%q", err, out)
+	}
+}


### PR DESCRIPTION
## Summary

`utils/grcputils.go` is the JSON ↔ protobuf converter for the gRPC transport. **Every gRPC request and response flowing through the vissr server hits this code.** Pre-fix it had ~60 unchecked type assertions on attacker-controlled JSON plus 5 empty-string-trim panics in the proto-to-JSON synthesizers — a gRPC fuzzer would crash this in seconds.

## HIGH severity (panic / crash)

| Bug | Description |
|---|---|
| **~60 unchecked type assertions** | Bare `.(string)` / `.(map[string]interface{})` / `.([]interface{})` on every `messageMap[...]` access across all 16 top-level converter functions. Any client sending JSON with a missing key or a wrong-typed value (e.g. `"requestId":42` instead of `"1"`) panicked the gRPC server. Replaced site-by-site with comma-ok via new defensive helpers `mapString` / `mapAsMap` / `asMap` / `asString`. |
| **5 trim-trailing-comma panics** | `getJsonFilter`, `getJsonFilterValuePaths`, `getJsonFilterValueRange`, `createJsonData`, `getJsonDp` all did `s[:len(s)-1]` unconditionally on accumulators that could be empty (e.g. ERROR response with no data, empty `FilterExp` slice from a SUCCESS subscribe). New `trimTrailingComma` helper only trims when there's a trailing comma. |
| **2 nil sub-message dereferences** | `populateJsonFromProtoGetResp` / `populateJsonFromProtoSubscribeStream` — `GetDataPack()` is nil-safe but only when the parent (`SuccessResponse` / `Event.SuccessResponse` / `Response`) is non-nil. Now defensively nil-checked. |
| `createDataElement` / `createDataPointElement` | Type-switch `default` arm asserted `.(map[string]interface{})` without check; a scalar in place of a struct panicked. Now returns nil cleanly. |
| `createPbFilter` | Assumed `filterExpression["variant"]` was a string and the parameter sub-shape was correct — both unchecked. Any variant value typed wrong panicked, and a malformed parameter type for the chosen variant (e.g. range parameter as a string) panicked the per-variant getter. |

## MEDIUM severity (data corruption / silent failure)

- **String-concatenation JSON building throughout.** Any value containing `"` or `\` or control chars produced invalid JSON that downstream consumers (other vissr clients, dashboards, anything that parsed the response) silently failed to read. New `jsonEscape` helper escapes the minimum set of JSON metachars before insertion.

## LOW severity

- `getFilterVariant` on unknown input returned an out-of-range enum value (`METADATA + 100`). `createPbFilter`'s switch fell into the `default` arm with a half-built `Value` struct. Now `createPbFilter` bails on missing variant before mutating.
- Filename: `grcputils.go` is misspelled (should be `grpcutils.go`). Left as-is — rename would churn imports across the repo.

## Refactors that go with the tests

- `mapString`, `mapStringOrEmpty`, `mapAsMap`, `asMap`, `asString` — defensive `map[string]interface{}` getters.
- `applyFilterFromMessage` — extracted shared filter parsing from `createGetRequestPb` / `createSubscribeRequestPb` (was duplicated).
- `trimTrailingComma` — shared safe trim helper.
- `jsonEscape`, `needsEscape` — JSON-safe string-body escape.

## Test coverage

`utils/grcputils_test.go` (new): **70+ tests, race-mode clean**. Direct coverage of **every function in the file**:

- All 8 `JsonToPb` top-level entry points with malformed/missing-field inputs.
- All 8 `PbToJson` top-level entry points incl. empty-data and nil-sub-message paths.
- All 7 filter variants (paths, timebased, range, change, curvelog, history, metadata) for both pb and json sides.
- `createDataElement` / `createDataPointElement` defensive paths (non-map input, OOB index, non-map array element).
- `getProtoErrorMessage` / `getJsonError` defensive on nil + non-string fields.
- `applyFilterFromMessage`: missing, single-object, two-element-array, wrong-length-array, non-map-element-in-array.
- `jsonEscape`: quotes, backslashes, newlines, tabs, control chars.

## Drive-by vet cleanups

Pre-existing failures blocking `go test ./...` on a clean master checkout:

- `utils/managerhandlers.go:334` — Printf shape error
- `utils/pbutils.go:32` — Printf shape error

## Test results

```
$ go vet ./utils/
(clean)

$ go test -race ./utils/ -count=1
ok  github.com/covesa/vissr/utils 1.411s
```

70+ tests pass, race detector clean.