### PR TITLE
fix(feeders): patch ~71 bugs across feederv1/v2/v3/rl + complete unit…

### DIFF
--- a/feeder/feeder-rl/feeder-rl.go
+++ b/feeder/feeder-rl/feeder-rl.go
@@ -9,18 +9,21 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/akamensky/argparse"
-	"github.com/covesa/vissr/utils"
-	"github.com/go-redis/redis"
-	"github.com/petervolvowinz/viss-rl-interfaces"
-	"log"
+	"errors"
+	"io"
 	"math/rand"
 	"net"
 	"os"
 	"os/signal"
 	"strconv"
+	"sync"
 	"syscall"
 	"time"
+
+	"github.com/akamensky/argparse"
+	"github.com/covesa/vissr/utils"
+	"github.com/go-redis/redis"
+	"github.com/petervolvowinz/viss-rl-interfaces"
 )
 
 var (
@@ -38,6 +41,36 @@ type FeederMap struct {
 	VehicleName string `json:"vehicledata"`
 }
 
+// mapString returns m[key] as a string. Returns ("", false) on absent, nil,
+// or wrong-type entries. Replaces the unchecked .(string) assertions that
+// previously panicked the feeder on any malformed server message.
+func mapString(m map[string]interface{}, key string) (string, bool) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
+}
+
+// marshalDatapointJSON encodes the {"value":..., "ts":...} datapoint using
+// encoding/json so values containing quotes / backslashes / control chars
+// can't produce malformed JSON. The pre-fix string-concat path corrupted
+// any value with a `"` in it.
+func marshalDatapointJSON(val, ts string) (string, error) {
+	b, err := json.Marshal(map[string]string{"value": val, "ts": ts})
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// readFeederMap pre-fix would index fMap[0] in the info log even when the
+// JSON unmarshal produced an empty slice (legal but unhelpful payload).
+// That panicked the feeder on any empty mapfile.
 func readFeederMap(mapFilename string) []FeederMap {
 	var fMap []FeederMap
 	data, err := os.ReadFile(mapFilename)
@@ -50,7 +83,11 @@ func readFeederMap(mapFilename string) []FeederMap {
 		utils.Error.Printf("readFeederMap():unmarshal error=%s", err)
 		return nil
 	}
-	utils.Info.Printf("readFeederMap():fMap[0].VssName=%s", fMap[0].VssName)
+	if len(fMap) > 0 {
+		utils.Info.Printf("readFeederMap():fMap[0].VssName=%s", fMap[0].VssName)
+	} else {
+		utils.Info.Printf("readFeederMap():loaded 0 entries from %s", mapFilename)
+	}
 	return fMap
 }
 
@@ -82,15 +119,23 @@ func initRedisClient() *redis.Client {
 }
 
 func redisSet(client *redis.Client, path string, val string, ts string) int {
-	dp := `{"value":"` + val + `", "ts":"` + ts + `"}`
-	err := client.Set(path, dp, time.Duration(0)).Err()
+	dp, err := marshalDatapointJSON(val, ts)
 	if err != nil {
+		utils.Error.Printf("redisSet:Marshal error=%v", err)
+		return -1
+	}
+	if err := client.Set(path, dp, time.Duration(0)).Err(); err != nil {
 		utils.Error.Printf("Job failed. Err=%s", err)
 		return -1
 	}
 	return 0
 }
 
+// initUdsEndpoint pre-fix accepted exactly one connection then read into a
+// fixed 512-byte buffer with no framing; any longer message was truncated
+// silently and produced an unmarshalable fragment. Connection drops left the
+// feeder dead. The fixed version loops on Accept, uses 8 KiB, and drops
+// oversized frames.
 func initUdsEndpoint(udsChan chan DomainData, redisClient *redis.Client) {
 	os.Remove(feedChan)
 	listener, err := net.Listen("unix", feedChan) //the file must be the same as declared in the feeder-registration.json that the service mgr reads
@@ -98,37 +143,85 @@ func initUdsEndpoint(udsChan chan DomainData, redisClient *redis.Client) {
 		utils.Error.Printf("initUdsEndpoint:UDS listen failed, err = %s", err)
 		os.Exit(-1)
 	}
-	conn, err := listener.Accept()
-	if err != nil {
-		utils.Error.Printf("initUdsEndpoint:UDS accept failed, err = %s", err)
-		os.Exit(-1)
-	}
-	defer conn.Close()
-	buf := make([]byte, 512)
+	defer listener.Close()
 	for {
-		n, err := conn.Read(buf)
+		conn, err := listener.Accept()
 		if err != nil {
-			utils.Error.Printf("initUdsEndpoint:Read failed, err = %s", err)
+			utils.Error.Printf("initUdsEndpoint:UDS accept failed, err = %s. Retrying in 1s.", err)
+			time.Sleep(1 * time.Second)
 			continue
 		}
-		utils.Info.Printf("Feeder:Server message: %s", string(buf[:n]))
-		domainData, _ := splitToDomainDataAndTs(string(buf[:n]))
-		udsChan <- domainData
+		udsServeConn(conn, udsChan)
 	}
 }
 
-func splitToDomainDataAndTs(serverMessage string) (DomainData, string) { // server={"dp": {"ts": "Z","value": "Y"},"path": "X"}, redis={"value":"xxx", "ts":"zzz"}
+const udsReadBuf = 8192
+
+func udsServeConn(conn net.Conn, udsChan chan DomainData) {
+	defer conn.Close()
+	buf := make([]byte, udsReadBuf)
+	for {
+		n, err := conn.Read(buf)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				utils.Info.Printf("initUdsEndpoint:peer closed, awaiting next connection")
+			} else {
+				utils.Error.Printf("initUdsEndpoint:Read failed, err = %s", err)
+			}
+			return
+		}
+		if n == len(buf) {
+			utils.Error.Printf("initUdsEndpoint:message at buffer size (%d); likely truncated, dropped", n)
+			continue
+		}
+		utils.Info.Printf("Feeder:Server message: %s", string(buf[:n]))
+		domainData, _, ok := splitToDomainDataAndTs(string(buf[:n]))
+		if !ok {
+			continue
+		}
+		select {
+		case udsChan <- domainData:
+		default:
+			utils.Error.Printf("initUdsEndpoint:udsChan full, dropping %q", domainData.Name)
+		}
+	}
+}
+
+// splitToDomainDataAndTs parses a server message of the shape
+//   {"dp": {"ts": "Z","value": "Y"},"path": "X"}
+// and returns the extracted DomainData, the timestamp string, and ok=true.
+// On any parse or shape error, returns zero values and ok=false. Pre-fix this
+// had four unchecked .(string)/.(map) assertions.
+func splitToDomainDataAndTs(serverMessage string) (DomainData, string, bool) {
 	var domainData DomainData
 	var serverMessageMap map[string]interface{}
-	err := json.Unmarshal([]byte(serverMessage), &serverMessageMap)
-	if err != nil {
+	if err := json.Unmarshal([]byte(serverMessage), &serverMessageMap); err != nil {
 		utils.Error.Printf("splitToDomainDataAndTs:Unmarshal error=%s", err)
-		return domainData, ""
+		return domainData, "", false
 	}
-	domainData.Name = serverMessageMap["path"].(string)
-	dpMap := serverMessageMap["dp"].(map[string]interface{})
-	domainData.Value = dpMap["value"].(string)
-	return domainData, dpMap["ts"].(string)
+	name, ok := mapString(serverMessageMap, "path")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid path")
+		return domainData, "", false
+	}
+	dpMap, ok := serverMessageMap["dp"].(map[string]interface{})
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid dp object")
+		return domainData, "", false
+	}
+	value, ok := mapString(dpMap, "value")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid value")
+		return domainData, "", false
+	}
+	ts, ok := mapString(dpMap, "ts")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid ts")
+		return domainData, "", false
+	}
+	domainData.Name = name
+	domainData.Value = value
+	return domainData, ts, true
 }
 
 type simulateDataCtx struct {
@@ -161,16 +254,16 @@ func initVehicleInterfaceMgr(fMap []FeederMap, inputChan chan DomainData, output
 	}
 }
 
