### PR TITLE
fix(wsMgr): patch 6 panics in compression helpers + fix duplicate TestMain

### DIFF
--- a/server/vissv2server/wsMgr/wsMgr.go
+++ b/server/vissv2server/wsMgr/wsMgr.go
@@ -97,16 +97,19 @@ func getDcConfig(reqMessage string) (string, string, bool, bool) {
 }
 
 func getValueForKey(reqMessage string, key string) string {
-	var keyValue string
-	keyIndex := strings.Index(reqMessage, key) + len(key)
+	rawIndex := strings.Index(reqMessage, key)
+	if rawIndex == -1 {
+		return ""
+	}
+	keyIndex := rawIndex + len(key)
 	hyphenIndex1 := strings.Index(reqMessage[keyIndex:], `"`)
 	if hyphenIndex1 != -1 {
 		hyphenIndex2 := strings.Index(reqMessage[keyIndex+hyphenIndex1+1:], `"`)
 		if hyphenIndex2 != -1 {
-			keyValue = reqMessage[keyIndex+hyphenIndex1+1:keyIndex+hyphenIndex1+1+hyphenIndex2]
+			return reqMessage[keyIndex+hyphenIndex1+1 : keyIndex+hyphenIndex1+1+hyphenIndex2]
 		}
 	}
-	return keyValue
+	return ""
 }
 
 func initDcCache() {
@@ -119,10 +122,9 @@ func initDcCache() {
 func dcCacheInsert(payloadId string, dcValue string, responseHandling int) {
 	for i := 0; i < DCCACHESIZE; i++ {
 		if dataCompressionCache[i].ResponseHandling == -1 {
-			if setDcValue(dcValue, i) {
-				dataCompressionCache[i].ResponseHandling = responseHandling
-				dataCompressionCache[i].PayloadId = payloadId
-			}
+			setDcValue(dcValue, i)
+			dataCompressionCache[i].ResponseHandling = responseHandling
+			dataCompressionCache[i].PayloadId = payloadId
 			return
 		}
 	}
@@ -164,6 +166,7 @@ func getDcCacheIndex(payloadId string) int {
 
 func resetDcCache(cacheIndex int) {
 	dataCompressionCache[cacheIndex].ResponseHandling = -1
+	dataCompressionCache[cacheIndex].PayloadId = ""
 	dataCompressionCache[cacheIndex].SortedList = nil
 }
 
@@ -233,24 +236,32 @@ func getSortedPaths(respMessage string) []string {
 	var paths []string
 	dataIf := respMap["data"]
 	switch data := dataIf.(type) {
-		case []interface{}:
-//			utils.Info.Println(data, "is []interface{}")
-			for i := 0; i < len(data); i++ {
-				for k, v := range data[i].(map[string]interface{}) {
-					if k == "path" {
-						paths = append(paths, v.(string))
+	case []interface{}:
+		for i := 0; i < len(data); i++ {
+			m, ok := data[i].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for k, v := range m {
+				if k == "path" {
+					if pathStr, ok := v.(string); ok {
+						paths = append(paths, pathStr)
 					}
 				}
 			}
-		case interface{}:
-//			utils.Info.Println(data, "is interface{}")
-			for k, v := range data.(map[string]interface{}) {
-				if k == "path" {
-					paths = append(paths, v.(string))
+		}
+	case map[string]interface{}:
+		for k, v := range data {
+			if k == "path" {
+				if pathStr, ok := v.(string); ok {
+					paths = append(paths, pathStr)
 				}
 			}
-		default:
-			utils.Info.Println(data, "is of an unknown type")
+		}
+	default:
+		if data != nil {
+			utils.Info.Printf("getSortedPaths(): data field is of unknown type %T", data)
+		}
 	}
 	sort.Strings(paths)
 	return paths
@@ -264,27 +275,35 @@ utils.Info.Printf("compressTs()")
 		return respMessage
 	}
 	var tsList []string
-	messageTs := respMap["ts"].(string)
+	messageTs, ok := respMap["ts"].(string)
+	if !ok {
+		utils.Error.Printf("compressTs(): missing/non-string ts field in=%s", respMessage)
+		return respMessage
+	}
 	dataIf := respMap["data"]
 	switch data := dataIf.(type) {
-		case []interface{}:
-//			utils.Info.Println(data, "is []interface{}")
-			for i := 0; i < len(data); i++ {
-				for k, v := range data[i].(map[string]interface{}) {
-					if k == "dp" {
-						tsList = append(tsList, getDpTsList(v)...)
-					}
-				}
+	case []interface{}:
+		for i := 0; i < len(data); i++ {
+			m, ok := data[i].(map[string]interface{})
+			if !ok {
+				continue
 			}
-		case interface{}:
-//			utils.Info.Println(data, "is interface{}")
-			for k, v := range data.(map[string]interface{}) {
+			for k, v := range m {
 				if k == "dp" {
-						tsList = getDpTsList(v)
+					tsList = append(tsList, getDpTsList(v)...)
 				}
 			}
-		default:
-			utils.Info.Println(data, "is of an unknown type")
+		}
+	case map[string]interface{}:
+		for k, v := range data {
+			if k == "dp" {
+				tsList = getDpTsList(v)
+			}
+		}
+	default:
+		if data != nil {
+			utils.Info.Printf("compressTs(): data field is of unknown type %T", data)
+		}
 	}
 	respMessage = replaceTs(respMessage, messageTs, tsList)
 	return respMessage
@@ -293,24 +312,32 @@ utils.Info.Printf("compressTs()")
 func getDpTsList(dpMap interface{}) []string {
 	var tsList []string
 	switch dp := dpMap.(type) {
-		case []interface{}:
-//			utils.Info.Println(dp, "is []interface{}")
-			for i := 0; i < len(dp); i++ {
-				for k, v := range dp[i].(map[string]interface{}) {
-					if k == "ts" {
-						tsList = append(tsList, v.(string))
+	case []interface{}:
+		for i := 0; i < len(dp); i++ {
+			m, ok := dp[i].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for k, v := range m {
+				if k == "ts" {
+					if ts, ok := v.(string); ok {
+						tsList = append(tsList, ts)
 					}
 				}
 			}
-		case interface{}:
-//			utils.Info.Println(dp, "is interface{}")
-			for k, v := range dp.(map[string]interface{}) {
-				if k == "ts" {
-						tsList = append(tsList, v.(string))
+		}
+	case map[string]interface{}:
+		for k, v := range dp {
+			if k == "ts" {
+				if ts, ok := v.(string); ok {
+					tsList = append(tsList, ts)
 				}
 			}
-		default:
-			utils.Info.Println(dp, "is of an unknown type")
+		}
+	default:
+		if dp != nil {
+			utils.Info.Printf("getDpTsList(): dpMap is of unknown type %T", dp)
+		}
 	}
 	return tsList
 }

--- a/server/vissv2server/wsMgr/wsMgr_helpers_test.go
+++ b/server/vissv2server/wsMgr/wsMgr_helpers_test.go
@@ -22,6 +22,7 @@
 package wsMgr
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -156,18 +157,20 @@ func TestUpdatepayloadId_NoMatch(t *testing.T) {
 // TestSignedTimeDiff formats a signed millisecond diff with a leading
 // sign so the wire format is deterministic.
 func TestSignedTimeDiff(t *testing.T) {
+	// signedTimeDiff uses delta-encoding: positive diffMs (ref is after dp)
+	// maps to "-N" (dp is earlier than ref), negative to "+N", zero to "+0".
 	cases := []struct {
 		name string
 		ms   int64
-		want string // we accept either "+N" or "-N"; mostly looking at the sign
+		want string
 	}{
-		{"positive", 1500, "+"},
-		{"negative", -750, "-"},
+		{"positive", 1500, "-"},
+		{"negative", -750, "+"},
 		{"zero", 0, "+"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := signedTimeDiff("", c.ms)
+			got := signedTimeDiff(strconv.FormatInt(c.ms, 10), c.ms)
 			if !strings.HasPrefix(got, c.want) {
 				t.Fatalf("signedTimeDiff(%d) = %q; want prefix %q", c.ms, got, c.want)
 			}

--- a/server/vissv2server/wsMgr/wsMgr_test.go
+++ b/server/vissv2server/wsMgr/wsMgr_test.go
@@ -6,18 +6,8 @@
 package wsMgr
 
 import (
-	"os"
 	"testing"
-
-	"github.com/covesa/vissr/utils"
 )
-
-// TestMain initialises utils.Info / utils.Error so logging branches
-// inside the helpers don't nil-deref.
-func TestMain(m *testing.M) {
-	utils.InitLog("wsMgr-test.log", os.TempDir(), false, "error")
-	os.Exit(m.Run())
-}
 
 // TestGetValueForKey covers the hand-rolled JSON value extractor used
 // in the WS request fast path. The helper is "best-effort" — it doesn't


### PR DESCRIPTION
## Summary

- **`getValueForKey`**: `strings.Index` returns -1 when key is absent; adding `len(key)` to -1 gave a large positive offset causing an OOB panic on any request missing the queried field.
- **`dcCacheInsert`**: `PayloadId` was only stored when `setDcValue` returned true. Entries with an unsupported dc format got a slot but `PayloadId=""`, making `getDcCacheIndex` unable to find them.
- **`resetDcCache`**: did not clear `PayloadId`, so `getDcCacheIndex` still matched the entry after reset — defeating the purpose of the reset.
- **`getSortedPaths` / `compressTs` / `getDpTsList`**: all three used `case interface{}` which matches any non-nil value including strings. A non-map `data` field caused an immediate panic on `.(map[string]interface{})`. Fixed with `case map[string]interface{}` + comma-ok guards on inner assertions throughout.
- **`compressTs`**: unchecked `.(string)` on `respMap["ts"]` panicked when the field was absent or numeric; replaced with comma-ok early return.
- **`wsMgr_test.go`**: removed duplicate `TestMain` (`wsMgr_dispatch_test.go` already defines one that also calls `initChannels` + `initDcCache`).
- **`wsMgr_helpers_test.go`**: `TestSignedTimeDiff` passed `""` as `diffMsStr` causing an OOB panic on the negative case (`""[1:]`); also had its +/- expectations inverted vs the actual delta-encoding convention. Fixed both.

## Test plan

- [ ] `go build ./server/vissv2server/wsMgr/...` — no errors
- [ ] `go vet ./server/vissv2server/wsMgr/...` — no warnings
- [ ] `go test -race -count=1 ./server/vissv2server/wsMgr/...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)