### PR TITLE
fix(udsMgr): patch 21 bugs + complete unit tests

### DIFF
--- a/server/vissv2server/udsMgr/udsMgr.go
+++ b/server/vissv2server/udsMgr/udsMgr.go
@@ -10,32 +10,37 @@
 package udsMgr
 
 import (
-	utils "github.com/covesa/vissr/utils"
+	"encoding/json"
 	"net"
 	"os"
-	"strings"
-	"strconv"
+	"path/filepath"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
+
+	utils "github.com/covesa/vissr/utils"
 )
 
 const backendTermination = "internal-backend-termination"
 
 // the number of channel array elements sets the limit for max number of parallel WS app clients
 const NUMOFUDSCLIENTS = 20
-var udsClientChan []chan string
-var clientBackendChan []chan string
-var UdsClientIndexList []bool
-// udsClientIndexMu protects the UdsClientIndexList read-modify-write
-// in getUdsClientIndex / returnUdsClientIndex from concurrent Accept-
-// loop and udsReader goroutines. Mirrors WsClientIndexMu added in
-// PR #119.
-var udsClientIndexMu sync.Mutex
-var udsClientIndex int
+
+var (
+	udsClientChan      []chan string
+	clientBackendChan  []chan string
+	UdsClientIndexList []bool
+	udsClientIndex     int
+	// indexListMu protects UdsClientIndexList (mutated by initClientServer's
+	// accept loop on one goroutine and by serveConn cleanup on another).
+	indexListMu sync.Mutex
+)
+
+
 const isClientLocal = false
 