+// initVehicleInterfaceMgr_2 pre-fix used a single-case `select` inside `for`,
+// which spins forever burning CPU once the input channel is closed. The fixed
+// version uses a plain for-range and returns when the publisher closes pub_Chan.
 func initVehicleInterfaceMgr_2(pub_Chan chan DomainData, outputChan chan viss_rl_interfaces.ValueChannel) {
-	for {
-		select {
-		case outData := <-pub_Chan:
-			data := &viss_rl_interfaces.ValueChannel{
-				Name:  outData.Name,
-				Value: outData.Value,
-			}
-			outputChan <- *data
+	for outData := range pub_Chan {
+		data := viss_rl_interfaces.ValueChannel{
+			Name:  outData.Name,
+			Value: outData.Value,
 		}
+		outputChan <- data
 	}
 }
 
@@ -189,13 +282,20 @@ func simulateInput(simCtx *simulateDataCtx) DomainData {
 }
 
 func calcInputValue(iteration int, setValue string) string {
-	setVal, _ := strconv.Atoi(setValue)
+	setVal, err := strconv.Atoi(setValue)
+	if err != nil {
+		utils.Error.Printf("calcInputValue:setValue=%q not an integer: %v", setValue, err)
+	}
 	newVal := setVal - 10 + iteration
 	return strconv.Itoa(newVal)
 }
 
+// selectRandomInput now guards against an empty fMap (rand.Intn panics on 0).
 func selectRandomInput(fMap []FeederMap) DomainData {
 	var domainData DomainData
+	if len(fMap) == 0 {
+		return domainData
+	}
 	signalIndex := rand.Intn(len(fMap))
 	domainData.Name = fMap[signalIndex].VehicleName
 	domainData.Value = strconv.Itoa(rand.Intn(1000))
@@ -218,12 +318,15 @@ func searchMap(fMap []FeederMap, inDomain string, signalName string) string {
 	return ""
 }
 
+// convertDomainData pre-fix would happily emit a DomainData with Name="" when
+// the lookup failed, poisoning downstream channels. It now returns the input
+// unchanged on unmapped names rather than producing an empty-name datapoint.
 func convertDomainData(inDomain string, inData DomainData, feederMap []FeederMap) DomainData {
-
 	var outData DomainData
 	outName := searchMap(feederMap, inDomain, inData.Name)
 	if outName == "" {
-		utils.Error.Printf("Domain mapping failed")
+		utils.Error.Printf("Domain mapping failed for %s/%s", inDomain, inData.Name)
+		return inData
 	}
 	outData.Name = outName
 	outData.Value = convertValue(inData.Value)
@@ -237,20 +340,11 @@ func convertValue(value string) string { // TODO: value may need to be scaled, a
 func covertChannelDataToString(data any) string {
 	switch data.(type) {
 	case float64:
-		{
-			str := strconv.FormatFloat(data.(float64), 'f', -1, 64)
-			return str
-		}
+		return strconv.FormatFloat(data.(float64), 'f', -1, 64)
 	case int64:
-		{
-			str := strconv.FormatInt(data.(int64), 10)
-			return str
-		}
+		return strconv.FormatInt(data.(int64), 10)
 	case bool:
-		{
-			str := strconv.FormatBool(data.(bool))
-			return str
-		}
+		return strconv.FormatBool(data.(bool))
 	case []byte:
 		return string(data.([]byte))
 	}
@@ -265,38 +359,51 @@ func TouchFile(name string) error {
 	return file.Close()
 }
 
+// RemotiveLabsBroker pre-fix had three serious issues:
+//   1. Double-close of readQuitSignal: the signal handler closed it on SIGTERM
+//      AND the WriterReader goroutine closed it again on return - the second
+//      close panics. Fixed by giving the signal handler sole ownership via
+//      sync.Once.
+//   2. ch := make(chan int, 2) was drained by `os.Exit(<-ch | <-ch)` *after* an
+//      infinite for-select - unreachable. Dropped that line.
+//   3. The for-select had no exit path: when WriterReader returned (errored or
+//      cleanly), the for loop kept running on dead channels. Added a quit
+//      channel that the WriterReader goroutine signals on return.
 func RemotiveLabsBroker() {
 	vssInputChan := make(chan DomainData, 1)
 	vssOutputChan := make(chan DomainData, 1)
 	vehicleOutputChan := make(chan DomainData, 1)
 
-	// Retrieving an instance of the SignalApi, start receiving data from the broker...
 	streamQuitSignal := make(chan struct{}, 1)
 	readQuitSignal := make(chan struct{}, 1)
+	var quitOnce sync.Once
+	closeQuits := func() {
+		quitOnce.Do(func() {
+			close(streamQuitSignal)
+			close(readQuitSignal)
+		})
+	}
 
 	sig := make(chan os.Signal, 1)
 	api := viss_rl_interfaces.GetWriterReaderlApi()
-	signal.Notify(sig, os.Interrupt, os.Kill, syscall.SIGTERM) // listen to OS interrupt, like ctrl-c
-	go func() {                                                // listen for system interrupt, quit streaming if so...
+	signal.Notify(sig, os.Interrupt, os.Kill, syscall.SIGTERM)
+	go func() { // listen for system interrupt, quit streaming if so...
 		<-sig
-		close(streamQuitSignal)
-		close(readQuitSignal)
+		closeQuits()
 	}()
 
 	writerChannel := make(chan viss_rl_interfaces.ValueChannel, 1)
 	readerChannel := make(chan viss_rl_interfaces.ValueChannel, 1)
 
-	utils.Info.Printf("feeder for rl stsrting...")
-	ch := make(chan int, 2)
+	utils.Info.Printf("feeder for rl starting...")
+	apiDone := make(chan struct{})
 	go func() {
+		defer close(apiDone)
 		err := api.WriterReader(readQuitSignal, writerChannel, readerChannel)
 		if err != nil {
-			log.Println(err)
-			ch <- 1
+			utils.Error.Printf("WriterReader error: %v", err)
 		}
-		close(readQuitSignal)
-		log.Println("subscribing is done")
-		ch <- 0
+		utils.Info.Printf("subscribing is done")
 	}()
 
 	go initVSSInterfaceMgr(vssInputChan, vssOutputChan)
@@ -308,15 +415,16 @@ func RemotiveLabsBroker() {
 		case vssInData := <-vssInputChan:
 			vehicleOutputChan <- convertDomainData("VSS", vssInData, nil)
 		case vehicleInData := <-readerChannel:
-			domainData := &DomainData{
+			domainData := DomainData{
 				Name:  vehicleInData.Name,
 				Value: covertChannelDataToString(vehicleInData.Value),
 			}
-			vssOutputChan <- *domainData
+			vssOutputChan <- domainData
+		case <-apiDone:
+			closeQuits()
+			return
 		}
 	}
-
-	os.Exit(<-ch | <-ch)
 }
 
 func Simulation(mapFile *string) {
@@ -327,6 +435,10 @@ func Simulation(mapFile *string) {
 
 	utils.Info.Printf("Initializing the feeder for mapping file %s.", *mapFile)
 	feederMap := readFeederMap(*mapFile)
+	if feederMap == nil {
+		utils.Error.Printf("Failed to read feeder map %s.", *mapFile)
+		os.Exit(1)
+	}
 	go initVSSInterfaceMgr(vssInputChan, vssOutputChan)
 	go initVehicleInterfaceMgr(feederMap, vehicleInputChan, vehicleOutputChan)
 
@@ -341,8 +453,6 @@ func Simulation(mapFile *string) {
 }
 
 func main() {
-	// Create new parser object
-
 	parser := argparse.NewParser("print", "Data feeder for the Vehicle tree") // The root node name Vehicle must be synched with the feeder-registration.json file.
 
 	mapFile := parser.String("m", "mapfile", &argparse.Options{
@@ -372,29 +482,32 @@ func main() {
 		Help:     "Set the path and redis channel",
 		Default:  "/var/tmp/vissv2/server-feeder-channel.sock"})
 
+	// Parse input. Pre-fix this only logged the error and continued running
+	// with whatever defaults / zero values had been left in place.
 	err := parser.Parse(os.Args)
-	dbPath = *dbp
-	feedChan = *fch
 	if err != nil {
 		utils.Error.Print(parser.Usage(err))
+		os.Exit(1)
 	}
+	dbPath = *dbp
+	feedChan = *fch
 
 	utils.InitLog("feeder-log.txt", "./logs", *logFile, *logLevel)
 	utils.Info.Printf("db path is=%s", dbPath)
 	utils.Info.Printf("Running version 0.1.0")
 
-	err = TouchFile(feedChan)
-	if err != nil {
-		utils.Error.Printf("file not created error=%s", err)
-		// utils.Error.Printf("could not create feeder channel file=#{err}")
-		// os.Exit(0)
+	if err := TouchFile(feedChan); err != nil {
+		utils.Error.Printf("feed-channel file not created path=%s err=%v", feedChan, err)
+		os.Exit(1)
 	}
 
 	switch *dataprovider {
 	case "remotive":
 		RemotiveLabsBroker()
-		break
 	case "sim":
 		Simulation(mapFile)
+	default:
+		utils.Error.Printf("Unknown dataprovider=%q (expected one of: remotive, sim)", *dataprovider)
+		os.Exit(1)
 	}
 }

--- a/feeder/feeder-template/feederv1/feederv1.go
+++ b/feeder/feeder-template/feederv1/feederv1.go
@@ -10,15 +10,18 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
-	"github.com/akamensky/argparse"
-	"github.com/covesa/vissr/utils"
-	"github.com/go-redis/redis"
-	_ "github.com/mattn/go-sqlite3"
+	"errors"
+	"io"
 	"math/rand"
 	"net"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/akamensky/argparse"
+	"github.com/covesa/vissr/utils"
+	"github.com/go-redis/redis"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 type DomainData struct {
@@ -35,6 +38,33 @@ var redisClient *redis.Client
 var dbHandle *sql.DB
 var stateDbType string
 
+// mapString returns m[key] as a string. Returns ("", false) on absent, nil,
+// or wrong-type entries. Replaces the unchecked .(string) assertions that
+// previously panicked the feeder on any malformed server message.
+func mapString(m map[string]interface{}, key string) (string, bool) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
+}
+
+// marshalDatapointJSON encodes the {"value":..., "ts":...} datapoint using
+// encoding/json so values containing quotes / backslashes / control chars
+// can't produce malformed JSON. The pre-fix string-concat path corrupted
+// any value with a `"` in it.
+func marshalDatapointJSON(val, ts string) (string, error) {
+	b, err := json.Marshal(map[string]string{"value": val, "ts": ts})
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
 func readFeederMap(mapFilename string) []FeederMap {
 	var fMap []FeederMap
 	data, err := os.ReadFile(mapFilename)
@@ -47,7 +77,6 @@ func readFeederMap(mapFilename string) []FeederMap {
 		utils.Error.Printf("readFeederMap():unmarshal error=%s", err)
 		return nil
 	}
-	//utils.Info.Printf("readFeederMap():fMap[0].VssName=%s", fMap[0].VssName)
 	return fMap
 }
 
@@ -60,7 +89,7 @@ func initVSSInterfaceMgr(inputChan chan DomainData, outputChan chan DomainData) 
 			utils.Info.Printf("Data written to statestorage: Name=%s, Value=%s", outData.Name, outData.Value)
 			status := statestorageSet(outData.Name, outData.Value, utils.GetRfcTime())
 			if status != 0 {
-				utils.Error.Printf("initVSSInterfaceMgr():Redis write failed")
+				utils.Error.Printf("initVSSInterfaceMgr():State storage write failed")
 			}
 		case actuatorData := <-udsChan:
 			inputChan <- actuatorData
@@ -85,9 +114,12 @@ func statestorageSet(path string, val string, ts string) int {
 		}
 		return 0
 	case "redis":
-		dp := `{"value":"` + val + `", "ts":"` + ts + `"}`
-		err := redisClient.Set(path, dp, time.Duration(0)).Err()
+		dp, err := marshalDatapointJSON(val, ts)
 		if err != nil {
+			utils.Error.Printf("statestorageSet:Marshal error=%v", err)
+			return -1
+		}
+		if err := redisClient.Set(path, dp, time.Duration(0)).Err(); err != nil {
 			utils.Error.Printf("Job failed. Err=%s", err)
 			return -1
 		}
@@ -96,44 +128,100 @@ func statestorageSet(path string, val string, ts string) int {
 	return -1
 }
 
+// The pre-fix initUdsEndpoint accepted exactly one connection then read into
+// a fixed 512-byte buffer with no framing; any longer message was truncated
+// silently and produced an unmarshalable fragment. The fixed version loops on
+// Accept (reconnect support), uses an 8 KiB buffer, and drops oversized frames
+// rather than feeding garbage downstream.
 func initUdsEndpoint(udsChan chan DomainData) {
-	os.Remove("/var/tmp/vissv2/server-feeder-channel.sock")
-	listener, err := net.Listen("unix", "/var/tmp/vissv2/server-feeder-channel.sock") //the file must be the same as declared in the feeder-registration.json that the service mgr reads
+	const sockPath = "/var/tmp/vissv2/server-feeder-channel.sock"
+	os.Remove(sockPath)
+	listener, err := net.Listen("unix", sockPath) //the file must be the same as declared in the feeder-registration.json that the service mgr reads
 	if err != nil {
 		utils.Error.Printf("initUdsEndpoint:UDS listen failed, err = %s", err)
 		os.Exit(-1)
 	}
-	conn, err := listener.Accept()
-	if err != nil {
-		utils.Error.Printf("initUdsEndpoint:UDS accept failed, err = %s", err)
-		os.Exit(-1)
-	}
-	defer conn.Close()
-	buf := make([]byte, 512)
+	defer listener.Close()
 	for {
-		n, err := conn.Read(buf)
+		conn, err := listener.Accept()
 		if err != nil {
-			utils.Error.Printf("initUdsEndpoint:Read failed, err = %s", err)
+			utils.Error.Printf("initUdsEndpoint:UDS accept failed, err = %s. Retrying in 1s.", err)
+			time.Sleep(1 * time.Second)
 			continue
 		}
-		utils.Info.Printf("Feeder:Server message: %s", string(buf[:n]))
-		domainData, _ := splitToDomainDataAndTs(string(buf[:n]))
-		udsChan <- domainData
+		udsServeConn(conn, udsChan)
 	}
 }
 
-func splitToDomainDataAndTs(serverMessage string) (DomainData, string) { // server={"dp": {"ts": "Z","value": "Y"},"path": "X"}, redis={"value":"xxx", "ts":"zzz"}
+const udsReadBuf = 8192
+
+func udsServeConn(conn net.Conn, udsChan chan DomainData) {
+	defer conn.Close()
+	buf := make([]byte, udsReadBuf)
+	for {
+		n, err := conn.Read(buf)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				utils.Info.Printf("initUdsEndpoint:peer closed, awaiting next connection")
+			} else {
+				utils.Error.Printf("initUdsEndpoint:Read failed, err = %s", err)
+			}
+			return
+		}
+		// n cannot exceed len(buf) but a full buffer suggests a truncated frame.
+		if n == len(buf) {
+			utils.Error.Printf("initUdsEndpoint:message at buffer size (%d); likely truncated, dropped", n)
+			continue
+		}
+		utils.Info.Printf("Feeder:Server message: %s", string(buf[:n]))
+		domainData, _, ok := splitToDomainDataAndTs(string(buf[:n]))
+		if !ok {
+			continue
+		}
+		select {
+		case udsChan <- domainData:
+		default:
+			utils.Error.Printf("initUdsEndpoint:udsChan full, dropping %q", domainData.Name)
+		}
+	}
+}
+
+// splitToDomainDataAndTs parses a server message of the shape
+//   {"dp": {"ts": "Z","value": "Y"},"path": "X"}
+// and returns the extracted DomainData, the timestamp string, and ok=true.
+// On any parse or shape error, returns zero values and ok=false. Pre-fix this
+// had four unchecked .(string)/.(map) assertions and panicked on any malformed
+// or partial message from the server.
+func splitToDomainDataAndTs(serverMessage string) (DomainData, string, bool) {
 	var domainData DomainData
 	var serverMessageMap map[string]interface{}
-	err := json.Unmarshal([]byte(serverMessage), &serverMessageMap)
-	if err != nil {
+	if err := json.Unmarshal([]byte(serverMessage), &serverMessageMap); err != nil {
 		utils.Error.Printf("splitToDomainDataAndTs:Unmarshal error=%s", err)
-		return domainData, ""
+		return domainData, "", false
 	}
-	domainData.Name = serverMessageMap["path"].(string)
-	dpMap := serverMessageMap["dp"].(map[string]interface{})
-	domainData.Value = dpMap["value"].(string)
-	return domainData, dpMap["ts"].(string)
+	name, ok := mapString(serverMessageMap, "path")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs:missing/invalid path")
+		return domainData, "", false
+	}
+	dpMap, ok := serverMessageMap["dp"].(map[string]interface{})
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs:missing/invalid dp object")
+		return domainData, "", false
+	}
+	value, ok := mapString(dpMap, "value")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs:missing/invalid value")
+		return domainData, "", false
+	}
+	ts, ok := mapString(dpMap, "ts")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs:missing/invalid ts")
+		return domainData, "", false
+	}
+	domainData.Name = name
+	domainData.Value = value
+	return domainData, ts, true
 }
 
 type simulateDataCtx struct {
@@ -180,14 +268,24 @@ func simulateInput(simCtx *simulateDataCtx) DomainData {
 	return input
 }
 
+// calcInputValue returns setValue - 10 + iteration as a decimal string. If
+// setValue is not numeric the parse error is reported (was silently swallowed
+// pre-fix) and the iteration offset alone is returned.
 func calcInputValue(iteration int, setValue string) string {
-	setVal, _ := strconv.Atoi(setValue)
+	setVal, err := strconv.Atoi(setValue)
+	if err != nil {
+		utils.Error.Printf("calcInputValue:setValue=%q not an integer: %v", setValue, err)
+	}
 	newVal := setVal - 10 + iteration
 	return strconv.Itoa(newVal)
 }
 
+// selectRandomInput now guards against an empty fMap (rand.Intn panics on 0).
 func selectRandomInput(fMap []FeederMap) DomainData {
 	var domainData DomainData
+	if len(fMap) == 0 {
+		return domainData
+	}
 	signalIndex := rand.Intn(len(fMap))
 	domainData.Name = fMap[signalIndex].VehicleName
 	domainData.Value = strconv.Itoa(rand.Intn(1000))
@@ -210,11 +308,15 @@ func searchMap(fMap []FeederMap, inDomain string, signalName string) string {
 	return ""
 }
 
+// convertDomainData pre-fix would happily emit a DomainData with Name="" when
+// the lookup failed, poisoning downstream channels. It now returns the input
+// unchanged on unmapped names rather than producing an empty-name datapoint.
 func convertDomainData(inDomain string, inData DomainData, feederMap []FeederMap) DomainData {
 	var outData DomainData
 	outName := searchMap(feederMap, inDomain, inData.Name)
 	if outName == "" {
-		utils.Error.Printf("Domain mapping failed")
+		utils.Error.Printf("Domain mapping failed for %s/%s", inDomain, inData.Name)
+		return inData
 	}
 	outData.Name = outName
 	outData.Value = convertValue(inData.Value)
@@ -243,10 +345,13 @@ func main() {
 		Required: false,
 		Help:     "statestorage database filename",
 		Default:  "../../server/vissv2server/serviceMgr/statestorage.db"})
-	// Parse input
+	// Parse input. Pre-fix this only logged the error and continued running
+	// with whatever defaults / zero values had been left in place. Now we
+	// exit non-zero so misconfiguration is obvious.
 	err := parser.Parse(os.Args)
 	if err != nil {
 		utils.Error.Print(parser.Usage(err))
+		os.Exit(1)
 	}
 	stateDbType = *stateDB
 
@@ -265,6 +370,7 @@ func main() {
 			}
 		} else {
 			utils.Error.Printf("Could not find state storage file = %s", *dbFile)
+			os.Exit(1)
 		}
 	case "redis":
 		redisClient = redis.NewClient(&redis.Options{
@@ -292,6 +398,10 @@ func main() {
 
 	utils.Info.Printf("Initializing the feeder for mapping file %s.", *mapFile)
 	feederMap := readFeederMap(*mapFile)
+	if feederMap == nil {
+		utils.Error.Printf("Failed to read feeder map %s.", *mapFile)
+		os.Exit(1)
+	}
 	go initVSSInterfaceMgr(vssInputChan, vssOutputChan)
 	go initVehicleInterfaceMgr(feederMap, vehicleInputChan, vehicleOutputChan)
 

--- a/feeder/feeder-template/feederv2/feederv2.go
+++ b/feeder/feeder-template/feederv2/feederv2.go
@@ -10,11 +10,8 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
-	"github.com/akamensky/argparse"
-	"github.com/bradfitz/gomemcache/memcache"
-	"github.com/covesa/vissr/utils"
-	"github.com/go-redis/redis"
-	_ "github.com/mattn/go-sqlite3"
+	"errors"
+	"io"
 	"math/rand"
 	"net"
 	"os"
@@ -23,6 +20,12 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/akamensky/argparse"
+	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/covesa/vissr/utils"
+	"github.com/go-redis/redis"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 type DomainData struct {
@@ -58,6 +61,33 @@ var memcacheClient *memcache.Client
 var dbHandle *sql.DB
 var stateDbType string
 
+// mapString returns m[key] as a string. Returns ("", false) on absent, nil,
+// or wrong-type entries. Replaces the unchecked .(string) assertions that
+// previously panicked the feeder on any malformed server message.
+func mapString(m map[string]interface{}, key string) (string, bool) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
+}
+
+// marshalDatapointJSON encodes the {"value":..., "ts":...} datapoint using
+// encoding/json so values containing quotes / backslashes / control chars
+// can't produce malformed JSON. The pre-fix string-concat path corrupted
+// any value with a `"` in it.
+func marshalDatapointJSON(val, ts string) (string, error) {
+	b, err := json.Marshal(map[string]string{"value": val, "ts": ts})
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
 func fileExists(filename string) bool {
 	info, err := os.Stat(filename)
 	if os.IsNotExist(err) {
@@ -92,47 +122,103 @@ func readFeederMap(mapFilename string) []FeederMap {
 		utils.Error.Printf("Could not open %s for reading map data", mapFilename)
 		return nil
 	}
+	defer treeFp.Close()
 	for {
-		mapElement := readElement(treeFp)
+		mapElement, ok := readElement(treeFp)
+		if !ok {
+			break
+		}
 		if mapElement.Name == "" {
 			break
 		}
 		feederMap = append(feederMap, mapElement)
 	}
-	treeFp.Close()
+	// Sort by Name so callers using sort.Search work correctly.
+	sort.Slice(feederMap, func(i, j int) bool { return feederMap[i].Name < feederMap[j].Name })
 	return feederMap
 }
 
-// The reading order must be aligned with the reading order by the Domain Conversion Tool
-func readElement(treeFp *os.File) FeederMap {
+// readElement reads one FeederMap entry. Returns (zero, false) on short/corrupt
+// read so the caller stops cleanly instead of inheriting a half-populated entry.
+// Pre-fix this had five unchecked type assertions on deSerializeUInt's return
+// (which is `nil` on short reads) and would panic on any truncated mapfile.
+func readElement(treeFp *os.File) (FeederMap, bool) {
 	var feederMap FeederMap
-	feederMap.MapIndex = deSerializeUInt(readBytes(2, treeFp)).(uint16)
-	//utils.Info.Printf("feederMap.MapIndex=%d\n", feederMap.MapIndex)
+	mapIndex, ok := readUint16(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.MapIndex = mapIndex
 
-	NameLen := deSerializeUInt(readBytes(1, treeFp)).(uint8)
-	feederMap.Name = string(readBytes((uint32)(NameLen), treeFp))
-	//utils.Info.Printf("NameLen=%d\n", NameLen)
-	//utils.Info.Printf("feederMap.Name=%s\n", feederMap.Name)
+	nameLen, ok := readUint8(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	nameBytes, ok := readBytes(uint32(nameLen), treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.Name = string(nameBytes)
 
-	feederMap.Type = (int8)(deSerializeUInt(readBytes(1, treeFp)).(uint8))
-	//utils.Info.Printf("feederMap.Type=%d\n", feederMap.Type)
+	typeByte, ok := readUint8(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.Type = int8(typeByte)
 
-	feederMap.Datatype = (int8)(deSerializeUInt(readBytes(1, treeFp)).(uint8))
-	//utils.Info.Printf("feederMap.Datatype=%d\n", feederMap.Datatype)
+	dataTypeByte, ok := readUint8(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.Datatype = int8(dataTypeByte)
 
-	feederMap.ConvertIndex = deSerializeUInt(readBytes(2, treeFp)).(uint16)
-	//utils.Info.Printf("feederMap.ConvertIndex=%d\n", feederMap.ConvertIndex)
-
-	return feederMap
+	convertIndex, ok := readUint16(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.ConvertIndex = convertIndex
+	return feederMap, true
 }
 
-func readBytes(numOfBytes uint32, treeFp *os.File) []byte {
-	if numOfBytes > 0 {
-		buf := make([]byte, numOfBytes)
-		treeFp.Read(buf)
-		return buf
+// MaxReadBytes caps per-call allocation so a corrupt mapfile with a large
+// length prefix cannot trigger a multi-GiB allocation.
+const MaxReadBytes = 1 << 20 // 1 MiB
+
+// readBytes pre-fix called treeFp.Read once and ignored the returned count and
+// error. It now uses io.ReadFull, caps the request size, and returns ok=false
+// on any short read so the caller can bail out cleanly.
+func readBytes(numOfBytes uint32, treeFp *os.File) ([]byte, bool) {
+	if numOfBytes == 0 {
+		return nil, true
 	}
-	return nil
+	if numOfBytes > MaxReadBytes {
+		utils.Error.Printf("readBytes: refusing to allocate %d bytes (cap=%d)", numOfBytes, MaxReadBytes)
+		return nil, false
+	}
+	buf := make([]byte, numOfBytes)
+	if _, err := io.ReadFull(treeFp, buf); err != nil {
+		if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			utils.Error.Printf("readBytes: read failed: %v", err)
+		}
+		return nil, false
+	}
+	return buf, true
+}
+
+func readUint8(treeFp *os.File) (uint8, bool) {
+	buf, ok := readBytes(1, treeFp)
+	if !ok {
+		return 0, false
+	}
+	return buf[0], true
+}
+
+func readUint16(treeFp *os.File) (uint16, bool) {
+	buf, ok := readBytes(2, treeFp)
+	if !ok {
+		return 0, false
+	}
+	return uint16(buf[1])*256 + uint16(buf[0]), true
 }
 
 func deSerializeUInt(buf []byte) interface{} {
@@ -161,13 +247,12 @@ func initVSSInterfaceMgr(inputChan chan DomainData, outputChan chan DomainData) 
 	for {
 		select {
 		case outData := <-outputChan:
-//			utils.Info.Printf("Data written to statestorage: Name=%s, Value=%s", outData.Name, outData.Value)
 			if len(outData.Name) == 0 {
 				continue
 			}
 			status := statestorageSet(outData.Name, outData.Value, utils.GetRfcTime())
 			if status != 0 {
-				utils.Error.Printf("initVSSInterfaceMgr():Redis write failed")
+				utils.Error.Printf("initVSSInterfaceMgr():State storage write failed")
 			}
 		case actuatorData := <-udsChan:
 			inputChan <- actuatorData
@@ -192,17 +277,23 @@ func statestorageSet(path string, val string, ts string) int {
 		}
 		return 0
 	case "redis":
-		dp := `{"value":"` + val + `", "ts":"` + ts + `"}`
-		err := redisClient.Set(path, dp, time.Duration(0)).Err()
+		dp, err := marshalDatapointJSON(val, ts)
 		if err != nil {
+			utils.Error.Printf("statestorageSet:Marshal error=%v", err)
+			return -1
+		}
+		if err := redisClient.Set(path, dp, time.Duration(0)).Err(); err != nil {
 			utils.Error.Printf("Job failed. Err=%s", err)
 			return -1
 		}
 		return 0
 	case "memcache":
-		dp := `{"value":"` + val + `", "ts":"` + ts + `"}`
-		err := memcacheClient.Set(&memcache.Item{Key: path, Value: []byte(dp)})
+		dp, err := marshalDatapointJSON(val, ts)
 		if err != nil {
+			utils.Error.Printf("statestorageSet:Marshal error=%v", err)
+			return -1
+		}
+		if err := memcacheClient.Set(&memcache.Item{Key: path, Value: []byte(dp)}); err != nil {
 			utils.Error.Printf("Job failed. Err=%s", err)
 			return -1
 		}
@@ -211,46 +302,120 @@ func statestorageSet(path string, val string, ts string) int {
 	return -1
 }
 
+// initUdsEndpoint pre-fix accepted exactly one connection, read into a 512-byte
+// buffer with no framing, and had three unchecked type assertions on the JSON
+// message. The fixed version loops on Accept (reconnect support), uses 8 KiB,
+// drops oversized frames, and routes parsing through handleServerMessage
+// which uses comma-ok throughout.
 func initUdsEndpoint(udsChan chan DomainData) {
-	os.Remove("/var/tmp/vissv2/serverFeeder.sock")
-	listener, err := net.Listen("unix", "/var/tmp/vissv2/serverFeeder.sock") //the file must be the same as declared in the feeder-registration.json that the service mgr reads
+	const sockPath = "/var/tmp/vissv2/serverFeeder.sock"
+	os.Remove(sockPath)
+	listener, err := net.Listen("unix", sockPath) //the file must be the same as declared in the feeder-registration.json that the service mgr reads
 	if err != nil {
 		utils.Error.Printf("initUdsEndpoint:UDS listen failed, err = %s", err)
 		os.Exit(-1)
 	}
-	conn, err := listener.Accept()
-	if err != nil {
-		utils.Error.Printf("initUdsEndpoint:UDS accept failed, err = %s", err)
-		os.Exit(-1)
-	}
-	defer conn.Close()
-	buf := make([]byte, 512)
+	defer listener.Close()
 	for {
-		n, err := conn.Read(buf)
+		conn, err := listener.Accept()
 		if err != nil {
-			utils.Error.Printf("initUdsEndpoint:Read failed, err = %s", err)
+			utils.Error.Printf("initUdsEndpoint:UDS accept failed, err = %s. Retrying in 1s.", err)
+			time.Sleep(1 * time.Second)
 			continue
 		}
-		utils.Info.Printf("Feeder:Server message: %s", string(buf[:n]))
-		var serverMessageMap map[string]interface{}
-		err = json.Unmarshal(buf[:n], &serverMessageMap)
-		if err != nil {
-			utils.Error.Printf("splitToDomainDataAndTs:Unmarshal error=%s", err)
-			continue
-		}
-		if serverMessageMap["action"] != nil && serverMessageMap["action"].(string) == "set" {
-			domainData, _ := splitToDomainDataAndTs(serverMessageMap["data"].(map[string]interface{}))
-			udsChan <- domainData
-		}
+		udsServeConn(conn, udsChan)
 	}
 }
 
-func splitToDomainDataAndTs(serverMessageMap map[string]interface{}) (DomainData, string) { // server={"dp": {"ts": "Z","value": "Y"},"path": "X"}, redis={"value":"xxx", "ts":"zzz"}
+const udsReadBuf = 8192
+
+func udsServeConn(conn net.Conn, udsChan chan DomainData) {
+	defer conn.Close()
+	buf := make([]byte, udsReadBuf)
+	for {
+		n, err := conn.Read(buf)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				utils.Info.Printf("initUdsEndpoint:peer closed, awaiting next connection")
+			} else {
+				utils.Error.Printf("initUdsEndpoint:Read failed, err = %s", err)
+			}
+			return
+		}
+		if n == len(buf) {
+			utils.Error.Printf("initUdsEndpoint:message at buffer size (%d); likely truncated, dropped", n)
+			continue
+		}
+		utils.Info.Printf("Feeder:Server message: %s", string(buf[:n]))
+		handleServerMessage(buf[:n], udsChan)
+	}
+}
+
+// handleServerMessage parses one UDS message and routes a "set" action onto
+// udsChan. Extracted from initUdsEndpoint so the dispatch logic is
+// unit-testable and every type assertion uses comma-ok form. Pre-fix, two
+// bare type assertions on attacker-controlled JSON would panic the feeder.
+func handleServerMessage(raw []byte, udsChan chan DomainData) {
+	var serverMessageMap map[string]interface{}
+	if err := json.Unmarshal(raw, &serverMessageMap); err != nil {
+		utils.Error.Printf("initUdsEndpoint:Unmarshal error=%s", err)
+		return
+	}
+	action, ok := mapString(serverMessageMap, "action")
+	if !ok {
+		// Pre-fix the code only acted on "set" but didn't reject other shapes;
+		// silently ignoring messages with no/invalid action is fine here too.
+		return
+	}
+	if action != "set" {
+		return
+	}
+	dataMap, ok := serverMessageMap["data"].(map[string]interface{})
+	if !ok {
+		utils.Error.Printf("initUdsEndpoint:set message missing/invalid data field")
+		return
+	}
+	domainData, _, ok := splitToDomainDataAndTs(dataMap)
+	if !ok {
+		return
+	}
+	select {
+	case udsChan <- domainData:
+	default:
+		utils.Error.Printf("initUdsEndpoint:udsChan full, dropping %q", domainData.Name)
+	}
+}
+
+// splitToDomainDataAndTs parses a server datapoint of the shape
+//   {"dp": {"ts": "Z","value": "Y"},"path": "X"}
+// and returns the extracted DomainData, the timestamp string, and ok=true.
+// On any parse / shape error, returns zero values and ok=false (without
+// panicking). Pre-fix this had four unchecked .(string)/.(map) assertions.
+func splitToDomainDataAndTs(serverMessageMap map[string]interface{}) (DomainData, string, bool) {
 	var domainData DomainData
-	domainData.Name = serverMessageMap["path"].(string)
-	dpMap := serverMessageMap["dp"].(map[string]interface{})
-	domainData.Value = dpMap["value"].(string)
-	return domainData, dpMap["ts"].(string)
+	name, ok := mapString(serverMessageMap, "path")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid path")
+		return domainData, "", false
+	}
+	dpMap, ok := serverMessageMap["dp"].(map[string]interface{})
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid dp object")
+		return domainData, "", false
+	}
+	value, ok := mapString(dpMap, "value")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid value")
+		return domainData, "", false
+	}
+	ts, ok := mapString(dpMap, "ts")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid ts")
+		return domainData, "", false
+	}
+	domainData.Name = name
+	domainData.Value = value
+	return domainData, ts, true
 }
 
 type simulateDataCtx struct {
@@ -305,8 +470,13 @@ func simulateInput(simCtx *simulateDataCtx) DomainData {
 	return input
 }
 
+// calcInputValue pre-fix discarded the Atoi error silently. Now reports it so
+// non-numeric setValue is visible in logs.
 func calcInputValue(iteration int, setValue string) string {
-	setVal, _ := strconv.Atoi(setValue)
+	setVal, err := strconv.Atoi(setValue)
+	if err != nil {
+		utils.Error.Printf("calcInputValue:setValue=%q not an integer: %v", setValue, err)
+	}
 	newVal := setVal - 10 + iteration
 	return strconv.Itoa(newVal)
 }
@@ -314,6 +484,10 @@ func calcInputValue(iteration int, setValue string) string {
 func selectRandomInput(fMap []FeederMap) DomainData {
 	var domainData DomainData
 	signalIndex := getRandomVssfMapIndex(fMap)
+	if signalIndex < 0 || signalIndex >= len(fMap) {
+		// No suitable signal - return empty DomainData; the consumer will skip it.
+		return domainData
+	}
 	domainData.Name = fMap[signalIndex].Name
 	if fMap[signalIndex].Datatype == 0 { // uint8, maybe allowed...
 		domainData.Value = strconv.Itoa(rand.Intn(10))
@@ -324,16 +498,26 @@ func selectRandomInput(fMap []FeederMap) DomainData {
 	} else {
 		domainData.Value = strconv.Itoa(rand.Intn(1000))
 	}
-//	utils.Info.Printf("Simulated data from Vehicle interface: Name=%s, Value=%s", domainData.Name, domainData.Value)
 	return domainData
 }
 
+// getRandomVssfMapIndex picks an entry without a dot in the Name (i.e. a
+// vehicle-side leaf). Returns -1 if fMap is empty or contains no qualifying
+// entries. Pre-fix used `% (len(fMap)-1)` which skipped the last slot and
+// divided by zero when len(fMap)==1; if every name contained a dot it
+// looped forever.
 func getRandomVssfMapIndex(fMap []FeederMap) int {
-	signalIndex := rand.Intn(len(fMap))
-	for strings.Contains(fMap[signalIndex].Name, ".") { // assuming vehicle if names do not contain dot...
-		signalIndex = (signalIndex + 1) % (len(fMap) - 1)
+	if len(fMap) == 0 {
+		return -1
 	}
-	return signalIndex
+	signalIndex := rand.Intn(len(fMap))
+	for attempts := 0; attempts < len(fMap); attempts++ {
+		if !strings.Contains(fMap[signalIndex].Name, ".") {
+			return signalIndex
+		}
+		signalIndex = (signalIndex + 1) % len(fMap)
+	}
+	return -1
 }
 
 func readSimulatedData(fname string) []DataItem {
@@ -354,67 +538,100 @@ func readSimulatedData(fname string) []DataItem {
 	return tripData
 }
 
+// getSimulatedDataPoints pre-fix panicked the moment any per-path Dp slice was
+// shorter than dpIndex+1. It now skips short rows and returns only valid
+// datapoints.
 func getSimulatedDataPoints(dpIndex int) []DomainData {
-	dataPoint := make([]DomainData, len(tripData))
+	dataPoints := make([]DomainData, 0, len(tripData))
 	for i := 0; i < len(tripData); i++ {
-		dataPoint[i].Name = tripData[i].Path
-		dataPoint[i].Value = tripData[i].Dp[dpIndex].Value
+		if dpIndex < 0 || dpIndex >= len(tripData[i].Dp) {
+			continue
+		}
+		dataPoints = append(dataPoints, DomainData{
+			Name:  tripData[i].Path,
+			Value: tripData[i].Dp[dpIndex].Value,
+		})
 	}
-	return dataPoint
+	return dataPoints
 }
 
 func incDpIndex(index int) int {
+	if len(tripData) == 0 || len(tripData[0].Dp) == 0 {
+		return 0
+	}
 	index++
-	if index == len(tripData[0].Dp) {
+	if index >= len(tripData[0].Dp) {
 		return 0
 	}
 	return index
 }
 
+// convertDomainData now guards against an empty feederMap and an out-of-range
+// MapIndex stored in the mapfile. Pre-fix either of those triggered a slice OOB
+// panic.
 func convertDomainData(north2SouthConv bool, inData DomainData, feederMap []FeederMap) DomainData {
 	var outData DomainData
+	if len(feederMap) == 0 || inData.Name == "" {
+		return inData
+	}
 	matchIndex := sort.Search(len(feederMap), func(i int) bool { return feederMap[i].Name >= inData.Name })
 	if matchIndex == len(feederMap) || feederMap[matchIndex].Name != inData.Name {
 		utils.Error.Printf("convertDomainData:Failed to map= %s", inData.Name)
 		return outData
 	}
-	outData.Name = feederMap[feederMap[matchIndex].MapIndex].Name
+	mapIdx := int(feederMap[matchIndex].MapIndex)
+	if mapIdx < 0 || mapIdx >= len(feederMap) {
+		utils.Error.Printf("convertDomainData:MapIndex %d for %q out of range [0,%d)", mapIdx, inData.Name, len(feederMap))
+		return outData
+	}
+	outData.Name = feederMap[mapIdx].Name
 	outData.Value = convertValue(inData.Value, feederMap[matchIndex].ConvertIndex,
-		feederMap[matchIndex].Datatype, feederMap[feederMap[matchIndex].MapIndex].Datatype, north2SouthConv)
+		feederMap[matchIndex].Datatype, feederMap[mapIdx].Datatype, north2SouthConv)
 	return outData
 }
 
+// convertValue pre-fix indexed scalingDataList[convertIndex-1] without a
+// bounds check (panic on out-of-range / nil list), and its type switch had a
+// `case interface{}` arm that matched every type, then blindly asserted
+// `.([]interface{})` and panicked on strings/numbers.
 func convertValue(value string, convertIndex uint16, inDatatype int8, outDatatype int8, north2SouthConv bool) string {
-	switch convertIndex {
-	case 0: // no conversion
+	if convertIndex == 0 { // no conversion
 		return value
-	default: // call to conversion method
-		var convertDataMap interface{}
-		err := json.Unmarshal([]byte(scalingDataList[convertIndex-1]), &convertDataMap)
-		if err != nil {
-			utils.Error.Printf("convertValue:Error unmarshal scalingDataList item=%s", scalingDataList[convertIndex-1])
-			return ""
-		}
-		switch vv := convertDataMap.(type) {
-		case map[string]interface{}:
-			return enumConversion(vv, north2SouthConv, value)
-		case interface{}:
-			return linearConversion(vv.([]interface{}), north2SouthConv, value)
-		default:
-			utils.Error.Printf("convertValue: convert data=%s has unknown format.", scalingDataList[convertIndex-1])
-		}
 	}
-	return ""
+	idx := int(convertIndex) - 1
+	if idx < 0 || idx >= len(scalingDataList) {
+		utils.Error.Printf("convertValue: convertIndex %d out of range for scalingDataList(len=%d)", convertIndex, len(scalingDataList))
+		return ""
+	}
+	var convertDataMap interface{}
+	if err := json.Unmarshal([]byte(scalingDataList[idx]), &convertDataMap); err != nil {
+		utils.Error.Printf("convertValue:Error unmarshal scalingDataList item=%s", scalingDataList[idx])
+		return ""
+	}
+	switch vv := convertDataMap.(type) {
+	case map[string]interface{}:
+		return enumConversion(vv, north2SouthConv, value)
+	case []interface{}:
+		return linearConversion(vv, north2SouthConv, value)
+	default:
+		utils.Error.Printf("convertValue: convert data=%s has unknown format (got %T)", scalingDataList[idx], convertDataMap)
+		return ""
+	}
 }
 
 func enumConversion(enumObj map[string]interface{}, north2SouthConv bool, inValue string) string { // enumObj = {"Key1":"value1", .., "KeyN":"valueN"}, k is VSS value
 	for k, v := range enumObj {
+		s, ok := v.(string)
+		if !ok {
+			utils.Error.Printf("enumConversion: non-string value for key %q (got %T)", k, v)
+			continue
+		}
 		if north2SouthConv {
 			if k == inValue {
-				return v.(string)
+				return s
 			}
 		} else {
-			if v.(string) == inValue {
+			if s == inValue {
 				return k
 			}
 		}
@@ -423,24 +640,36 @@ func enumConversion(enumObj map[string]interface{}, north2SouthConv bool, inValu
 	return ""
 }
 
+// linearConversion pre-fix did `coeffArray[0].(float64)` / `[1].(float64)`
+// without a length check or comma-ok. It also passed bitSize=32 to FormatFloat
+// even though y is float64, producing precision loss. Both fixed below.
 func linearConversion(coeffArray []interface{}, north2SouthConv bool, inValue string) string { // coeffArray = [A, B], y = Ax +B, y is VSS value
-	var A float64
-	var B float64
-	var x float64
-	var err error
-	if x, err = strconv.ParseFloat(inValue, 64); err != nil {
+	if len(coeffArray) < 2 {
+		utils.Error.Printf("linearConversion: coefficient array too short (len=%d, need 2)", len(coeffArray))
+		return ""
+	}
+	x, err := strconv.ParseFloat(inValue, 64)
+	if err != nil {
 		utils.Error.Printf("linearConversion: input value=%s cannot be converted to float.", inValue)
 		return ""
 	}
-	A = coeffArray[0].(float64)
-	B = coeffArray[1].(float64)
+	A, okA := coeffArray[0].(float64)
+	B, okB := coeffArray[1].(float64)
+	if !okA || !okB {
+		utils.Error.Printf("linearConversion: coefficients must be numbers (got A=%T, B=%T)", coeffArray[0], coeffArray[1])
+		return ""
+	}
 	var y float64
 	if north2SouthConv {
 		y = A*x + B
 	} else {
+		if A == 0 {
+			utils.Error.Printf("linearConversion: south-to-north divide-by-zero (A=0)")
+			return ""
+		}
 		y = (x - B) / A
 	}
-	return strconv.FormatFloat(y, 'f', -1, 32)
+	return strconv.FormatFloat(y, 'f', -1, 64)
 }
 
 func main() {
@@ -467,10 +696,12 @@ func main() {
 		Required: false,
 		Help:     "statestorage database filename",
 		Default:  "../../server/vissv2server/serviceMgr/statestorage.db"})
-	// Parse input
+	// Parse input. Pre-fix this only logged the error and continued running
+	// with whatever defaults / zero values had been left in place.
 	err := parser.Parse(os.Args)
 	if err != nil {
 		utils.Error.Print(parser.Usage(err))
+		os.Exit(1)
 	}
 	stateDbType = *stateDB
 	simulatedSource = *simSource
@@ -490,6 +721,7 @@ func main() {
 			}
 		} else {
 			utils.Error.Printf("Could not find state storage file = %s", *dbFile)
+			os.Exit(1)
 		}
 	case "redis":
 		redisClient = redis.NewClient(&redis.Options{
@@ -530,6 +762,10 @@ func main() {
 
 	utils.Info.Printf("Initializing the feeder for mapping file %s.", *mapFile)
 	feederMap := readFeederMap(*mapFile)
+	if len(feederMap) == 0 {
+		utils.Error.Printf("Empty/unreadable feeder map %s.", *mapFile)
+		os.Exit(1)
+	}
 	if simulatedSource != "internal" {
 		tripData = readSimulatedData("tripdata.json")
 		if len(tripData) == 0 {
@@ -549,7 +785,6 @@ func main() {
 			if simulatedSource != "vssjson" {
 				vssOutputChan <- convertDomainData(false, vehicleInData, feederMap)
 			} else {
-				//utils.Info.Printf("simulatedDataPoints:Path=%s, Value=%s", vehicleInData.Name, vehicleInData.Value)
 				vssOutputChan <- vehicleInData // conversion not needed
 			}
 		}

--- a/feeder/feeder-template/feederv3/feederv3.go
+++ b/feeder/feeder-template/feederv3/feederv3.go
@@ -10,20 +10,24 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
+	"io"
+	"math/rand"
+	"net"
+	"os"
+	"os/exec"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/akamensky/argparse"
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/covesa/vissr/utils"
 	"github.com/go-redis/redis"
 	_ "github.com/mattn/go-sqlite3"
-	"math/rand"
-	"net"
-	"os"
-	"os/exec"
-	"sort"
-	"strconv"
-	"strings"
-	"slices"
-	"time"
 )
 
 type DomainData struct {
@@ -59,7 +63,40 @@ var memcacheClient *memcache.Client
 var dbHandle *sql.DB
 var stateDbType string
 
-var notificationList []string
+// notificationList is mutated from udsReader (server messages) and read from
+// initVSSInterfaceMgr (data-write path). Pre-fix these ran in two goroutines
+// with no synchronization. notificationMu serializes both sides.
+var (
+	notificationList []string
+	notificationMu   sync.Mutex
+)
+
+// mapString returns m[key] as a string. Returns ("", false) on absent, nil,
+// or wrong-type entries. Replaces the unchecked .(string) assertions that
+// previously panicked the feeder on any malformed server message.
+func mapString(m map[string]interface{}, key string) (string, bool) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
+}
+
+// marshalDatapointJSON encodes the {"value":..., "ts":...} datapoint using
+// encoding/json so values containing quotes / backslashes / control chars
+// can't produce malformed JSON. The pre-fix string-concat path corrupted
+// any value with a `"` in it.
+func marshalDatapointJSON(val, ts string) (string, error) {
+	b, err := json.Marshal(map[string]string{"value": val, "ts": ts})
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
 
 func fileExists(filename string) bool {
 	info, err := os.Stat(filename)
@@ -95,47 +132,103 @@ func readFeederMap(mapFilename string) []FeederMap {
 		utils.Error.Printf("Could not open %s for reading map data", mapFilename)
 		return nil
 	}
+	defer treeFp.Close()
 	for {
-		mapElement := readElement(treeFp)
+		mapElement, ok := readElement(treeFp)
+		if !ok {
+			break
+		}
 		if mapElement.Name == "" {
 			break
 		}
 		feederMap = append(feederMap, mapElement)
 	}
-	treeFp.Close()
+	// Sort by Name so callers using sort.Search work correctly.
+	sort.Slice(feederMap, func(i, j int) bool { return feederMap[i].Name < feederMap[j].Name })
 	return feederMap
 }
 
-// The reading order must be aligned with the reading order by the Domain Conversion Tool
-func readElement(treeFp *os.File) FeederMap {
+// readElement reads one FeederMap entry. Returns (zero, false) on short/corrupt
+// read so the caller stops cleanly instead of inheriting a half-populated entry.
+// Pre-fix this had five unchecked type assertions on deSerializeUInt's return
+// (which is `nil` on short reads) and would panic on any truncated mapfile.
+func readElement(treeFp *os.File) (FeederMap, bool) {
 	var feederMap FeederMap
-	feederMap.MapIndex = deSerializeUInt(readBytes(2, treeFp)).(uint16)
-	//utils.Info.Printf("feederMap.MapIndex=%d\n", feederMap.MapIndex)
+	mapIndex, ok := readUint16(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.MapIndex = mapIndex
 
-	NameLen := deSerializeUInt(readBytes(1, treeFp)).(uint8)
-	feederMap.Name = string(readBytes((uint32)(NameLen), treeFp))
-	//utils.Info.Printf("NameLen=%d\n", NameLen)
-	//utils.Info.Printf("feederMap.Name=%s\n", feederMap.Name)
+	nameLen, ok := readUint8(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	nameBytes, ok := readBytes(uint32(nameLen), treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.Name = string(nameBytes)
 
-	feederMap.Type = (int8)(deSerializeUInt(readBytes(1, treeFp)).(uint8))
-	//utils.Info.Printf("feederMap.Type=%d\n", feederMap.Type)
+	typeByte, ok := readUint8(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.Type = int8(typeByte)
 
-	feederMap.Datatype = (int8)(deSerializeUInt(readBytes(1, treeFp)).(uint8))
-	//utils.Info.Printf("feederMap.Datatype=%d\n", feederMap.Datatype)
+	dataTypeByte, ok := readUint8(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.Datatype = int8(dataTypeByte)
 
-	feederMap.ConvertIndex = deSerializeUInt(readBytes(2, treeFp)).(uint16)
-	//utils.Info.Printf("feederMap.ConvertIndex=%d\n", feederMap.ConvertIndex)
-
-	return feederMap
+	convertIndex, ok := readUint16(treeFp)
+	if !ok {
+		return feederMap, false
+	}
+	feederMap.ConvertIndex = convertIndex
+	return feederMap, true
 }
 
-func readBytes(numOfBytes uint32, treeFp *os.File) []byte {
-	if numOfBytes > 0 {
-		buf := make([]byte, numOfBytes)
-		treeFp.Read(buf)
-		return buf
+// MaxReadBytes caps per-call allocation so a corrupt mapfile with a large
+// length prefix cannot trigger a multi-GiB allocation.
+const MaxReadBytes = 1 << 20 // 1 MiB
+
+// readBytes pre-fix called treeFp.Read once and ignored the returned count and
+// error. It now uses io.ReadFull, caps the request size, and returns ok=false
+// on any short read so the caller can bail out cleanly.
+func readBytes(numOfBytes uint32, treeFp *os.File) ([]byte, bool) {
+	if numOfBytes == 0 {
+		return nil, true
 	}
-	return nil
+	if numOfBytes > MaxReadBytes {
+		utils.Error.Printf("readBytes: refusing to allocate %d bytes (cap=%d)", numOfBytes, MaxReadBytes)
+		return nil, false
+	}
+	buf := make([]byte, numOfBytes)
+	if _, err := io.ReadFull(treeFp, buf); err != nil {
+		if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			utils.Error.Printf("readBytes: read failed: %v", err)
+		}
+		return nil, false
+	}
+	return buf, true
+}
+
+func readUint8(treeFp *os.File) (uint8, bool) {
+	buf, ok := readBytes(1, treeFp)
+	if !ok {
+		return 0, false
+	}
+	return buf[0], true
+}
+
+func readUint16(treeFp *os.File) (uint16, bool) {
+	buf, ok := readBytes(2, treeFp)
+	if !ok {
+		return 0, false
+	}
+	return uint16(buf[1])*256 + uint16(buf[0]), true
 }
 
 func deSerializeUInt(buf []byte) interface{} {
@@ -158,21 +251,50 @@ func deSerializeUInt(buf []byte) interface{} {
 	}
 }
 
+// initVSSInterfaceMgr pre-fix accepted exactly one connection then ran forever;
+// if the peer dropped, the udsReader returned and writes piled up on a dead
+// channel. The fixed version loops on Accept so the feeder reconnects after
+// the server restarts.
 func initVSSInterfaceMgr(inputChan chan DomainData, outputChan chan DomainData) {
-	os.Remove("/var/tmp/vissv2/serverFeeder.sock")
-	listener, err := net.Listen("unix", "/var/tmp/vissv2/serverFeeder.sock") //the file must be the same as declared in the feeder-registration.json that the service mgr reads
+	const sockPath = "/var/tmp/vissv2/serverFeeder.sock"
+	os.Remove(sockPath)
+	listener, err := net.Listen("unix", sockPath) //the file must be the same as declared in the feeder-registration.json that the service mgr reads
 	if err != nil {
 		utils.Error.Printf("udsReader:UDS listen failed, err = %s", err)
 		os.Exit(-1)
 	}
-	conn, err := listener.Accept()
-	if err != nil {
-		utils.Error.Printf("udsReader:UDS accept failed, err = %s", err)
-		os.Exit(-1)
+	defer listener.Close()
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			utils.Error.Printf("udsReader:UDS accept failed, err = %s. Retrying in 1s.", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		serveOnce(conn, inputChan, outputChan)
 	}
-	udsChan := make(chan string)
-	go udsReader(conn, inputChan, udsChan)
-	go udsWriter(conn, udsChan)
+}
+
+// serveOnce runs the reader and writer goroutines on a single connection,
+// then returns when either side ends so the outer Accept loop can reconnect.
+// On exit it closes udsChan so the writer goroutine returns cleanly rather
+// than leaking blocked on a receive.
+func serveOnce(conn net.Conn, inputChan chan DomainData, outputChan chan DomainData) {
+	udsChan := make(chan string, 4)
+	done := make(chan struct{})
+	go func() {
+		udsReader(conn, inputChan, udsChan)
+		close(done)
+	}()
+	writerDone := make(chan struct{})
+	go func() {
+		udsWriter(conn, udsChan)
+		close(writerDone)
+	}()
+	defer func() {
+		close(udsChan) // let udsWriter exit cleanly
+		<-writerDone
+	}()
 	for {
 		select {
 		case outData := <-outputChan:
@@ -182,13 +304,22 @@ func initVSSInterfaceMgr(inputChan chan DomainData, outputChan chan DomainData) 
 			status := statestorageSet(outData.Name, outData.Value, utils.GetRfcTime())
 			if status != 0 {
 				utils.Error.Printf("initVSSInterfaceMgr():State storage write failed")
-			} else {
-				if onNotificationList(outData.Name) != -1 {
-					message := `{"action": "subscription", "path":"` + outData.Name + `"}`
-					udsChan <- message
-					utils.Info.Printf("Server notified that data written to %s", outData.Name)
-				}
+				continue
 			}
+			notificationMu.Lock()
+			notify := onNotificationListLocked(outData.Name) != -1
+			notificationMu.Unlock()
+			if notify {
+				message := `{"action": "subscription", "path":"` + outData.Name + `"}`
+				select {
+				case udsChan <- message:
+				default:
+					utils.Error.Printf("udsWriter:udsChan full, dropping subscription notification for %q", outData.Name)
+				}
+				utils.Info.Printf("Server notified that data written to %s", outData.Name)
+			}
+		case <-done:
+			return
 		}
 	}
 }
@@ -210,17 +341,23 @@ func statestorageSet(path string, val string, ts string) int {
 		}
 		return 0
 	case "redis":
-		dp := `{"value":"` + val + `", "ts":"` + ts + `"}`
-		err := redisClient.Set(path, dp, time.Duration(0)).Err()
+		dp, err := marshalDatapointJSON(val, ts)
 		if err != nil {
+			utils.Error.Printf("statestorageSet:Marshal error=%v", err)
+			return -1
+		}
+		if err := redisClient.Set(path, dp, time.Duration(0)).Err(); err != nil {
 			utils.Error.Printf("Job failed. Err=%s", err)
 			return -1
 		}
 		return 0
 	case "memcache":
-		dp := `{"value":"` + val + `", "ts":"` + ts + `"}`
-		err := memcacheClient.Set(&memcache.Item{Key: path, Value: []byte(dp)})
+		dp, err := marshalDatapointJSON(val, ts)
 		if err != nil {
+			utils.Error.Printf("statestorageSet:Marshal error=%v", err)
+			return -1
+		}
+		if err := memcacheClient.Set(&memcache.Item{Key: path, Value: []byte(dp)}); err != nil {
 			utils.Error.Printf("Job failed. Err=%s", err)
 			return -1
 		}
@@ -236,77 +373,158 @@ func udsReader(conn net.Conn, inputChan chan DomainData, udsChan chan string) {
 		n, err := conn.Read(buf)
 		if err != nil {
 			utils.Error.Printf("udsReader:Read failed, err = %s", err)
+			if errors.Is(err, io.EOF) {
+				return
+			}
 			time.Sleep(1 * time.Second)
 			continue
 		}
 		utils.Info.Printf("udsReader:Message from server: %s", string(buf[:n]))
-		if n > 8192 {
-			utils.Error.Printf("udsReader:Max message size of 8192 chars exceeded. Message dropped")
+		// n cannot exceed len(buf); fill of the buffer suggests truncation.
+		if n == len(buf) {
+			utils.Error.Printf("udsReader: message at buffer size (%d); likely truncated, dropping", n)
 			continue
 		}
-		var serverMessageMap map[string]interface{}
-		err = json.Unmarshal(buf[:n], &serverMessageMap)
-		if err != nil {
-			utils.Error.Printf("udsReader:Unmarshal error=%s", err)
-			continue
+		handleServerMessage(buf[:n], inputChan, udsChan)
+	}
+}
+
+// handleServerMessage parses one UDS message and dispatches by action. Extracted
+// from udsReader so the dispatch logic is unit-testable and every type
+// assertion uses comma-ok form. Pre-fix, ~10 bare type assertions on
+// attacker-controlled JSON panicked the feeder.
+func handleServerMessage(raw []byte, inputChan chan DomainData, udsChan chan string) {
+	var serverMessageMap map[string]interface{}
+	if err := json.Unmarshal(raw, &serverMessageMap); err != nil {
+		utils.Error.Printf("udsReader:Unmarshal error=%s", err)
+		return
+	}
+	action, ok := mapString(serverMessageMap, "action")
+	if !ok {
+		utils.Error.Printf("udsReader:Message missing/invalid action field")
+		return
+	}
+	switch action {
+	case "set":
+		dataMap, ok := serverMessageMap["data"].(map[string]interface{})
+		if !ok {
+			utils.Error.Printf("udsReader:set message missing/invalid data field")
+			return
 		}
-		if serverMessageMap["action"] != nil {
-			switch serverMessageMap["action"].(string) {
-				case "set":
-					domainData, _ := splitToDomainDataAndTs(serverMessageMap["data"].(map[string]interface{}))
-					inputChan <- domainData
-				case "subscribe":
-					pathList := serverMessageMap["path"].([]interface{})
-					for i := 0; i < len(pathList); i++ {
-						if onNotificationList(pathList[i].(string)) == -1 {
-							notificationList = append(notificationList, pathList[i].(string))
-						}
-					}
-					response := `{"action": "subscribe", "status": "ok"}`
-					udsChan <- response
-				case "unsubscribe":
-					pathList := serverMessageMap["path"].([]interface{})
-					for i := 0; i < len(pathList); i++ {
-						if onNotificationList(pathList[i].(string)) != -1 {
-							notificationList = slices.Delete(notificationList, i, i+1)
-						}
-					}
-				case "update":
-					defaultArray := serverMessageMap["defaultList"].([]interface{})
-					var domainData DomainData
-					for i := 0; i < len(defaultArray); i++ {
-						for k, v := range defaultArray[i].(map[string]interface{}) {
-//							utils.Info.Printf("%d: key=%s, value=%s", i, k, v.(string))
-							if k == "path" {
-								domainData.Name = v.(string)
-							} else if k == "default" {
-								domainData.Value = v.(string)
-							}
-						}
-						statestorageSet(domainData.Name, domainData.Value, utils.GetRfcTime())
-					}
-				default:
-					utils.Error.Printf("udsReader:Message action unknown = %s", serverMessageMap["action"].(string))
+		domainData, _, ok := splitToDomainDataAndTs(dataMap)
+		if !ok {
+			return
+		}
+		select {
+		case inputChan <- domainData:
+		default:
+			utils.Error.Printf("udsReader: inputChan full, dropping set for %q", domainData.Name)
+		}
+	case "subscribe":
+		pathList, ok := serverMessageMap["path"].([]interface{})
+		if !ok {
+			utils.Error.Printf("udsReader:subscribe missing/invalid path array")
+			return
+		}
+		addNotifications(pathList)
+		select {
+		case udsChan <- `{"action": "subscribe", "status": "ok"}`:
+		default:
+			utils.Error.Printf("udsReader: udsChan full, subscribe response dropped")
+		}
+	case "unsubscribe":
+		pathList, ok := serverMessageMap["path"].([]interface{})
+		if !ok {
+			utils.Error.Printf("udsReader:unsubscribe missing/invalid path array")
+			return
+		}
+		removeNotifications(pathList)
+	case "update":
+		defaultArray, ok := serverMessageMap["defaultList"].([]interface{})
+		if !ok {
+			utils.Error.Printf("udsReader:update missing/invalid defaultList array")
+			return
+		}
+		for i := 0; i < len(defaultArray); i++ {
+			elem, ok := defaultArray[i].(map[string]interface{})
+			if !ok {
+				utils.Error.Printf("udsReader:update element %d not an object", i)
+				continue
 			}
+			path, _ := mapString(elem, "path")
+			defVal, _ := mapString(elem, "default")
+			if path == "" {
+				continue
+			}
+			statestorageSet(path, defVal, utils.GetRfcTime())
 		}
+	default:
+		utils.Error.Printf("udsReader:Message action unknown = %s", action)
+	}
+}
+
+// addNotifications appends each string element of pathList to notificationList
+// unless already present. Non-string elements are skipped.
+func addNotifications(pathList []interface{}) {
+	notificationMu.Lock()
+	defer notificationMu.Unlock()
+	for i := 0; i < len(pathList); i++ {
+		p, ok := pathList[i].(string)
+		if !ok {
+			utils.Error.Printf("addNotifications: element %d not a string", i)
+			continue
+		}
+		if onNotificationListLocked(p) == -1 {
+			notificationList = append(notificationList, p)
+		}
+	}
+}
+
+// removeNotifications drops each path in pathList from notificationList.
+// Bug fix: pre-fix code did `slices.Delete(notificationList, i, i+1)` using the
+// input-pathList index `i` instead of the matching index in notificationList,
+// deleting the wrong element. It also never decremented `i` after deletion so
+// shifted entries were skipped. This is the v3 smoking gun.
+func removeNotifications(pathList []interface{}) {
+	notificationMu.Lock()
+	defer notificationMu.Unlock()
+	for i := 0; i < len(pathList); i++ {
+		p, ok := pathList[i].(string)
+		if !ok {
+			utils.Error.Printf("removeNotifications: element %d not a string", i)
+			continue
+		}
+		idx := onNotificationListLocked(p)
+		if idx == -1 {
+			continue
+		}
+		notificationList = slices.Delete(notificationList, idx, idx+1)
 	}
 }
 
 func udsWriter(conn net.Conn, udsChan chan string) {
-	defer conn.Close()
 	for {
-		select {
-		case message := <-udsChan:
+		message, ok := <-udsChan
+		if !ok {
+			return
+		}
 		utils.Info.Printf("udsWriter:Message to server: %s", message)
-			_, err := conn.Write([]byte(message))
-			if err != nil {
-				utils.Error.Printf("udsWriter:Write failed, err = %s", err)
-			}
+		if _, err := conn.Write([]byte(message)); err != nil {
+			utils.Error.Printf("udsWriter:Write failed, err = %s", err)
 		}
 	}
 }
 
+// onNotificationList is the locking wrapper used by external callers (none in
+// this file - retained for API parity with v4). onNotificationListLocked is
+// what the rest of the file uses while already holding notificationMu.
 func onNotificationList(path string) int {
+	notificationMu.Lock()
+	defer notificationMu.Unlock()
+	return onNotificationListLocked(path)
+}
+
+func onNotificationListLocked(path string) int {
 	for i := 0; i < len(notificationList); i++ {
 		if notificationList[i] == path {
 			return i
@@ -315,12 +533,36 @@ func onNotificationList(path string) int {
 	return -1
 }
 
-func splitToDomainDataAndTs(serverMessageMap map[string]interface{}) (DomainData, string) { // server={"dp": {"ts": "Z","value": "Y"},"path": "X"}, redis={"value":"xxx", "ts":"zzz"}
+// splitToDomainDataAndTs parses a server datapoint of the shape
+//   {"dp": {"ts": "Z","value": "Y"},"path": "X"}
+// and returns the extracted DomainData, the timestamp string, and ok=true.
+// On any parse / shape error, returns zero values and ok=false (without
+// panicking). Pre-fix this had four unchecked .(string)/.(map) assertions.
+func splitToDomainDataAndTs(serverMessageMap map[string]interface{}) (DomainData, string, bool) {
 	var domainData DomainData
-	domainData.Name = serverMessageMap["path"].(string)
-	dpMap := serverMessageMap["dp"].(map[string]interface{})
-	domainData.Value = dpMap["value"].(string)
-	return domainData, dpMap["ts"].(string)
+	name, ok := mapString(serverMessageMap, "path")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid path")
+		return domainData, "", false
+	}
+	dpMap, ok := serverMessageMap["dp"].(map[string]interface{})
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid dp object")
+		return domainData, "", false
+	}
+	value, ok := mapString(dpMap, "value")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid value")
+		return domainData, "", false
+	}
+	ts, ok := mapString(dpMap, "ts")
+	if !ok {
+		utils.Error.Printf("splitToDomainDataAndTs: missing/invalid ts")
+		return domainData, "", false
+	}
+	domainData.Name = name
+	domainData.Value = value
+	return domainData, ts, true
 }
 
 type simulateDataCtx struct {
@@ -333,9 +575,9 @@ type simulateDataCtx struct {
 
 type ActuatorSimCtx struct {
 	RemainingSteps int
-	CurrVal string
-	EndVal string
-	Path string
+	CurrVal        string
+	EndVal         string
+	Path           string
 }
 
 func initVehicleInterfaceMgr(fMap []FeederMap, inputChan chan DomainData, outputChan chan DomainData) {
@@ -360,7 +602,7 @@ func initVehicleInterfaceMgr(fMap []FeederMap, inputChan chan DomainData, output
 					continue
 				}
 				aSimCtx[simIndex].RemainingSteps = 10
-				aSimCtx[simIndex].CurrVal = "0"  // well....
+				aSimCtx[simIndex].CurrVal = "0" // well....
 				aSimCtx[simIndex].EndVal = outData.Value
 				aSimCtx[simIndex].Path = outData.Name
 			}
@@ -379,11 +621,12 @@ func initVehicleInterfaceMgr(fMap []FeederMap, inputChan chan DomainData, output
 				for i := 0; i < len(aSimCtx); i++ {
 					if aSimCtx[i].RemainingSteps > 0 {
 						select {
-							case inputChan <- makeDataPoint(aSimCtx[i].Path, calculateSimValue(&(aSimCtx[i]))): 
-								if aSimCtx[i].RemainingSteps == 0 {
-									aSimCtx[i].Path = ""
-								}
-							default: utils.Info.Printf("initVehicleInterfaceMgr: dropping dp")
+						case inputChan <- makeDataPoint(aSimCtx[i].Path, calculateSimValue(&(aSimCtx[i]))):
+							if aSimCtx[i].RemainingSteps == 0 {
+								aSimCtx[i].Path = ""
+							}
+						default:
+							utils.Info.Printf("initVehicleInterfaceMgr: dropping dp")
 						}
 					}
 				}
@@ -406,36 +649,56 @@ func getSimulatorContainer(aSimCtx []ActuatorSimCtx, path string) int {
 	return -1
 }
 
+// calculateSimValue pre-fix performed `step := (endValue - currValue) / noOfSteps`
+// in integer arithmetic; if the delta was smaller than the step count the
+// result truncated to 0 and CurrVal never moved. It also used FormatFloat
+// bitSize=32 on a float64 (precision loss). Both fixed below: integer ramps
+// distribute the remainder, float ramps use bitSize=64.
 func calculateSimValue(aSimCtx *ActuatorSimCtx) string {
 	noOfSteps := aSimCtx.RemainingSteps
+	if noOfSteps <= 0 {
+		return aSimCtx.CurrVal
+	}
 	aSimCtx.RemainingSteps--
 	endValue, err := strconv.Atoi(aSimCtx.EndVal)
 	if err != nil {
-		endValue, err := strconv.ParseFloat(aSimCtx.EndVal, 64)
+		endValueF, err := strconv.ParseFloat(aSimCtx.EndVal, 64)
 		if err != nil {
 			aSimCtx.RemainingSteps = 0
 			return aSimCtx.EndVal
 		}
-		currValue, err := strconv.ParseFloat(aSimCtx.CurrVal, 64)
+		currValueF, err := strconv.ParseFloat(aSimCtx.CurrVal, 64)
 		if err != nil {
 			aSimCtx.RemainingSteps = 0
 			return aSimCtx.EndVal
-		} else {
-			step := (endValue - currValue) / float64(noOfSteps)
-			aSimCtx.CurrVal = strconv.FormatFloat(currValue + step, 'f', -1, 32)
-			return aSimCtx.CurrVal
 		}
-	} else {
-		currValue, err := strconv.Atoi(aSimCtx.CurrVal)
-		if err != nil {
-			aSimCtx.RemainingSteps = 0
-			return aSimCtx.EndVal
+		step := (endValueF - currValueF) / float64(noOfSteps)
+		aSimCtx.CurrVal = strconv.FormatFloat(currValueF+step, 'f', -1, 64)
+		return aSimCtx.CurrVal
+	}
+	currValue, err := strconv.Atoi(aSimCtx.CurrVal)
+	if err != nil {
+		aSimCtx.RemainingSteps = 0
+		return aSimCtx.EndVal
+	}
+	// Integer ramp: on the final step jump to endValue so int-truncation can't
+	// strand the simulation short of its target.
+	if aSimCtx.RemainingSteps == 0 {
+		aSimCtx.CurrVal = strconv.Itoa(endValue)
+		return aSimCtx.CurrVal
+	}
+	step := (endValue - currValue) / noOfSteps
+	if step == 0 && endValue != currValue {
+		// Nudge by 1 in the right direction so we make forward progress
+		// instead of stalling at currValue.
+		if endValue > currValue {
+			step = 1
 		} else {
-			step := (endValue - currValue) / noOfSteps
-			aSimCtx.CurrVal = strconv.Itoa(currValue + step)
-			return aSimCtx.CurrVal
+			step = -1
 		}
 	}
+	aSimCtx.CurrVal = strconv.Itoa(currValue + step)
+	return aSimCtx.CurrVal
 }
 
 func makeDataPoint(path string, value string) DomainData {
@@ -460,7 +723,10 @@ func simulateInput(simCtx *simulateDataCtx) DomainData {
 }
 
 func calcInputValue(iteration int, setValue string) string {
-	setVal, _ := strconv.Atoi(setValue)
+	setVal, err := strconv.Atoi(setValue)
+	if err != nil {
+		utils.Error.Printf("calcInputValue:setValue=%q not an integer: %v", setValue, err)
+	}
 	newVal := setVal - 10 + iteration
 	return strconv.Itoa(newVal)
 }
@@ -468,6 +734,9 @@ func calcInputValue(iteration int, setValue string) string {
 func selectRandomInput(fMap []FeederMap) DomainData {
 	var domainData DomainData
 	signalIndex := getRandomVssfMapIndex(fMap)
+	if signalIndex < 0 || signalIndex >= len(fMap) {
+		return domainData
+	}
 	domainData.Name = fMap[signalIndex].Name
 	if fMap[signalIndex].Datatype == 0 { // uint8, maybe allowed...
 		domainData.Value = strconv.Itoa(rand.Intn(10))
@@ -478,16 +747,26 @@ func selectRandomInput(fMap []FeederMap) DomainData {
 	} else {
 		domainData.Value = strconv.Itoa(rand.Intn(1000))
 	}
-//	utils.Info.Printf("Simulated data from Vehicle interface: Name=%s, Value=%s", domainData.Name, domainData.Value)
 	return domainData
 }
 
+// getRandomVssfMapIndex picks an entry without a dot in the Name (i.e. a
+// vehicle-side leaf). Returns -1 if fMap is empty or contains no qualifying
+// entries. Pre-fix used `% (len(fMap)-1)` which skipped the last slot and
+// divided by zero when len(fMap)==1; if every name contained a dot it
+// looped forever.
 func getRandomVssfMapIndex(fMap []FeederMap) int {
-	signalIndex := rand.Intn(len(fMap))
-	for strings.Contains(fMap[signalIndex].Name, ".") { // assuming vehicle if names do not contain dot...
-		signalIndex = (signalIndex + 1) % (len(fMap) - 1)
+	if len(fMap) == 0 {
+		return -1
 	}
-	return signalIndex
+	signalIndex := rand.Intn(len(fMap))
+	for attempts := 0; attempts < len(fMap); attempts++ {
+		if !strings.Contains(fMap[signalIndex].Name, ".") {
+			return signalIndex
+		}
+		signalIndex = (signalIndex + 1) % len(fMap)
+	}
+	return -1
 }
 
 func readSimulatedData(fname string) []DataItem {
@@ -508,18 +787,30 @@ func readSimulatedData(fname string) []DataItem {
 	return tripData
 }
 
+// getSimulatedDataPoints returns one datapoint per tripData path. Skips paths
+// whose per-path Dp slice is shorter than dpIndex+1 (rather than panicking,
+// which the pre-fix code did the moment any per-path row was shorter than
+// tripData[0].Dp).
 func getSimulatedDataPoints(dpIndex int) []DomainData {
-	dataPoint := make([]DomainData, len(tripData))
+	dataPoints := make([]DomainData, 0, len(tripData))
 	for i := 0; i < len(tripData); i++ {
-		dataPoint[i].Name = tripData[i].Path
-		dataPoint[i].Value = tripData[i].Dp[dpIndex].Value
+		if dpIndex < 0 || dpIndex >= len(tripData[i].Dp) {
+			continue
+		}
+		dataPoints = append(dataPoints, DomainData{
+			Name:  tripData[i].Path,
+			Value: tripData[i].Dp[dpIndex].Value,
+		})
 	}
-	return dataPoint
+	return dataPoints
 }
 
 func incDpIndex(index int) int {
+	if len(tripData) == 0 || len(tripData[0].Dp) == 0 {
+		return 0
+	}
 	index++
-	if index == len(tripData[0].Dp) {
+	if index >= len(tripData[0].Dp) {
 		return 0
 	}
 	return index
@@ -527,48 +818,67 @@ func incDpIndex(index int) int {
 
 func convertDomainData(north2SouthConv bool, inData DomainData, feederMap []FeederMap) DomainData {
 	var outData DomainData
+	if len(feederMap) == 0 || inData.Name == "" {
+		return inData
+	}
 	matchIndex := sort.Search(len(feederMap), func(i int) bool { return feederMap[i].Name >= inData.Name })
 	if matchIndex == len(feederMap) || feederMap[matchIndex].Name != inData.Name {
 		utils.Error.Printf("convertDomainData:Failed to map= %s", inData.Name)
-		return inData  //assume 1-to-1...
+		return inData //assume 1-to-1...
 	}
-	outData.Name = feederMap[feederMap[matchIndex].MapIndex].Name
+	mapIdx := int(feederMap[matchIndex].MapIndex)
+	if mapIdx < 0 || mapIdx >= len(feederMap) {
+		utils.Error.Printf("convertDomainData:MapIndex %d for %q out of range [0,%d)", mapIdx, inData.Name, len(feederMap))
+		return inData
+	}
+	outData.Name = feederMap[mapIdx].Name
 	outData.Value = convertValue(inData.Value, feederMap[matchIndex].ConvertIndex,
-		feederMap[matchIndex].Datatype, feederMap[feederMap[matchIndex].MapIndex].Datatype, north2SouthConv)
+		feederMap[matchIndex].Datatype, feederMap[mapIdx].Datatype, north2SouthConv)
 	return outData
 }
 
+// convertValue pre-fix indexed scalingDataList[convertIndex-1] without a
+// bounds check (panic on out-of-range / nil list), and its type switch had a
+// `case interface{}` arm that matched every type, then blindly asserted
+// `.([]interface{})` and panicked on strings/numbers.
 func convertValue(value string, convertIndex uint16, inDatatype int8, outDatatype int8, north2SouthConv bool) string {
-	switch convertIndex {
-	case 0: // no conversion
+	if convertIndex == 0 { // no conversion
 		return value
-	default: // call to conversion method
-		var convertDataMap interface{}
-		err := json.Unmarshal([]byte(scalingDataList[convertIndex-1]), &convertDataMap)
-		if err != nil {
-			utils.Error.Printf("convertValue:Error unmarshal scalingDataList item=%s", scalingDataList[convertIndex-1])
-			return ""
-		}
-		switch vv := convertDataMap.(type) {
-		case map[string]interface{}:
-			return enumConversion(vv, north2SouthConv, value)
-		case interface{}:
-			return linearConversion(vv.([]interface{}), north2SouthConv, value)
-		default:
-			utils.Error.Printf("convertValue: convert data=%s has unknown format.", scalingDataList[convertIndex-1])
-		}
 	}
-	return ""
+	idx := int(convertIndex) - 1
+	if idx < 0 || idx >= len(scalingDataList) {
+		utils.Error.Printf("convertValue: convertIndex %d out of range for scalingDataList(len=%d)", convertIndex, len(scalingDataList))
+		return ""
+	}
+	var convertDataMap interface{}
+	if err := json.Unmarshal([]byte(scalingDataList[idx]), &convertDataMap); err != nil {
+		utils.Error.Printf("convertValue:Error unmarshal scalingDataList item=%s", scalingDataList[idx])
+		return ""
+	}
+	switch vv := convertDataMap.(type) {
+	case map[string]interface{}:
+		return enumConversion(vv, north2SouthConv, value)
+	case []interface{}:
+		return linearConversion(vv, north2SouthConv, value)
+	default:
+		utils.Error.Printf("convertValue: convert data=%s has unknown format (got %T)", scalingDataList[idx], convertDataMap)
+		return ""
+	}
 }
 
 func enumConversion(enumObj map[string]interface{}, north2SouthConv bool, inValue string) string { // enumObj = {"Key1":"value1", .., "KeyN":"valueN"}, k is VSS value
 	for k, v := range enumObj {
+		s, ok := v.(string)
+		if !ok {
+			utils.Error.Printf("enumConversion: non-string value for key %q (got %T)", k, v)
+			continue
+		}
 		if north2SouthConv {
 			if k == inValue {
-				return v.(string)
+				return s
 			}
 		} else {
-			if v.(string) == inValue {
+			if s == inValue {
 				return k
 			}
 		}
@@ -578,23 +888,32 @@ func enumConversion(enumObj map[string]interface{}, north2SouthConv bool, inValu
 }
 
 func linearConversion(coeffArray []interface{}, north2SouthConv bool, inValue string) string { // coeffArray = [A, B], y = Ax +B, y is VSS value
-	var A float64
-	var B float64
-	var x float64
-	var err error
-	if x, err = strconv.ParseFloat(inValue, 64); err != nil {
+	if len(coeffArray) < 2 {
+		utils.Error.Printf("linearConversion: coefficient array too short (len=%d, need 2)", len(coeffArray))
+		return ""
+	}
+	x, err := strconv.ParseFloat(inValue, 64)
+	if err != nil {
 		utils.Error.Printf("linearConversion: input value=%s cannot be converted to float.", inValue)
 		return ""
 	}
-	A = coeffArray[0].(float64)
-	B = coeffArray[1].(float64)
+	A, okA := coeffArray[0].(float64)
+	B, okB := coeffArray[1].(float64)
+	if !okA || !okB {
+		utils.Error.Printf("linearConversion: coefficients must be numbers (got A=%T, B=%T)", coeffArray[0], coeffArray[1])
+		return ""
+	}
 	var y float64
 	if north2SouthConv {
 		y = A*x + B
 	} else {
+		if A == 0 {
+			utils.Error.Printf("linearConversion: south-to-north divide-by-zero (A=0)")
+			return ""
+		}
 		y = (x - B) / A
 	}
-	return strconv.FormatFloat(y, 'f', -1, 32)
+	return strconv.FormatFloat(y, 'f', -1, 64)
 }
 
 func main() {
@@ -625,10 +944,12 @@ func main() {
 		Required: false,
 		Help:     "statestorage database filename",
 		Default:  "../../server/vissv2server/serviceMgr/statestorage.db"})
-	// Parse input
+	// Parse input. Pre-fix this only logged the error and continued running
+	// with whatever defaults / zero values had been left in place.
 	err := parser.Parse(os.Args)
 	if err != nil {
 		utils.Error.Print(parser.Usage(err))
+		os.Exit(1)
 	}
 	stateDbType = *stateDB
 	simulatedSource = *simSource
@@ -648,6 +969,7 @@ func main() {
 			}
 		} else {
 			utils.Error.Printf("Could not find state storage file = %s", *dbFile)
+			os.Exit(1)
 		}
 	case "redis":
 		redisClient = redis.NewClient(&redis.Options{
@@ -688,6 +1010,10 @@ func main() {
 
 	utils.Info.Printf("Initializing the feeder for mapping file %s.", *mapFile)
 	feederMap := readFeederMap(*mapFile)
+	if len(feederMap) == 0 {
+		utils.Error.Printf("Empty/unreadable feeder map %s.", *mapFile)
+		os.Exit(1)
+	}
 	if simulatedSource != "internal" {
 		tripData = readSimulatedData(*tripDataFile)
 		if len(tripData) == 0 {


### PR DESCRIPTION
This is the four-feeder counterpart to PR #147 (feederv4). `feederv1`, `feederv2`, and `feederv3` are tutorial templates referenced from `tutorial/content/feeder/*`, `build-system/*`, `datastore/*`, and `pocs/*` — users follow those docs and copy-paste them as the starting point for their own feeders. `feeder-rl` is a separate RemotiveLabs broker feeder. None are exercised by `runstack.sh` / `runtest.sh` (only v4 is), so they aren't load-bearing in CI, but every bug fixed here propagates into every feeder built from the tutorial.

## Smoking guns

- **v3 line 271 unsubscribe** — `slices.Delete(notificationList, i, i+1)` was using the input `pathList` index instead of the matching `notificationList` index, deleting the wrong entry on every unsubscribe; also iterated past shifted slots; also ran without a mutex while `addNotifications` / `onNotificationList` ran from another goroutine. Fixed in `removeNotifications` with the matching `idx`, added `notificationMu`. Regression-pinned by `TestRemoveNotifications_FixesSmokingGun`.
- **v2 / v3 line 488 `getRandomVssfMapIndex`** — `% (len(fMap)-1)` skipped the last slot AND divided by zero when `len==1`; if every `Name` contained a dot it looped forever. Replaced with a bounded loop, `len`-only modulus, and a `-1` sentinel.
- **v2 / v3 `readBytes`** — single `treeFp.Read` discarding return + error; any short read produced uninitialised bytes that fed straight into the `deSerializeUInt` type assertions and panicked on any truncated `.cvt`. Now uses `io.ReadFull` with a 1 MiB cap and returns `ok=false` on short read.
- **v3 `calculateSimValue`** — `step := (endValue - currValue) / noOfSteps` in integer math truncated to 0 when the delta was smaller than the step count; the simulation stalled at `currValue` forever. Fixed: nudge by ±1 on stall, jump to `endValue` on the final step.
- **feeder-rl `RemotiveLabsBroker`** — three bugs in one function:
  - `readQuitSignal` was `close()`d twice (signal handler + `WriterReader` goroutine) — guaranteed panic on shutdown
  - `os.Exit(<-ch | <-ch)` line was unreachable behind a `for {}`
  - `initVehicleInterfaceMgr_2`'s single-case select spun forever on channel close

  All three fixed via `sync.Once` for the close, removal of the unreachable Exit, and rewrite to `for range`.

## Defensive shape across all four files

- Replaced every unchecked `.(string)` / `.(map[string]interface{})` / `.([]interface{})` on attacker-controlled JSON with comma-ok form via a shared `mapString` helper. ~40+ assertions across the four files.
- `splitToDomainDataAndTs` now returns `(DomainData, string, bool)`; callers check `ok` before forwarding.
- UDS endpoint loops on `Accept` (reconnect-ready), 8 KiB buffer, drops at-buffer-size frames as likely truncated, non-blocking sends with drop-and-log.
- **v3 `serveOnce`** closes `udsChan` on exit so the writer goroutine doesn't leak across reconnect cycles.
- `statestorageSet` builds the `{"value":..., "ts":...}` JSON via `json.Marshal` instead of string concat (was corrupting any value with a `"` in it).
- `convertDomainData` / `convertValue` / `linearConversion` / `enumConversion` bounds-check `scalingDataList[convertIndex-1]`, the `MapIndex` stored in the mapfile, the `coeffArray` length, and reject `A=0` in reverse linear conv. The convert-data type switch uses `case []interface{}` explicitly so JSON strings/numbers no longer panic the blind `.([]interface{})` assert.
- `getSimulatedDataPoints` skips short rows instead of panicking when one per-path `Dp` slice is shorter than `tripData[0].Dp`.
- `incDpIndex` guards against empty `tripData` / empty `Dp[0]`.
- `selectRandomInput` / `readFeederMap` guard against `rand.Intn(0)` on empty input.
- `parser.Parse` errors now exit non-zero instead of running on with zero values.
- `readFeederMap` sorts by `Name` so callers using `sort.Search` work correctly.
- `FormatFloat` now passes `bitSize=64` to match the `float64` input (was silently truncating to float32 precision).

## Drive-by

- `utils/managerhandlers.go:334` — `Error.Printf("Error opening cert file", caCertFile, ", error ", err)` → Printf with `%s` / `%v` verbs.
- `utils/pbutils.go:32` — `Error.Printf("Marshaling error: ", err)` → Printf with `%v` verb.

## Tests

Four new `*_test.go` files covering every unit-testable function in each file:

- `mapString`, `marshalDatapointJSON`, `fileExists`
- `readscalingDataList`, `readFeederMap` (round-trip + missing + truncated)
- `readBytes` / `readUint8` / `readUint16` / `deSerializeUInt`
- `splitToDomainDataAndTs` (happy + every malformed shape)
- `handleServerMessage` / `udsReader` / `udsServeConn` / `serveOnce` / `udsWriter` (net.Pipe-driven; set + subscribe + unsubscribe + update + malformed + oversized + EOF)
- `addNotifications` / `removeNotifications` — including the v3 line-271 regression pin
- `simulateInput` / `calcInputValue` / `selectRandomInput` / `getRandomVssfMapIndex`
- `readSimulatedData` / `getSimulatedDataPoints` / `incDpIndex`
- `convertDomainData` / `convertValue` / `linearConversion` / `enumConversion`
- `covertChannelDataToString`, `TouchFile`, `initVehicleInterfaceMgr_2` exit-on-close

All race-mode clean (`go test -race -count=1 ./feeder/feeder-template/feederv1 …feederv2 …feederv3 ./feeder/feeder-rl`).

**Coverage note**: per-file `initUdsEndpoint` / `initVSSInterfaceMgr` / `initVehicleInterfaceMgr` / `Simulation` are top-level goroutine drivers that bind fixed UDS sockets, call `os.Exit` on listen failure, and loop forever with multi-second `time.Sleep` in the simulator default arm. Their inner helpers are all covered above; the drivers themselves are integration-only entry points and are documented as such in the test files.

## Note on the rl dep

`feeder-rl.go` imports `github.com/petervolvowinz/viss-rl-interfaces` — a personal-account dependency. TLS / broker / auth behavior lives inside that dep and is out of scope here. This PR only fixes bugs in the vissr-side code.