### PR TITLE
fix(agtServer): remove duplicate jtiCacheMu, fix 413 response, guard nil jtiCache

### DIFF
--- a/server/agt_server/agt_server.go
+++ b/server/agt_server/agt_server.go
@@ -124,13 +124,6 @@ func allowedOriginHeader(req *http.Request) string {
 	return ""
 }
 
-// jtiCacheMu serialises access to jtiCache from the main request loop
-// (addCheckJti) and the per-jti expiry goroutines (deleteJti). Without
-// it the Go runtime aborts the process with "concurrent map read and
-// map write" once two AGT requests overlap. Mirrors the equivalent
-// fix in server/vissv2server/atServer/atServer.go.
-var jtiCacheMu sync.Mutex
-
 type Payload struct {
 	// Action  string `json:"action"`
 	Vin     string `json:"vin"`
@@ -166,7 +159,12 @@ func makeAgtServerHandler(serverChannel chan string) func(http.ResponseWriter, *
 		req.Body = http.MaxBytesReader(w, req.Body, MAX_REQUEST_BODY)
 		bodyBytes, err := io.ReadAll(req.Body)
 		if err != nil {
-			http.Error(w, "400 request unreadable or too large.", 400)
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				http.Error(w, "Request Entity Too Large.", http.StatusRequestEntityTooLarge)
+			} else {
+				http.Error(w, "400 request unreadable.", http.StatusBadRequest)
+			}
 			return
 		}
 		utils.Info.Printf("agtServer:received POST request=%s\n", string(bodyBytes))
@@ -341,6 +339,9 @@ func authenticateClient(payload Payload) bool {
 func addCheckJti(jti string) bool {
 	jtiCacheMu.Lock()
 	defer jtiCacheMu.Unlock()
+	if jtiCache == nil {
+		jtiCache = make(map[string]struct{})
+	}
 	if _, ok := jtiCache[jti]; ok {
 		return false
 	}


### PR DESCRIPTION
## Summary

- **Duplicate `jtiCacheMu` declaration** (lines ~60 and ~132): `jtiCacheMu` is declared at file scope alongside `jtiCache`; the second declaration was a merge artifact that causes a compile error.
- **`MaxBytesReader` error returns 400 instead of 413**: `io.ReadAll` returns `*http.MaxBytesError` when the body exceeds the cap. The original handler returned 400 for both oversized and unreadable cases. Oversized bodies now correctly return 413 (`StatusRequestEntityTooLarge`) so clients can distinguish the two conditions.
- **`addCheckJti` nil-map panic**: `jtiCache` is initialised at declaration but test helpers reset it to `nil` for isolation. Added a nil-init guard (`if jtiCache == nil { jtiCache = make(...) }`) so the function is safe regardless.

## Test plan

- [ ] `go build ./server/agt_server/...` — no errors
- [ ] `go vet ./server/agt_server/...` — no warnings
- [ ] `go test -race -count=1 ./server/agt_server/...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)