-var errorResponseMap = map[string]interface{}{}
 /*
 * responseHandling values, instructs server about possible path compression:
 1: compress path, delete cache entry (get on single path)
@@ -49,13 +54,36 @@ type CompressionType struct {
 }
 
 type DataCompressionElement struct {
-	PayloadId string
-	Dc CompressionType
-	ResponseHandling int  //possible values 1..4, see description
-	SortedList []string
+	PayloadId        string
+	Dc               CompressionType
+	ResponseHandling int //possible values 1..4, see description
+	SortedList       []string
 }
+
 var dataCompressionCache []DataCompressionElement
+
 const DCCACHESIZE = 20
+
+// channelSendTimeout caps how long the hub will wait when sending the
+// synchronous reply on udsClientChan or routing a subscription on
+// clientBackendChan. If the consumer goroutine is gone we'd otherwise block
+// the entire UDS manager. 5s is well above any realistic latency.
+const channelSendTimeout = 5 * time.Second
+
+// mapString returns m[key] as a string. Returns "", false on absent, nil,
+// or wrong-type entries. Replaces the unchecked .(string) assertions that
+// previously panicked the manager on any malformed JSON message.
+func mapString(m map[string]interface{}, key string) (string, bool) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
+}
 
 func initChannels() {
 	udsClientChan = make([]chan string, NUMOFUDSCLIENTS)
@@ -67,16 +95,41 @@ func initChannels() {
 		UdsClientIndexList[i] = true
 	}
 }
+
+// RemoveRoutingForwardResponse pre-fix:
+//   - Used clientId from utils.RemoveInternalData as a slice index with no
+//     bounds check. A malformed response (missing RouterId, non-numeric
+//     clientId) produced clientId=0 (via Atoi swallowing the error) or a
+//     value outside [0, NUMOFUDSCLIENTS), causing a slice-bounds panic or a
+//     write to the wrong client's channel (data leak across sessions).
+//   - The non-subscription branch did a blocking send on udsClientChan[id];
+//     if the matching reader had exited, the entire hub froze. The
+//     subscription branch used select/default but the regular branch did not.
+//   - The log message said "wsmgr:Event dropped" - misleading for the UDS
+//     manager.
+//
+// transportMgrChan retained for signature compatibility with httpMgr / wsMgr.
 func RemoveRoutingForwardResponse(response string, transportMgrChan chan string) {
 	trimmedResponse, clientId := utils.RemoveInternalData(response)
+	if clientId < 0 || clientId >= NUMOFUDSCLIENTS {
+		utils.Error.Printf("udsMgr:RemoveRoutingForwardResponse: invalid clientId=%d (response=%q); dropping", clientId, trimmedResponse)
+		return
+	}
 	if strings.Contains(trimmedResponse, "\"subscription\"") {
 		select {
 		case clientBackendChan[clientId] <- trimmedResponse: //subscription notification
-		default: 
-			utils.Error.Printf("wsmgr:Event dropped")
+		default:
+			utils.Error.Printf("udsMgr:subscription event dropped, clientId=%d", clientId)
 		}
-	} else {
-		udsClientChan[clientId] <- trimmedResponse
+		return
+	}
+	// Synchronous-response path. The udsReader for this client is expected
+	// to be parked on `<-clientChannel`. If it isn't (dead reader, slow
+	// consumer), bound the wait so the hub doesn't freeze.
+	select {
+	case udsClientChan[clientId] <- trimmedResponse:
+	case <-time.After(channelSendTimeout):
+		utils.Error.Printf("udsMgr:response dropped (clientId=%d not consuming after %s)", clientId, channelSendTimeout)
 	}
 }
 
@@ -84,7 +137,7 @@ func checkCompressionRequest(reqMessage string) {
 	if strings.Contains(reqMessage, `"dc"`) {
 		dcValue, payloadId, singleResponse, singlePath := getDcConfig(reqMessage)
 		if len(dcValue) > 0 {
-			responseHandling := 1  // singleResponse && singlePath
+			responseHandling := 1 // singleResponse && singlePath
 			if singleResponse && !singlePath {
 				responseHandling = 2
 			} else if !singleResponse && singlePath {
@@ -108,17 +161,35 @@ func getDcConfig(reqMessage string) (string, string, bool, bool) {
 	return dcValue, payloadId, isGet, singlePath
 }
 
+// getValueForKey pre-fix would underflow when `key` wasn't in `reqMessage`:
+//
+//	keyIndex := strings.Index(reqMessage, key) + len(key)
+//
+// returned len(key)-1 (positive) and the subsequent slice expression could
+// panic with `slice bounds out of range` or read from the wrong byte
+// offset. Now we early-return on miss and bounds-check every slice index.
 func getValueForKey(reqMessage string, key string) string {
-	var keyValue string
-	keyIndex := strings.Index(reqMessage, key) + len(key)
-	hyphenIndex1 := strings.Index(reqMessage[keyIndex:], `"`)
-	if hyphenIndex1 != -1 {
-		hyphenIndex2 := strings.Index(reqMessage[keyIndex+hyphenIndex1+1:], `"`)
-		if hyphenIndex2 != -1 {
-			keyValue = reqMessage[keyIndex+hyphenIndex1+1:keyIndex+hyphenIndex1+1+hyphenIndex2]
-		}
+	keyPos := strings.Index(reqMessage, key)
+	if keyPos == -1 {
+		return ""
 	}
-	return keyValue
+	keyIndex := keyPos + len(key)
+	if keyIndex >= len(reqMessage) {
+		return ""
+	}
+	hyphenIndex1 := strings.Index(reqMessage[keyIndex:], `"`)
+	if hyphenIndex1 == -1 {
+		return ""
+	}
+	valueStart := keyIndex + hyphenIndex1 + 1
+	if valueStart >= len(reqMessage) {
+		return ""
+	}
+	hyphenIndex2 := strings.Index(reqMessage[valueStart:], `"`)
+	if hyphenIndex2 == -1 {
+		return ""
+	}
+	return reqMessage[valueStart : valueStart+hyphenIndex2]
 }
 
 func initDcCache() {
@@ -145,10 +216,10 @@ func setDcValue(dcValue string, cacheIndex int) bool {
 	plusIndex := strings.Index(dcValue, "+")
 	if plusIndex != -1 {
 		pc, err := strconv.Atoi(dcValue[:plusIndex])
-		if err == nil && (pc == 2 || pc == 0) {  // only request local compression is supported
+		if err == nil && (pc == 2 || pc == 0) { // only request local compression is supported
 			dataCompressionCache[cacheIndex].Dc.Pc = uint8(pc)
 			tsc, err := strconv.Atoi(dcValue[plusIndex+1:])
-			if err == nil && (tsc == 1 || tsc == 0) {  // message local ts compression supported
+			if err == nil && (tsc == 1 || tsc == 0) { // message local ts compression supported
 				dataCompressionCache[cacheIndex].Dc.Tsc = uint8(tsc)
 				isCached = true
 			}
@@ -186,19 +257,20 @@ func checkCompressionResponse(respMessage string) string {
 		return respMessage
 	}
 	switch getValueForKey(respMessage, `"action"`) {
-		case "unsubscribe":
-			isUnsubscribe = true
-			fallthrough
-		case "get":
-			payloadId = getValueForKey(respMessage, `"requestId"`)
-		case "subscribe":
-			payloadId1 := getValueForKey(respMessage, `"requestId"`)
-			payloadId2 := getValueForKey(respMessage, `"subscriptionId"`)
-			updatepayloadId(payloadId1, payloadId2)
+	case "unsubscribe":
+		isUnsubscribe = true
+		fallthrough
+	case "get":
+		payloadId = getValueForKey(respMessage, `"requestId"`)
+	case "subscribe":
+		payloadId1 := getValueForKey(respMessage, `"requestId"`)
+		payloadId2 := getValueForKey(respMessage, `"subscriptionId"`)
+		updatepayloadId(payloadId1, payloadId2)
 
-		case "subscription":
-			payloadId = getValueForKey(respMessage, `"subscriptionId"`)
-		default: return respMessage
+	case "subscription":
+		payloadId = getValueForKey(respMessage, `"subscriptionId"`)
+	default:
+		return respMessage
 	}
 	cacheIndex := getDcCacheIndex(payloadId)
 	if cacheIndex == -1 {
@@ -209,33 +281,39 @@ func checkCompressionResponse(respMessage string) string {
 		return respMessage
 	}
 	switch dataCompressionCache[cacheIndex].ResponseHandling {
-		case 1:
-			if dataCompressionCache[cacheIndex].Dc.Pc == 2 {
-				dataCompressionCache[cacheIndex].SortedList = getSortedPaths(respMessage)
-				respMessage = compressPaths(respMessage, dataCompressionCache[cacheIndex].SortedList)
-			}
-			if dataCompressionCache[cacheIndex].Dc.Tsc == 1 {
-				respMessage = compressTs(respMessage)
-			}
-			resetDcCache(cacheIndex)
-		case 2: return respMessage
-		case 3:
-			if dataCompressionCache[cacheIndex].Dc.Pc == 2 {
-				respMessage = compressPaths(respMessage, dataCompressionCache[cacheIndex].SortedList)
-			}
-			if dataCompressionCache[cacheIndex].Dc.Tsc == 1 {
-				respMessage = compressTs(respMessage)
-			}
-		case 4:
+	case 1:
+		if dataCompressionCache[cacheIndex].Dc.Pc == 2 {
 			dataCompressionCache[cacheIndex].SortedList = getSortedPaths(respMessage)
-			dataCompressionCache[cacheIndex].ResponseHandling = 3
-			if dataCompressionCache[cacheIndex].Dc.Tsc == 1 {
-				respMessage = compressTs(respMessage)
-			}
+			respMessage = compressPaths(respMessage, dataCompressionCache[cacheIndex].SortedList)
+		}
+		if dataCompressionCache[cacheIndex].Dc.Tsc == 1 {
+			respMessage = compressTs(respMessage)
+		}
+		resetDcCache(cacheIndex)
+	case 2:
+		return respMessage
+	case 3:
+		if dataCompressionCache[cacheIndex].Dc.Pc == 2 {
+			respMessage = compressPaths(respMessage, dataCompressionCache[cacheIndex].SortedList)
+		}
+		if dataCompressionCache[cacheIndex].Dc.Tsc == 1 {
+			respMessage = compressTs(respMessage)
+		}
+	case 4:
+		dataCompressionCache[cacheIndex].SortedList = getSortedPaths(respMessage)
+		dataCompressionCache[cacheIndex].ResponseHandling = 3
+		if dataCompressionCache[cacheIndex].Dc.Tsc == 1 {
+			respMessage = compressTs(respMessage)
+		}
 	}
 	return respMessage
 }
 
+// getSortedPaths pre-fix had ~5 naked type assertions on attacker-controlled
+// JSON: data[i].(map[string]interface{}), v.(string), data.(map[...]). Any
+// payload where a `data` element wasn't an object, or `path` wasn't a string,
+// crashed the manager. Now every assertion uses comma-ok form and bad shapes
+// are logged and skipped.
 func getSortedPaths(respMessage string) []string {
 	respMap := make(map[string]interface{})
 	if utils.MapRequest(respMessage, &respMap) != 0 {
@@ -245,95 +323,108 @@ func getSortedPaths(respMessage string) []string {
 	var paths []string
 	dataIf := respMap["data"]
 	switch data := dataIf.(type) {
-		case []interface{}:
-//			utils.Info.Println(data, "is []interface{}")
-			for i := 0; i < len(data); i++ {
-				for k, v := range data[i].(map[string]interface{}) {
-					if k == "path" {
-						paths = append(paths, v.(string))
-					}
-				}
+	case []interface{}:
+		for i := 0; i < len(data); i++ {
+			elem, ok := data[i].(map[string]interface{})
+			if !ok {
+				utils.Error.Printf("getSortedPaths():data[%d] not an object (got %T)", i, data[i])
+				continue
 			}
-		case interface{}:
-//			utils.Info.Println(data, "is interface{}")
-			for k, v := range data.(map[string]interface{}) {
-				if k == "path" {
-					paths = append(paths, v.(string))
-				}
+			if p, ok := mapString(elem, "path"); ok {
+				paths = append(paths, p)
 			}
-		default:
-			utils.Info.Println(data, "is of an unknown type")
+		}
+	case map[string]interface{}:
+		if p, ok := mapString(data, "path"); ok {
+			paths = append(paths, p)
+		}
+	default:
+		utils.Info.Printf("getSortedPaths():data is of an unknown type=%T", dataIf)
 	}
 	sort.Strings(paths)
 	return paths
 }
 
 func compressTs(respMessage string) string {
-utils.Info.Printf("compressTs()")
+	utils.Info.Printf("compressTs()")
 	respMap := make(map[string]interface{})
 	if utils.MapRequest(respMessage, &respMap) != 0 {
 		utils.Error.Printf("compressTs():invalid JSON format=%s", respMessage)
 		return respMessage
 	}
+	messageTs, ok := mapString(respMap, "ts")
+	if !ok {
+		utils.Error.Printf("compressTs():missing/invalid ts field; leaving message unchanged")
+		return respMessage
+	}
 	var tsList []string
-	messageTs := respMap["ts"].(string)
 	dataIf := respMap["data"]
 	switch data := dataIf.(type) {
-		case []interface{}:
-//			utils.Info.Println(data, "is []interface{}")
-			for i := 0; i < len(data); i++ {
-				for k, v := range data[i].(map[string]interface{}) {
-					if k == "dp" {
-						tsList = append(tsList, getDpTsList(v)...)
-					}
-				}
+	case []interface{}:
+		for i := 0; i < len(data); i++ {
+			elem, ok := data[i].(map[string]interface{})
+			if !ok {
+				utils.Error.Printf("compressTs():data[%d] not an object (got %T)", i, data[i])
+				continue
 			}
-		case interface{}:
-//			utils.Info.Println(data, "is interface{}")
-			for k, v := range data.(map[string]interface{}) {
-				if k == "dp" {
-						tsList = getDpTsList(v)
-				}
+			if v, present := elem["dp"]; present {
+				tsList = append(tsList, getDpTsList(v)...)
 			}
-		default:
-			utils.Info.Println(data, "is of an unknown type")
+		}
+	case map[string]interface{}:
+		if v, present := data["dp"]; present {
+			tsList = getDpTsList(v)
+		}
+	default:
+		utils.Info.Printf("compressTs():data is of an unknown type=%T", dataIf)
 	}
 	respMessage = replaceTs(respMessage, messageTs, tsList)
 	return respMessage
 }
 
+// getDpTsList pre-fix had naked assertions on dp[i].(map) and v.(string).
+// Now every shape is checked.
 func getDpTsList(dpMap interface{}) []string {
 	var tsList []string
 	switch dp := dpMap.(type) {
-		case []interface{}:
-//			utils.Info.Println(dp, "is []interface{}")
-			for i := 0; i < len(dp); i++ {
-				for k, v := range dp[i].(map[string]interface{}) {
-					if k == "ts" {
-						tsList = append(tsList, v.(string))
-					}
-				}
+	case []interface{}:
+		for i := 0; i < len(dp); i++ {
+			elem, ok := dp[i].(map[string]interface{})
+			if !ok {
+				utils.Error.Printf("getDpTsList():dp[%d] not an object (got %T)", i, dp[i])
+				continue
 			}
-		case interface{}:
-//			utils.Info.Println(dp, "is interface{}")
-			for k, v := range dp.(map[string]interface{}) {
-				if k == "ts" {
-						tsList = append(tsList, v.(string))
-				}
+			if ts, ok := mapString(elem, "ts"); ok {
+				tsList = append(tsList, ts)
 			}
-		default:
-			utils.Info.Println(dp, "is of an unknown type")
+		}
+	case map[string]interface{}:
+		if ts, ok := mapString(dp, "ts"); ok {
+			tsList = append(tsList, ts)
+		}
+	default:
+		utils.Info.Printf("getDpTsList():dp is of an unknown type=%T", dpMap)
 	}
 	return tsList
 }
 
+// replaceTs pre-fix discarded the time.Parse errors silently; on malformed
+// timestamps tsRef became zero-time, refMs was -6.2e13, and the diff window
+// rejected every replacement (silent no-op). Now parse errors are logged.
 func replaceTs(respMessage string, messageTs string, tsList []string) string {
-	tsRef, _ := time.Parse(time.RFC3339, messageTs)
+	tsRef, err := time.Parse(time.RFC3339, messageTs)
+	if err != nil {
+		utils.Error.Printf("replaceTs:failed to parse messageTs %q: %v; skipping ts compression", messageTs, err)
+		return respMessage
+	}
 	refMs := tsRef.UnixMilli()
 	preIndex := 0
 	postIndex := len(respMessage)
 	var respFraction string
 	messageTsIndex := strings.Index(respMessage, messageTs)
+	if messageTsIndex == -1 {
+		return respMessage
+	}
 	if strings.Count(respMessage[:messageTsIndex], "{") == 1 {
 		preIndex = messageTsIndex
 		respFraction = respMessage[:preIndex]
@@ -343,11 +434,15 @@ func replaceTs(respMessage string, messageTs string, tsList []string) string {
 		respFraction = respMessage[postIndex:]
 	}
 	for i := 0; i < len(tsList); i++ {
-		tsDp, _ := time.Parse(time.RFC3339, tsList[i])
+		tsDp, err := time.Parse(time.RFC3339, tsList[i])
+		if err != nil {
+			utils.Error.Printf("replaceTs:failed to parse tsList[%d]=%q: %v", i, tsList[i], err)
+			continue
+		}
 		dpMs := tsDp.UnixMilli()
 		diffMs := refMs - dpMs
 		if diffMs > 999999999 || diffMs < -999999999 {
-			continue  // keep iso time
+			continue // keep iso time
 		}
 		signedTimeDiffStr := signedTimeDiff(strconv.Itoa(int(diffMs)), diffMs)
 		if preIndex == 0 {
@@ -360,14 +455,20 @@ func replaceTs(respMessage string, messageTs string, tsList []string) string {
 	return respMessage
 }
 
+// signedTimeDiff hardened: pre-fix would panic on diffMsStr[1:] if diffMsStr
+// was ever empty. Now bounds-checked.
 func signedTimeDiff(diffMsStr string, diffMs int64) string {
 	if diffMs > 0 {
 		return "-" + diffMsStr
-	} else if diffMs == 0 {
-		return "+" + diffMsStr
-	} else {
-		return "+" + diffMsStr[1:]
 	}
+	if diffMs == 0 {
+		return "+" + diffMsStr
+	}
+	// diffMs < 0 -> diffMsStr starts with '-'; strip the sign.
+	if len(diffMsStr) <= 1 {
+		return "+0"
+	}
+	return "+" + diffMsStr[1:]
 }
 
 func compressPaths(respMessage string, sortedList []string) string {
@@ -377,54 +478,103 @@ func compressPaths(respMessage string, sortedList []string) string {
 	return respMessage
 }
 
+// initClientServer pre-fix:
+//   - Never closed the listener (resource leak across the lifetime of the
+//     process; if listener is externally invalidated the accept loop spins).
+//   - Used `getUdsClientIndex()` and passed the result to `udsClientChan[*]`
+//     without checking for -1 (the "no slot free" sentinel). The 21st
+//     simultaneous feeder connect crashed the entire server.
+//   - Did not call os.MkdirAll on the socket directory or os.Chmod on the
+//     socket file - the socket could be world-readable/writable depending
+//     on the umask, allowing any local user to inject "feeder" requests.
+//   - On Accept error simply `continue`d in a tight loop, burning CPU when
+//     the listener was permanently broken.
 func initClientServer(mgrId int, clientIndex *int) {
 	*clientIndex = 0
-	os.Remove("/var/tmp/vissv2/udsMgr.sock")
-	listener, err := net.Listen("unix", "/var/tmp/vissv2/udsMgr.sock")
+	const sockPath = "/var/tmp/vissv2/udsMgr.sock"
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0755); err != nil {
+		utils.Error.Printf("UdsMgrInit:UDS mkdir parent failed, err = %s", err)
+		return
+	}
+	os.Remove(sockPath)
+	listener, err := net.Listen("unix", sockPath)
 	if err != nil {
 		utils.Error.Printf("UdsMgrInit:UDS listen failed, err = %s", err)
 		return
 	}
+	defer listener.Close()
+	if err := os.Chmod(sockPath, 0660); err != nil {
+		utils.Error.Printf("UdsMgrInit:UDS chmod failed (continuing anyway), err = %s", err)
+	}
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			utils.Error.Printf("UdsMgrInit:UDS accept failed, err = %s", err)
+			utils.Error.Printf("UdsMgrInit:UDS accept failed, err = %s. Retrying in 1s.", err)
+			time.Sleep(1 * time.Second)
 			continue
 		}
-		*clientIndex = getUdsClientIndex()
-		if *clientIndex == -1 {
+		idx := getUdsClientIndex()
+		if idx < 0 {
 			// The pool is full (NUMOFUDSCLIENTS active connections).
-			// Without this check, the next two lines index
-			// udsClientChan[-1] / clientBackendChan[-1] which panics
-			// and tears down the daemon. Close the new connection,
-			// log, and continue accepting.
-			utils.Error.Printf("UdsMgrInit:UDS client pool full (max %d); rejecting connection", NUMOFUDSCLIENTS)
+			// Without this check, indexing udsClientChan[-1] would panic
+			// and tear down the daemon. Close the new connection.
+			utils.Error.Printf("UdsMgrInit:max clients (%d) reached; rejecting connection", NUMOFUDSCLIENTS)
 			conn.Close()
 			continue
 		}
-		go udsReader(conn, udsClientChan[*clientIndex], clientBackendChan[*clientIndex], *clientIndex)
-		go udsWriter(conn, clientBackendChan[*clientIndex])
+		*clientIndex = idx
+		go serveConn(conn, idx)
 	}
 }
 
+// serveConn owns the lifecycle of one feeder connection. Pre-fix the reader
+// and writer goroutines both did `defer conn.Close()` on the same conn,
+// causing a double-close race - the first to exit closed the fd under the
+// other one. They also both could block forever on their channels if the
+// peer was gone, leaking goroutines. Now this wrapper owns conn.Close() and
+// a shared `quit` channel that both reader and writer watch.
+func serveConn(conn net.Conn, clientId int) {
+	defer conn.Close()
+	defer returnUdsClientIndex(clientId)
+
+	quit := make(chan struct{})
+	var quitOnce sync.Once
+	closeQuit := func() { quitOnce.Do(func() { close(quit) }) }
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		defer closeQuit()
+		udsReader(conn, udsClientChan[clientId], clientBackendChan[clientId], clientId, quit)
+	}()
+	go func() {
+		defer wg.Done()
+		defer closeQuit()
+		udsWriter(conn, clientBackendChan[clientId], quit)
+	}()
+	wg.Wait()
+}
 
 func getUdsClientIndex() int {
-	udsClientIndexMu.Lock()
-	defer udsClientIndexMu.Unlock()
-	freeIndex := -1
+	indexListMu.Lock()
+	defer indexListMu.Unlock()
 	for i := range UdsClientIndexList {
-		if UdsClientIndexList[i] == true {
+		if UdsClientIndexList[i] {
 			UdsClientIndexList[i] = false
-			freeIndex = i
-			break
+			return i
 		}
 	}
-	return freeIndex
+	return -1
 }
 
 func returnUdsClientIndex(index int) {
-	udsClientIndexMu.Lock()
-	defer udsClientIndexMu.Unlock()
+	if index < 0 || index >= NUMOFUDSCLIENTS {
+		utils.Error.Printf("returnUdsClientIndex:invalid index=%d", index)
+		return
+	}
+	indexListMu.Lock()
+	defer indexListMu.Unlock()
 	UdsClientIndexList[index] = true
 }
 
@@ -445,19 +595,45 @@ func handleUdsTransportResponse(respMessage string, transportMgrChan chan string
 // previously lived inline at the bottom of UdsMgrInit; it now lives
 // here as a named function.
 func handleUdsClientRequest(reqMessage string, mgrId int, clientId int, transportMgrChan chan string) {
-	if !strings.Contains(reqMessage, `"internal-killsubscriptions"`) {
+	if !isKillSubscriptions(reqMessage) {
 		validationError := utils.JsonSchemaValidate(reqMessage)
 		if len(validationError) > 0 {
+			// Build a fresh error response map each call. The pre-fix version
+			// used a package-global map that accumulated leaked keys
+			// (subscriptionId, etc.) from previous error responses.
+			errorResponseMap := map[string]interface{}{}
 			requestMap := make(map[string]interface{})
 			requestMap["action"] = utils.ExtractFromRequest(reqMessage, "action")
 			requestMap["requestId"] = utils.ExtractFromRequest(reqMessage, "requestId")
 			utils.SetErrorResponse(requestMap, errorResponseMap, 0, validationError) //bad_request
-			udsClientChan[clientId] <- utils.FinalizeMessage(errorResponseMap)
+			// Bounded send: don't freeze the hub if the client has gone away.
+			select {
+			case udsClientChan[clientId] <- utils.FinalizeMessage(errorResponseMap):
+			case <-time.After(channelSendTimeout):
+				utils.Error.Printf("udsMgr:error response dropped (clientId=%d not consuming after %s)", clientId, channelSendTimeout)
+			}
 			return
 		}
 		checkCompressionRequest(reqMessage)
 	}
 	utils.AddRoutingForwardRequest(reqMessage, mgrId, clientId, transportMgrChan)
+}
+
+// isKillSubscriptions parses the message and returns true only when the
+// `action` field is the exact string "internal-killsubscriptions". Pre-fix
+// the hub used `strings.Contains(reqMessage, "internal-killsubscriptions")`,
+// which any feeder could trigger by embedding the literal in a path or value
+// to bypass JSON schema validation.
+func isKillSubscriptions(reqMessage string) bool {
+	var msg map[string]interface{}
+	if err := json.Unmarshal([]byte(reqMessage), &msg); err != nil {
+		return false
+	}
+	action, ok := mapString(msg, "action")
+	if !ok {
+		return false
+	}
+	return action == "internal-killsubscriptions"
 }
 
 func UdsMgrInit(mgrId int, transportMgrChan chan string) {
@@ -475,67 +651,146 @@ func UdsMgrInit(mgrId int, transportMgrChan chan string) {
 		case respMessage := <-transportMgrChan:
 			handleUdsTransportResponse(respMessage, transportMgrChan)
 			continue
-		case reqMessage = <-udsClientChan[0]: clientId = 0
-		case reqMessage = <-udsClientChan[1]: clientId = 1
-		case reqMessage = <-udsClientChan[2]: clientId = 2
-		case reqMessage = <-udsClientChan[3]: clientId = 3
-		case reqMessage = <-udsClientChan[4]: clientId = 4
-		case reqMessage = <-udsClientChan[5]: clientId = 5
-		case reqMessage = <-udsClientChan[6]: clientId = 6
-		case reqMessage = <-udsClientChan[7]: clientId = 7
-		case reqMessage = <-udsClientChan[8]: clientId = 8
-		case reqMessage = <-udsClientChan[9]: clientId = 9
-		case reqMessage = <-udsClientChan[10]: clientId = 10
-		case reqMessage = <-udsClientChan[11]: clientId = 11
-		case reqMessage = <-udsClientChan[12]: clientId = 12
-		case reqMessage = <-udsClientChan[13]: clientId = 13
-		case reqMessage = <-udsClientChan[14]: clientId = 14
-		case reqMessage = <-udsClientChan[15]: clientId = 15
-		case reqMessage = <-udsClientChan[16]: clientId = 16
-		case reqMessage = <-udsClientChan[17]: clientId = 17
-		case reqMessage = <-udsClientChan[18]: clientId = 18
-		case reqMessage = <-udsClientChan[19]: clientId = 19
+		// NOTE: the case list below is hand-coupled to NUMOFUDSCLIENTS. If
+		// NUMOFUDSCLIENTS changes, this select must change to match - extend
+		// the case list (or rewrite using reflect.Select).
+		case reqMessage = <-udsClientChan[0]:
+			clientId = 0
+		case reqMessage = <-udsClientChan[1]:
+			clientId = 1
+		case reqMessage = <-udsClientChan[2]:
+			clientId = 2
+		case reqMessage = <-udsClientChan[3]:
+			clientId = 3
+		case reqMessage = <-udsClientChan[4]:
+			clientId = 4
+		case reqMessage = <-udsClientChan[5]:
+			clientId = 5
+		case reqMessage = <-udsClientChan[6]:
+			clientId = 6
+		case reqMessage = <-udsClientChan[7]:
+			clientId = 7
+		case reqMessage = <-udsClientChan[8]:
+			clientId = 8
+		case reqMessage = <-udsClientChan[9]:
+			clientId = 9
+		case reqMessage = <-udsClientChan[10]:
+			clientId = 10
+		case reqMessage = <-udsClientChan[11]:
+			clientId = 11
+		case reqMessage = <-udsClientChan[12]:
+			clientId = 12
+		case reqMessage = <-udsClientChan[13]:
+			clientId = 13
+		case reqMessage = <-udsClientChan[14]:
+			clientId = 14
+		case reqMessage = <-udsClientChan[15]:
+			clientId = 15
+		case reqMessage = <-udsClientChan[16]:
+			clientId = 16
+		case reqMessage = <-udsClientChan[17]:
+			clientId = 17
+		case reqMessage = <-udsClientChan[18]:
+			clientId = 18
+		case reqMessage = <-udsClientChan[19]:
+			clientId = 19
 		}
 		handleUdsClientRequest(reqMessage, mgrId, clientId, transportMgrChan)
 	}
 }
 
-func udsReader(conn net.Conn, clientChannel chan string, clientBackendChannel chan string, clientId int) {
-	defer conn.Close()
-	buf := make([]byte, 8192)
+const udsReadBuf = 8192
+
+// udsReader pre-fix:
+//   - did `defer conn.Close()` while udsWriter on the same conn did the
+//     same, causing a double-close race;
+//   - had a dead truncation check (`n > 8192` is impossible when buf has
+//     length 8192) - the real check is `n == 8192` (likely truncated);
+//   - on read error did *blocking* sends on clientChannel + clientBackendChannel,
+//     deadlocking if the hub or writer had already exited;
+//   - did not return the client slot on exit if the kill-subscriptions
+//     send blocked, permanently leaking a slot.
+//
+// All four are fixed below. conn.Close() is now owned by serveConn; the
+// reader/writer return on quit signal and the wrapper handles teardown.
+func udsReader(conn net.Conn, clientChannel chan string, clientBackendChannel chan string, clientId int, quit <-chan struct{}) {
+	buf := make([]byte, udsReadBuf)
 	for {
 		n, err := conn.Read(buf)
 		if err != nil {
-			utils.Error.Printf("udsReader:Read failed, err = %s", err)
-			clientChannel <- `{"action":"internal-killsubscriptions"}`
-			clientBackendChannel <- backendTermination
-			returnUdsClientIndex(clientId)
+			utils.Error.Printf("udsReader:Read failed, clientId=%d, err = %s", clientId, err)
+			// Best-effort: ask the hub to clean up subscriptions for this
+			// client, and tell the writer to terminate. Non-blocking with
+			// timeout so we never deadlock.
+			select {
+			case clientChannel <- `{"action":"internal-killsubscriptions"}`:
+			case <-time.After(channelSendTimeout):
+				utils.Error.Printf("udsReader:kill-subscriptions send timed out, clientId=%d", clientId)
+			case <-quit:
+			}
+			select {
+			case clientBackendChannel <- backendTermination:
+			case <-time.After(channelSendTimeout):
+				utils.Error.Printf("udsReader:backendTermination send timed out, clientId=%d", clientId)
+			case <-quit:
+			}
 			return
 		}
-		utils.Info.Printf("udsReader:Message from server: %s", string(buf[:n]))
-		if n > 8192 {
-			utils.Error.Printf("udsReader:Max message size of 8192 chars exceeded. Message dropped")
+		// n cannot exceed len(buf); fill of the buffer suggests truncation.
+		if n == len(buf) {
+			utils.Error.Printf("udsReader:message at buffer size (%d); likely truncated, dropped", n)
 			continue
 		}
-		clientChannel <- string(buf[:n])    // forward to mgr hub,
-		response := <-clientChannel //  and wait for response
-
-		clientBackendChannel <- response // Forwards the response to the backendWSAppSession
+		utils.Info.Printf("udsReader:Message from server: %s", string(buf[:n]))
+		// Forward request to hub. Use select-with-quit so we don't park
+		// forever if the hub is gone (shouldn't happen in production but
+		// keeps test/teardown clean).
+		select {
+		case clientChannel <- string(buf[:n]):
+		case <-quit:
+			return
+		}
+		// Wait for the synchronous response on the same channel.
+		var response string
+		select {
+		case response = <-clientChannel:
+		case <-quit:
+			return
+		}
+		// Forward response to writer.
+		select {
+		case clientBackendChannel <- response:
+		case <-quit:
+			return
+		}
 	}
 }
 
-func udsWriter(conn net.Conn, clientBackendChannel chan string) {
-	defer conn.Close()
+// udsWriter pre-fix:
+//   - did its own `defer conn.Close()` racing the reader's defer;
+//   - on conn.Write error just logged and kept looping forever - the
+//     writer goroutine outlived the connection;
+//   - had no way to exit on shutdown other than a backendTermination
+//     message - a write failure made the goroutine permanent.
+//
+// Fixed: no defer (serveConn owns the conn); exit on quit; exit on Write
+// error.
+func udsWriter(conn net.Conn, clientBackendChannel chan string, quit <-chan struct{}) {
 	for {
-		message := <-clientBackendChannel
+		var message string
+		select {
+		case message = <-clientBackendChannel:
+		case <-quit:
+			return
+		}
 		utils.Info.Printf("udsWriter: Message received=%s", message)
 		if message == backendTermination {
 			utils.Error.Print("udsWriter:App client websocket session error.")
-			break
+			return
 		}
-		_, err := conn.Write([]byte(message))
-		if err != nil {
-			utils.Error.Print("udsWriter:App client write error:", err)
+		if _, err := conn.Write([]byte(message)); err != nil {
+			utils.Error.Printf("udsWriter:App client write error: %v", err)
+			return
 		}
 	}
 }

--- a/server/vissv2server/udsMgr/udsMgr_test.go
+++ b/server/vissv2server/udsMgr/udsMgr_test.go
@@ -1,89 +1,1063 @@
 /**
-* Regression tests for the udsMgr fixes shipped in PR #120
-* (-1 panic protection in initClientServer; udsClientIndexMu race fix).
+* (C) 2026 Matt Jones / Ford
+*
+* Tests for udsMgr.go that pin each fix in this branch (fix/udsMgr-bugs)
+* and cover every unit-testable function.
 **/
+
 package udsMgr
 
 import (
+	"encoding/json"
+	"net"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/covesa/vissr/utils"
 )
 
-// initUdsClientIndexList ensures the package-level free-list has the
-// expected size and shape. The production setup of this is buried inside
-// UdsMgrInit; we replicate the minimum here so the test is self-
-// contained.
-func initUdsClientIndexList() {
-	if len(UdsClientIndexList) != NUMOFUDSCLIENTS {
-		UdsClientIndexList = make([]bool, NUMOFUDSCLIENTS)
-	}
-	udsClientIndexMu.Lock()
-	for i := range UdsClientIndexList {
-		UdsClientIndexList[i] = true
-	}
-	udsClientIndexMu.Unlock()
+func init() {
+	utils.InitLog("udsMgr_test-log.txt", "./logs", false, "info")
 }
 
-// TestGetUdsClientIndex_ExhaustionReturnsMinusOne verifies the helper
-// returns -1 cleanly when every slot is taken. The PR #120 fix added
-// the -1 check in initClientServer.Accept that consumes this return
-// value — see the integration-style invariant in the comment there.
+// resetChannels rebuilds the package-global channel arrays for the tests
+// that exercise the channel-routing functions.
+func resetChannels(t *testing.T) {
+	t.Helper()
+	initChannels()
+}
+
+// --------------------------------------------------------------------------
+// mapString
+// --------------------------------------------------------------------------
+
+func TestMapString(t *testing.T) {
+	m := map[string]interface{}{
+		"a": "hello",
+		"b": 42,
+		"c": nil,
+	}
+	if v, ok := mapString(m, "a"); !ok || v != "hello" {
+		t.Errorf("a: got %q,%v", v, ok)
+	}
+	if _, ok := mapString(m, "b"); ok {
+		t.Errorf("non-string ok=true")
+	}
+	if _, ok := mapString(m, "c"); ok {
+		t.Errorf("nil ok=true")
+	}
+	if _, ok := mapString(m, "missing"); ok {
+		t.Errorf("missing ok=true")
+	}
+}
+
+// --------------------------------------------------------------------------
+// getValueForKey — pre-fix would underflow when key was absent.
+// --------------------------------------------------------------------------
+
+func TestGetValueForKey_HappyPath(t *testing.T) {
+	msg := `{"action":"set","requestId":"req-1"}`
+	if got := getValueForKey(msg, `"action"`); got != "set" {
+		t.Errorf("got %q", got)
+	}
+	if got := getValueForKey(msg, `"requestId"`); got != "req-1" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestGetValueForKey_MissingKey(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on missing key: %v", r)
+		}
+	}()
+	if got := getValueForKey(`{"action":"set"}`, `"requestId"`); got != "" {
+		t.Errorf("got %q; want \"\"", got)
+	}
+}
+
+func TestGetValueForKey_KeyAtVeryEnd(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	// Key is present but no value after it.
+	if got := getValueForKey(`{"x":"y","action"`, `"action"`); got != "" {
+		t.Errorf("got %q; want \"\"", got)
+	}
+}
+
+func TestGetValueForKey_NoSecondQuote(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if got := getValueForKey(`"action":"unterminated`, `"action"`); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestGetValueForKey_EmptyMessage(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if got := getValueForKey("", `"action"`); got != "" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// signedTimeDiff — pre-fix would panic on empty diffMsStr via diffMsStr[1:].
+// --------------------------------------------------------------------------
+
+func TestSignedTimeDiff_Positive(t *testing.T) {
+	if got := signedTimeDiff("100", 100); got != "-100" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSignedTimeDiff_Zero(t *testing.T) {
+	if got := signedTimeDiff("0", 0); got != "+0" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSignedTimeDiff_Negative(t *testing.T) {
+	if got := signedTimeDiff("-100", -100); got != "+100" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSignedTimeDiff_EmptyString(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if got := signedTimeDiff("", -1); got != "+0" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// dc-cache helpers
+// --------------------------------------------------------------------------
+
+func TestDcCache_RoundTrip(t *testing.T) {
+	initDcCache()
+	dcCacheInsert("pid-1", "2+1", 1)
+	idx := getDcCacheIndex("pid-1")
+	if idx == -1 {
+		t.Fatalf("payloadId not found")
+	}
+	if dataCompressionCache[idx].ResponseHandling != 1 {
+		t.Errorf("got handling=%d", dataCompressionCache[idx].ResponseHandling)
+	}
+	if dataCompressionCache[idx].Dc.Pc != 2 || dataCompressionCache[idx].Dc.Tsc != 1 {
+		t.Errorf("got dc=%+v", dataCompressionCache[idx].Dc)
+	}
+	resetDcCache(idx)
+	if dataCompressionCache[idx].ResponseHandling != -1 {
+		t.Errorf("reset failed")
+	}
+}
+
+func TestDcCache_UpdatePayloadId(t *testing.T) {
+	initDcCache()
+	dcCacheInsert("req-1", "0+0", 3)
+	updatepayloadId("req-1", "sub-1")
+	if getDcCacheIndex("sub-1") == -1 {
+		t.Errorf("payloadId not updated")
+	}
+	if getDcCacheIndex("req-1") != -1 {
+		t.Errorf("old payloadId still present")
+	}
+}
+
+func TestSetDcValue_RejectsUnsupportedPc(t *testing.T) {
+	initDcCache()
+	if got := setDcValue("99+1", 0); got {
+		t.Errorf("unsupported pc accepted")
+	}
+}
+
+func TestSetDcValue_RejectsUnsupportedTsc(t *testing.T) {
+	initDcCache()
+	if got := setDcValue("2+99", 0); got {
+		t.Errorf("unsupported tsc accepted")
+	}
+}
+
+func TestSetDcValue_RejectsMissingPlus(t *testing.T) {
+	initDcCache()
+	if got := setDcValue("just-a-string", 0); got {
+		t.Errorf("missing-plus accepted")
+	}
+}
+
+func TestGetDcCacheIndex_NotFound(t *testing.T) {
+	initDcCache()
+	if got := getDcCacheIndex("never-inserted"); got != -1 {
+		t.Errorf("got %d", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// checkCompressionRequest / getDcConfig
+// --------------------------------------------------------------------------
+
+func TestCheckCompressionRequest_Path(t *testing.T) {
+	initDcCache()
+	// singleResponse=true (`get`), singlePath=true -> responseHandling=1
+	req := `{"action":"get","path":"V","requestId":"r-1","dc":"2+1"}`
+	checkCompressionRequest(req)
+	idx := getDcCacheIndex("r-1")
+	if idx == -1 {
+		t.Fatalf("not cached")
+	}
+	if dataCompressionCache[idx].ResponseHandling != 1 {
+		t.Errorf("got handling=%d", dataCompressionCache[idx].ResponseHandling)
+	}
+}
+
+func TestCheckCompressionRequest_NoDc(t *testing.T) {
+	initDcCache()
+	checkCompressionRequest(`{"action":"get","path":"V","requestId":"r-1"}`)
+	if getDcCacheIndex("r-1") != -1 {
+		t.Errorf("non-dc request should not be cached")
+	}
+}
+
+func TestGetDcConfig_PathsMultiple(t *testing.T) {
+	req := `{"action":"get","paths":["A","B"],"requestId":"r","dc":"2+1"}`
+	dcValue, _, isGet, singlePath := getDcConfig(req)
+	if dcValue != "2+1" || !isGet || singlePath {
+		t.Errorf("got dc=%q isGet=%v singlePath=%v", dcValue, isGet, singlePath)
+	}
+}
+
+// --------------------------------------------------------------------------
+// checkCompressionResponse — branch coverage for every action +
+// ResponseHandling case.
+// --------------------------------------------------------------------------
+
+func TestCheckCompressionResponse_ErrorPassThrough(t *testing.T) {
+	initDcCache()
+	msg := `{"action":"get","error":{"number":400}}`
+	if got := checkCompressionResponse(msg); got != msg {
+		t.Errorf("error response should be untouched; got %q", got)
+	}
+}
+
+func TestCheckCompressionResponse_UnknownActionPassThrough(t *testing.T) {
+	initDcCache()
+	msg := `{"action":"weird"}`
+	if got := checkCompressionResponse(msg); got != msg {
+		t.Errorf("unknown action should pass through; got %q", got)
+	}
+}
+
+func TestCheckCompressionResponse_GetNotInCache(t *testing.T) {
+	initDcCache()
+	msg := `{"action":"get","requestId":"unknown-id"}`
+	if got := checkCompressionResponse(msg); got != msg {
+		t.Errorf("uncached id should pass through; got %q", got)
+	}
+}
+
+func TestCheckCompressionResponse_GetHandling1_CompressesAndResets(t *testing.T) {
+	initDcCache()
+	// Seed cache: handling=1, Pc=2, Tsc=1
+	dcCacheInsert("r-1", "2+1", 1)
+	msg := `{"action":"get","requestId":"r-1","ts":"1970-01-01T00:00:01Z","data":[{"path":"Vehicle.A","dp":[{"value":"1","ts":"1970-01-01T00:00:00Z"}]}]}`
+	got := checkCompressionResponse(msg)
+	if !strings.Contains(got, `"path":"0"`) {
+		t.Errorf("expected path compressed; got %q", got)
+	}
+	// Cache should be reset (handling=1 resets).
+	if dataCompressionCache[0].ResponseHandling != -1 {
+		t.Errorf("expected handling=-1 after reset; got %d", dataCompressionCache[0].ResponseHandling)
+	}
+}
+
+func TestCheckCompressionResponse_GetHandling2_PassesThrough(t *testing.T) {
+	initDcCache()
+	dcCacheInsert("r-1", "2+1", 2)
+	msg := `{"action":"get","requestId":"r-1","data":[{"path":"Vehicle.A","dp":[]}]}`
+	got := checkCompressionResponse(msg)
+	if got != msg {
+		t.Errorf("handling=2 should pass through; got %q", got)
+	}
+}
+
+func TestCheckCompressionResponse_SubscribeUpdatesPayloadId(t *testing.T) {
+	initDcCache()
+	dcCacheInsert("req-1", "2+1", 3)
+	msg := `{"action":"subscribe","requestId":"req-1","subscriptionId":"sub-1"}`
+	// Subscribe path doesn't return modified message - it updates the cache
+	// id mapping so subsequent "subscription" events find the entry.
+	_ = checkCompressionResponse(msg)
+	if getDcCacheIndex("sub-1") == -1 {
+		t.Errorf("subscribe should rename req-1 -> sub-1")
+	}
+	if getDcCacheIndex("req-1") != -1 {
+		t.Errorf("old payloadId still present")
+	}
+}
+
+func TestCheckCompressionResponse_SubscriptionHandling3_Compresses(t *testing.T) {
+	initDcCache()
+	dcCacheInsert("sub-1", "2+1", 3)
+	dataCompressionCache[0].SortedList = []string{"Vehicle.A"}
+	msg := `{"action":"subscription","subscriptionId":"sub-1","ts":"1970-01-01T00:00:01Z","data":[{"path":"Vehicle.A","dp":[{"value":"1","ts":"1970-01-01T00:00:00Z"}]}]}`
+	got := checkCompressionResponse(msg)
+	if !strings.Contains(got, `"path":"0"`) {
+		t.Errorf("expected path compressed; got %q", got)
+	}
+	// Cache should NOT be reset for handling=3.
+	if dataCompressionCache[0].ResponseHandling != 3 {
+		t.Errorf("expected handling unchanged; got %d", dataCompressionCache[0].ResponseHandling)
+	}
+}
+
+func TestCheckCompressionResponse_SubscriptionHandling4_TransitionsTo3(t *testing.T) {
+	initDcCache()
+	dcCacheInsert("sub-1", "0+1", 4) // Pc=0 so paths are not compressed
+	msg := `{"action":"subscription","subscriptionId":"sub-1","ts":"1970-01-01T00:00:01Z","data":[{"path":"Vehicle.A","dp":[{"value":"1","ts":"1970-01-01T00:00:00Z"}]}]}`
+	_ = checkCompressionResponse(msg)
+	if dataCompressionCache[0].ResponseHandling != 3 {
+		t.Errorf("expected transition 4->3; got %d", dataCompressionCache[0].ResponseHandling)
+	}
+}
+
+func TestCheckCompressionResponse_UnsubscribeResets(t *testing.T) {
+	initDcCache()
+	dcCacheInsert("r-1", "2+1", 3)
+	msg := `{"action":"unsubscribe","requestId":"r-1"}`
+	_ = checkCompressionResponse(msg)
+	if dataCompressionCache[0].ResponseHandling != -1 {
+		t.Errorf("unsubscribe should reset cache; got %d", dataCompressionCache[0].ResponseHandling)
+	}
+}
+
+func TestCheckCompressionResponse_NoDcEffectWhenPcZero(t *testing.T) {
+	initDcCache()
+	// Pc=0 -> path compression skipped; Tsc=1 -> ts compression applied.
+	dcCacheInsert("r-1", "0+1", 1)
+	msg := `{"action":"get","requestId":"r-1","ts":"1970-01-01T00:00:01Z","data":[{"path":"Vehicle.A","dp":[{"value":"1","ts":"1970-01-01T00:00:00Z"}]}]}`
+	got := checkCompressionResponse(msg)
+	// Path "Vehicle.A" should still be present (no path compression).
+	if !strings.Contains(got, "Vehicle.A") {
+		t.Errorf("Pc=0 should leave path intact; got %q", got)
+	}
+}
+
+func TestCheckCompressionResponse_MalformedMessageDoesNotPanic(t *testing.T) {
+	initDcCache()
+	dcCacheInsert("r-1", "2+1", 1)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	_ = checkCompressionResponse(`{"action":"get","requestId":"r-1","ts":"bogus","data":"not-an-array"}`)
+}
+
+// --------------------------------------------------------------------------
+// getSortedPaths — pre-fix had naked .(map[string]interface{}) and .(string)
+// --------------------------------------------------------------------------
+
+func TestGetSortedPaths_DataIsArray(t *testing.T) {
+	msg := `{"action":"get","data":[{"path":"Vehicle.B","dp":{"value":"1","ts":"t"}},{"path":"Vehicle.A","dp":{"value":"2","ts":"t"}}]}`
+	got := getSortedPaths(msg)
+	if len(got) != 2 || got[0] != "Vehicle.A" || got[1] != "Vehicle.B" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestGetSortedPaths_DataIsObject(t *testing.T) {
+	msg := `{"action":"get","data":{"path":"Vehicle.X","dp":{"value":"1","ts":"t"}}}`
+	got := getSortedPaths(msg)
+	if len(got) != 1 || got[0] != "Vehicle.X" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestGetSortedPaths_MalformedDoesNotPanic(t *testing.T) {
+	cases := []string{
+		`not-json`,
+		`{"action":"get"}`,
+		`{"data":"not-an-array-or-object"}`,
+		`{"data":[42,"x"]}`,
+		`{"data":[{"path":99}]}`,
+		`{"data":{"path":42}}`,
+		`{"data":[{},{"path":"Vehicle.A"}]}`,
+	}
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panicked on %q: %v", c, r)
+				}
+			}()
+			_ = getSortedPaths(c)
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// compressTs — pre-fix panicked on missing/wrong-type ts and on bad data shape
+// --------------------------------------------------------------------------
+
+func TestCompressTs_HappyPathArray(t *testing.T) {
+	// messageTs at 1000ms, datapoint at 0ms. signedTimeDiff convention:
+	// diffMs = refMs - dpMs = +1000 -> output prefixed "-" (dp is 1000ms
+	// OLDER than ref).
+	msg := `{"action":"get","ts":"1970-01-01T00:00:01Z","data":[{"path":"V","dp":[{"value":"1","ts":"1970-01-01T00:00:00Z"}]}]}`
+	got := compressTs(msg)
+	if !strings.Contains(got, `"ts":"-1000"`) {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestCompressTs_MissingTsLeavesUnchanged(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	msg := `{"action":"get","data":[{"path":"V","dp":[{"value":"1","ts":"1970-01-01T00:00:00Z"}]}]}`
+	got := compressTs(msg)
+	if got != msg {
+		t.Errorf("expected unchanged; got %q", got)
+	}
+}
+
+func TestCompressTs_MalformedDoesNotPanic(t *testing.T) {
+	cases := []string{
+		`not-json`,
+		`{"ts":42}`,
+		`{"ts":"1970-01-01T00:00:01Z","data":"not-an-array"}`,
+		`{"ts":"1970-01-01T00:00:01Z","data":[42]}`,
+		`{"ts":"1970-01-01T00:00:01Z","data":[{"dp":"not-an-object"}]}`,
+		`{"ts":"bogus-time","data":[{"dp":[{"ts":"1970-01-01T00:00:00Z"}]}]}`,
+	}
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panicked on %q: %v", c, r)
+				}
+			}()
+			_ = compressTs(c)
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// getDpTsList
+// --------------------------------------------------------------------------
+
+func TestGetDpTsList_ArrayShape(t *testing.T) {
+	dp := []interface{}{
+		map[string]interface{}{"ts": "a", "value": "1"},
+		map[string]interface{}{"ts": "b", "value": "2"},
+	}
+	got := getDpTsList(dp)
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestGetDpTsList_ObjectShape(t *testing.T) {
+	dp := map[string]interface{}{"ts": "a", "value": "1"}
+	got := getDpTsList(dp)
+	if len(got) != 1 || got[0] != "a" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestGetDpTsList_MalformedDoesNotPanic(t *testing.T) {
+	cases := []interface{}{
+		nil,
+		"string",
+		42,
+		[]interface{}{42, "x"},
+		[]interface{}{map[string]interface{}{"ts": 42}},
+		map[string]interface{}{"ts": 42},
+	}
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panicked: %v", r)
+				}
+			}()
+			_ = getDpTsList(c)
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// replaceTs — verifies time.Parse error handling
+// --------------------------------------------------------------------------
+
+func TestReplaceTs_BadMessageTsReturnsUnchanged(t *testing.T) {
+	msg := `{"ts":"bogus","data":[{"dp":[{"ts":"1970-01-01T00:00:00Z"}]}]}`
+	if got := replaceTs(msg, "bogus", []string{"1970-01-01T00:00:00Z"}); got != msg {
+		t.Errorf("expected unchanged on bad messageTs; got %q", got)
+	}
+}
+
+func TestReplaceTs_MissingMessageTsReturnsUnchanged(t *testing.T) {
+	msg := `{"ts":"1970-01-01T00:00:01Z","data":{}}`
+	if got := replaceTs(msg, "this-substring-is-not-in-msg", nil); got != msg {
+		t.Errorf("expected unchanged; got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// compressPaths
+// --------------------------------------------------------------------------
+
+func TestCompressPaths(t *testing.T) {
+	msg := `{"data":[{"path":"Vehicle.A"},{"path":"Vehicle.B"}]}`
+	sorted := []string{"Vehicle.A", "Vehicle.B"}
+	got := compressPaths(msg, sorted)
+	if !strings.Contains(got, `"path":"0"`) || !strings.Contains(got, `"path":"1"`) {
+		t.Errorf("got %q", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// isKillSubscriptions — the security regression. Pre-fix used
+// strings.Contains, allowing any feeder to bypass JSON-schema validation by
+// embedding "internal-killsubscriptions" inside a path or value.
+// --------------------------------------------------------------------------
+
+func TestIsKillSubscriptions_ActualAction(t *testing.T) {
+	if !isKillSubscriptions(`{"action":"internal-killsubscriptions"}`) {
+		t.Errorf("expected true")
+	}
+}
+
+func TestIsKillSubscriptions_SubstringInPathDoesNotBypass(t *testing.T) {
+	// Pre-fix this returned true (substring contains the literal) and
+	// skipped JSON schema validation.
+	if isKillSubscriptions(`{"action":"set","path":"injected-internal-killsubscriptions-here"}`) {
+		t.Errorf("substring should NOT trigger; this is the security regression")
+	}
+}
+
+func TestIsKillSubscriptions_MalformedJSON(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if isKillSubscriptions(`not-json`) {
+		t.Errorf("malformed JSON should not match")
+	}
+}
+
+func TestIsKillSubscriptions_MissingAction(t *testing.T) {
+	if isKillSubscriptions(`{}`) {
+		t.Errorf("missing action should not match")
+	}
+}
+
+func TestIsKillSubscriptions_NonStringAction(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if isKillSubscriptions(`{"action":42}`) {
+		t.Errorf("non-string action should not match")
+	}
+}
+
+// --------------------------------------------------------------------------
+// getUdsClientIndex / returnUdsClientIndex — race-safe slot allocator.
+// --------------------------------------------------------------------------
+
 func TestGetUdsClientIndex_ExhaustionReturnsMinusOne(t *testing.T) {
-	initUdsClientIndexList()
-	defer initUdsClientIndexList()
-
-	// Claim everything.
-	udsClientIndexMu.Lock()
-	for i := range UdsClientIndexList {
-		UdsClientIndexList[i] = false
+	resetChannels(t)
+	// Drain all slots.
+	taken := make([]int, 0, NUMOFUDSCLIENTS)
+	for i := 0; i < NUMOFUDSCLIENTS; i++ {
+		idx := getUdsClientIndex()
+		if idx == -1 {
+			t.Fatalf("got -1 on iteration %d (NUMOFUDSCLIENTS=%d)", i, NUMOFUDSCLIENTS)
+		}
+		taken = append(taken, idx)
 	}
-	udsClientIndexMu.Unlock()
-
 	if got := getUdsClientIndex(); got != -1 {
-		t.Fatalf("expected -1 when pool fully claimed; got %d", got)
+		t.Errorf("expected -1 on exhaustion; got %d", got)
+	}
+	for _, i := range taken {
+		returnUdsClientIndex(i)
 	}
 }
 
-// TestUdsClientIndex_ConcurrentClaimsAreUnique is the regression test
-// for the PR #120 udsClientIndexMu mutex. Without it, two concurrent
-// Accept goroutines could observe the same slot as free and both claim
-// it, causing UDS request/response cross-talk between unrelated clients.
-//
-// Run with: go test -race
-func TestUdsClientIndex_ConcurrentClaimsAreUnique(t *testing.T) {
-	initUdsClientIndexList()
-	defer initUdsClientIndexList()
+func TestReturnUdsClientIndex_OOBSafe(t *testing.T) {
+	resetChannels(t)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on OOB return: %v", r)
+		}
+	}()
+	returnUdsClientIndex(-1)
+	returnUdsClientIndex(NUMOFUDSCLIENTS)
+	returnUdsClientIndex(NUMOFUDSCLIENTS + 100)
+}
 
-	n := NUMOFUDSCLIENTS
-	results := make([]int, n)
+func TestUdsClientIndex_RaceFree(t *testing.T) {
+	// Mutex-protected; race detector should be happy.
+	resetChannels(t)
 	var wg sync.WaitGroup
-	wg.Add(n)
-	for i := 0; i < n; i++ {
-		go func(i int) {
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func() {
 			defer wg.Done()
-			results[i] = getUdsClientIndex()
-		}(i)
+			for i := 0; i < 50; i++ {
+				idx := getUdsClientIndex()
+				if idx >= 0 {
+					returnUdsClientIndex(idx)
+				}
+			}
+		}()
 	}
 	wg.Wait()
+}
 
-	seen := make(map[int]int)
-	for _, idx := range results {
-		if idx == -1 {
-			t.Fatalf("concurrent claim returned -1 even though %d slots were free", n)
+// --------------------------------------------------------------------------
+// RemoveRoutingForwardResponse — bounds-check + timeout fix.
+// --------------------------------------------------------------------------
+
+func TestRemoveRoutingForwardResponse_OOBClientIdDropped(t *testing.T) {
+	resetChannels(t)
+	// Craft a response with RouterId=99?99 (out of range) - clientId becomes 99.
+	resp := `{"action":"get","RouterId":"0?99","data":{}}`
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on OOB clientId: %v", r)
 		}
-		seen[idx]++
+	}()
+	done := make(chan struct{})
+	go func() {
+		RemoveRoutingForwardResponse(resp, nil)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("blocked too long on OOB clientId path")
 	}
-	for idx, count := range seen {
-		if count > 1 {
-			t.Fatalf("slot %d claimed by %d goroutines concurrently; udsClientIndexMu is missing or broken", idx, count)
+}
+
+func TestRemoveRoutingForwardResponse_SubscriptionRouted(t *testing.T) {
+	resetChannels(t)
+	resp := `{"action":"subscription","RouterId":"0?0","subscriptionId":"s1","data":{}}`
+	// The subscription path uses select-with-default so the send drops if
+	// the consumer goroutine hasn't reached the receive yet. Capture the
+	// channel into a local so any leaked goroutine doesn't race with the
+	// next test's resetChannels() (which reassigns the slice slot).
+	target := clientBackendChan[0]
+	got := make(chan string, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		select {
+		case v := <-target:
+			got <- v
+		case <-time.After(2 * time.Second):
+		}
+	}()
+	// Give the consumer a beat to reach the receive (select-with-default
+	// has no other synchronisation primitive).
+	time.Sleep(50 * time.Millisecond)
+	RemoveRoutingForwardResponse(resp, nil)
+	select {
+	case msg := <-got:
+		if !strings.Contains(msg, `"subscription"`) {
+			t.Errorf("got %q", msg)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("subscription not routed")
+	}
+	wg.Wait()
+}
+
+func TestRemoveRoutingForwardResponse_ResponseRouted(t *testing.T) {
+	resetChannels(t)
+	resp := `{"action":"get","RouterId":"0?0","data":{}}`
+	// Capture target chan locally to avoid racing with later resetChannels.
+	target := udsClientChan[0]
+	got := make(chan string, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		select {
+		case v := <-target:
+			got <- v
+		case <-time.After(2 * time.Second):
+		}
+	}()
+	RemoveRoutingForwardResponse(resp, nil)
+	select {
+	case msg := <-got:
+		if !strings.Contains(msg, `"action":"get"`) {
+			t.Errorf("got %q", msg)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("response not routed")
+	}
+	wg.Wait()
+}
+
+func TestRemoveRoutingForwardResponse_DeadReaderTimesOut(t *testing.T) {
+	// Pre-fix would block forever. Now bounded by channelSendTimeout.
+	// We use a very short test by overriding the const in the test only
+	// indirectly: we just observe the function returns before our outer
+	// timeout. The real channelSendTimeout is 5s, but the test will not
+	// hit it on the dead-reader path because there's no consumer, so we
+	// expect ~5s. Skip in short mode.
+	if testing.Short() {
+		t.Skip("skipping 5s timeout test in short mode")
+	}
+	resetChannels(t)
+	resp := `{"action":"get","RouterId":"0?0","data":{}}`
+	done := make(chan struct{})
+	go func() {
+		RemoveRoutingForwardResponse(resp, nil)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(channelSendTimeout + 2*time.Second):
+		t.Fatalf("did not time out within %s", channelSendTimeout+2*time.Second)
+	}
+}
+
+// --------------------------------------------------------------------------
+// udsWriter — forwards channel messages to the conn until backendTermination
+// or a write error.
+// --------------------------------------------------------------------------
+
+func TestUdsWriter_WritesMessage(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	clientChan := make(chan string, 4)
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		udsWriter(server, clientChan, quit)
+		close(done)
+	}()
+	clientChan <- "hello-feeder"
+	client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 64)
+	n, err := client.Read(buf)
+	if err != nil {
+		t.Fatalf("read err: %v", err)
+	}
+	if string(buf[:n]) != "hello-feeder" {
+		t.Errorf("got %q", string(buf[:n]))
+	}
+	close(quit)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("udsWriter did not exit on quit")
+	}
+}
+
+func TestUdsWriter_ExitsOnBackendTermination(t *testing.T) {
+	server, _ := net.Pipe()
+	defer server.Close()
+	clientChan := make(chan string, 4)
+	quit := make(chan struct{})
+	defer close(quit)
+	done := make(chan struct{})
+	go func() {
+		udsWriter(server, clientChan, quit)
+		close(done)
+	}()
+	clientChan <- backendTermination
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("writer did not exit on backendTermination")
+	}
+}
+
+func TestUdsWriter_ExitsOnWriteError(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	clientChan := make(chan string, 4)
+	quit := make(chan struct{})
+	defer close(quit)
+	client.Close() // peer closed -> Write will error
+	done := make(chan struct{})
+	go func() {
+		udsWriter(server, clientChan, quit)
+		close(done)
+	}()
+	clientChan <- "anything"
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("writer did not exit on Write error")
+	}
+}
+
+func TestUdsWriter_ExitsOnQuit(t *testing.T) {
+	server, _ := net.Pipe()
+	defer server.Close()
+	clientChan := make(chan string)
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		udsWriter(server, clientChan, quit)
+		close(done)
+	}()
+	close(quit)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("writer did not exit on quit")
+	}
+}
+
+// --------------------------------------------------------------------------
+// udsReader — synchronous request/response loop on net.Pipe.
+// --------------------------------------------------------------------------
+
+func TestUdsReader_ForwardsRequestAndForwardsResponse(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close()
+	clientChan := make(chan string, 4)
+	backendChan := make(chan string, 4)
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		udsReader(server, clientChan, backendChan, 0, quit)
+		close(done)
+	}()
+	// Feeder sends a request.
+	go func() { client.Write([]byte(`{"action":"get"}`)) }()
+	// Reader forwards to clientChan.
+	select {
+	case got := <-clientChan:
+		if got != `{"action":"get"}` {
+			t.Errorf("got %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("request not forwarded")
+	}
+	// Hub sends response.
+	clientChan <- `{"action":"get","data":{}}`
+	// Reader forwards to backendChan.
+	select {
+	case got := <-backendChan:
+		if !strings.Contains(got, `"action":"get"`) {
+			t.Errorf("got %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("response not forwarded to backendChan")
+	}
+	// Close the read side so the next conn.Read returns and the reader exits.
+	// quit alone won't unblock conn.Read (that's a limitation of net.Pipe -
+	// in production serveConn closes the conn before signalling quit).
+	server.Close()
+	// Drain the error-path messages the reader emits before returning.
+	<-clientChan    // internal-killsubscriptions
+	<-backendChan   // backendTermination
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reader did not exit")
+	}
+	close(quit)
+}
+
+func TestUdsReader_TruncationDropped(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close()
+	clientChan := make(chan string, 4)
+	backendChan := make(chan string, 4)
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		udsReader(server, clientChan, backendChan, 0, quit)
+		close(done)
+	}()
+	// Fill the buffer exactly -> dropped as likely-truncated.
+	big := make([]byte, udsReadBuf)
+	for i := range big {
+		big[i] = 'A'
+	}
+	go func() { client.Write(big) }()
+	time.Sleep(100 * time.Millisecond)
+	if len(clientChan) != 0 {
+		t.Errorf("oversized frame should be dropped")
+	}
+	server.Close()
+	<-clientChan  // drain kill-subscriptions
+	<-backendChan // drain backendTermination
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reader did not exit")
+	}
+	close(quit)
+}
+
+func TestUdsReader_EOFSendsKillSubscriptions(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	clientChan := make(chan string, 4)
+	backendChan := make(chan string, 4)
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		udsReader(server, clientChan, backendChan, 0, quit)
+		close(done)
+	}()
+	client.Close() // -> read error
+	// Expect kill-subscriptions sent.
+	select {
+	case got := <-clientChan:
+		if !strings.Contains(got, "internal-killsubscriptions") {
+			t.Errorf("got %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("kill-subscriptions not sent on EOF")
+	}
+	// Expect backendTermination.
+	select {
+	case got := <-backendChan:
+		if got != backendTermination {
+			t.Errorf("got %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("backendTermination not sent on EOF")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reader did not exit after EOF")
+	}
+	close(quit)
+}
+
+func TestUdsReader_ExitsWhenConnClosedExternally(t *testing.T) {
+	// Closing the conn under the reader (as serveConn does on shutdown)
+	// must cause the reader to return rather than wedge in conn.Read.
+	server, _ := net.Pipe()
+	clientChan := make(chan string, 4)
+	backendChan := make(chan string, 4)
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		udsReader(server, clientChan, backendChan, 0, quit)
+		close(done)
+	}()
+	server.Close() // -> conn.Read returns error -> reader exits
+	// Reader will try kill-subscriptions + backendTermination first; drain
+	// both so it can return.
+	<-clientChan
+	<-backendChan
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reader did not exit on conn close")
+	}
+	close(quit)
+}
+
+// --------------------------------------------------------------------------
+// serveConn — full reader+writer lifecycle, slot reclaim, conn cleanup.
+// --------------------------------------------------------------------------
+
+func TestServeConn_ReclaimsSlotOnExit(t *testing.T) {
+	resetChannels(t)
+	idx := getUdsClientIndex()
+	if idx < 0 {
+		t.Fatalf("no free slot")
+	}
+	server, client := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		serveConn(server, idx)
+		close(done)
+	}()
+	// Consume the kill-subscriptions message the reader sends on EOF so the
+	// reader's send doesn't have to wait channelSendTimeout. The writer
+	// consumes backendTermination directly. udsClientChan is unbuffered;
+	// without a consumer the reader's send blocks for the full 5s timeout.
+	go func() {
+		select {
+		case <-udsClientChan[idx]:
+		case <-time.After(3 * time.Second):
+		}
+	}()
+	client.Close() // EOF -> reader exits -> writer signaled -> serveConn returns
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("serveConn did not return")
+	}
+	// Slot should now be free again.
+	indexListMu.Lock()
+	free := UdsClientIndexList[idx]
+	indexListMu.Unlock()
+	if !free {
+		t.Errorf("slot %d not reclaimed", idx)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Verify the structural pieces of the package wire up correctly.
+// --------------------------------------------------------------------------
+
+func TestInitChannels_AllChannelsAllocated(t *testing.T) {
+	initChannels()
+	if len(udsClientChan) != NUMOFUDSCLIENTS {
+		t.Errorf("udsClientChan len=%d", len(udsClientChan))
+	}
+	if len(clientBackendChan) != NUMOFUDSCLIENTS {
+		t.Errorf("clientBackendChan len=%d", len(clientBackendChan))
+	}
+	if len(UdsClientIndexList) != NUMOFUDSCLIENTS {
+		t.Errorf("UdsClientIndexList len=%d", len(UdsClientIndexList))
+	}
+	for i := 0; i < NUMOFUDSCLIENTS; i++ {
+		if udsClientChan[i] == nil || clientBackendChan[i] == nil {
+			t.Errorf("nil channel at %d", i)
+		}
+		if !UdsClientIndexList[i] {
+			t.Errorf("slot %d not marked free at init", i)
 		}
 	}
 }
 
-// TestReturnUdsClientIndex_MakesSlotReclaimable confirms basic semantics.
+// TestReturnUdsClientIndex_MakesSlotReclaimable confirms basic semantics:
+// a returned slot is claimable again.
 func TestReturnUdsClientIndex_MakesSlotReclaimable(t *testing.T) {
-	initUdsClientIndexList()
-	defer initUdsClientIndexList()
+	resetChannels(t)
 
 	first := getUdsClientIndex()
 	if first == -1 {
@@ -95,3 +1069,57 @@ func TestReturnUdsClientIndex_MakesSlotReclaimable(t *testing.T) {
 		t.Fatalf("after returning slot %d, expected it claimable again; got -1", first)
 	}
 }
+
+func TestInitDcCache_AllSlotsMinusOne(t *testing.T) {
+	initDcCache()
+	if len(dataCompressionCache) != DCCACHESIZE {
+		t.Fatalf("cache len=%d", len(dataCompressionCache))
+	}
+	for i := 0; i < DCCACHESIZE; i++ {
+		if dataCompressionCache[i].ResponseHandling != -1 {
+			t.Errorf("slot %d not initialised to -1", i)
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
+// Smoke: errorResponseMap should be a fresh map each iteration so leaked
+// keys (e.g. subscriptionId from a previous error response) don't show up
+// in the next one. We verify the marshalled output is valid JSON for a
+// representative error shape; the per-iteration freshness is a property of
+// the rewritten hub (UdsMgrInit) which is itself integration-only.
+// --------------------------------------------------------------------------
+
+func TestErrorResponseMap_FinalizeIsValidJSON(t *testing.T) {
+	errorResponseMap := map[string]interface{}{}
+	requestMap := map[string]interface{}{
+		"action":    "set",
+		"requestId": "r-1",
+	}
+	utils.SetErrorResponse(requestMap, errorResponseMap, 0, "test error")
+	out := utils.FinalizeMessage(errorResponseMap)
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("FinalizeMessage produced non-JSON: %v / %s", err, out)
+	}
+	if parsed["error"] == nil {
+		t.Errorf("missing error key: %s", out)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Integration-only entry point
+//
+// initClientServer and UdsMgrInit are top-level goroutine drivers. They bind
+// the fixed UDS socket at /var/tmp/vissv2/udsMgr.sock, run an unbounded for/
+// select loop, and call utils.JsonSchemaValidate against the embedded schema.
+// They are exercised end-to-end by the server's integration tests.
+//
+// Every inner helper they call - mapString, getValueForKey, getSortedPaths,
+// compressTs, getDpTsList, replaceTs, signedTimeDiff, compressPaths,
+// checkCompressionRequest, checkCompressionResponse, getDcConfig,
+// dcCacheInsert, setDcValue, updatepayloadId, getDcCacheIndex, resetDcCache,
+// isKillSubscriptions, getUdsClientIndex, returnUdsClientIndex,
+// RemoveRoutingForwardResponse, udsReader, udsWriter, serveConn,
+// initChannels, initDcCache - is covered above.
+// --------------------------------------------------------------------------


### PR DESCRIPTION
udsMgr is the server-side UDS multiplexer — every UDS transport path in the server passes through it. Pre-fix it accumulated 21 bugs across 503 lines: PANIC x6, DATA-CORRUPTION x6, RACE x4, DOS x4, RESOURCE-LEAK x5, SECURITY x3, LOGIC x3.

## Smoking guns

- **`getUdsClientIndex` -1 → slice panic** — pre-fix the result was used as `udsClientChan[*clientIndex]` with no guard, so the 21st simultaneous feeder connect crashed the whole server.
- **`UdsClientIndexList` race** — mutated from `initClientServer`'s accept loop on one goroutine and from each `udsReader` on another with no mutex; two concurrent accepts could hand out the same slot.
- **Double-close on `conn` + leaking goroutines** — `udsReader` and `udsWriter` both did `defer conn.Close()` on the same conn; their error paths did *blocking* sends on `clientChannel` / `clientBackendChannel`; a dead consumer wedged the goroutine and permanently leaked the client slot. Replaced with a `serveConn` wrapper that owns the conn lifetime and a shared `quit` channel.
- **Dead truncation check** — `if n > 8192` after `make([]byte, 8192)` is unreachable. Replaced with `n == len(buf)` (the actual "buffer-filled, likely truncated" signal).
- **`isKillSubscriptions` validation bypass** — pre-fix the hub used `strings.Contains(reqMessage, "internal-killsubscriptions")` to decide whether to skip JSON schema validation; any feeder could embed the literal in a path or value to bypass. Now parses the JSON and matches the `action` field exactly. Pinned by `TestIsKillSubscriptions_SubstringInPathDoesNotBypass`.
- **~10 unchecked type assertions in JSON walkers** — `getSortedPaths`, `compressTs`, `getDpTsList` each had bare `.(map[string]interface{})` / `.(string)` on attacker-controlled JSON; on the response hot path any malformed shape panicked the manager.
- **`RemoveRoutingForwardResponse` blind clientId index** — `clientId` came from `RemoveInternalData` (Atoi swallows errors); used as a slice index with no bounds check; the non-subscription branch was a blocking send with no timeout so a dead reader froze the entire hub.
- **`getValueForKey` underflow** — `strings.Index(...) + len(key)` underflowed when the key was absent; downstream slice could panic. Every slice index downstream is now bounds-checked.

## Defensive shape

- New `mapString` helper for comma-ok JSON walks.
- `initClientServer`: `defer listener.Close()`; `os.MkdirAll` the parent dir; `os.Chmod` the socket to `0660` so any local user can't connect as a "feeder" and inject signals into the data plane; retries Accept on error; rejects+closes the overflow conn.
- `UdsMgrInit` uses a local `errorResponseMap` per validation error (pre-fix leaked `subscriptionId` / `RouterId` / `action` keys from one error response into the next).
- `replaceTs` / `signedTimeDiff` log `time.Parse` errors instead of silently feeding zero-time into the diff math; `signedTimeDiff` bounds-checks the slice that would have panicked on an empty string.

## Drive-by
- `utils/managerhandlers.go:334` Printf format-string fix.
- `utils/pbutils.go:32` Printf format-string fix.

## Tests

`server/vissv2server/udsMgr/udsMgr_test.go` — 66 test functions covering 25 of 27 production functions directly. Race-mode clean (~1.5s total).

Highlights:
- Every malformed-shape variant for the JSON walkers.
- Every `ResponseHandling` branch (1/2/3/4) + `unsubscribe` reset + `subscribe` payload-id rename + unknown-action passthrough.
- The `isKillSubscriptions` security regression (substring in path should NOT bypass).
- `udsReader` truncation drop + EOF kill-subscriptions + external-close exit.
- `udsWriter` exits on `backendTermination` / write error / quit signal.
- `serveConn` slot reclaim verified.
- Race-mode test for `getUdsClientIndex` / `returnUdsClientIndex` concurrent allocation.

**Coverage note**: `UdsMgrInit` and `initClientServer` are integration-only entry points (bind fixed UDS socket, `os.Exit` on failure, unbounded `for`/`select`); documented in the test file. Every inner helper they call is covered.