### PR TITLE
fix: resolve 12 vet failures and test bugs surfaced by upstream merge

### DIFF
--- a/client/client-1.0/compress_client/compress_client.go
+++ b/client/client-1.0/compress_client/compress_client.go
@@ -49,6 +49,7 @@ func pathToUrl(path string) string {
 }
 
 func jsonToStructList(jsonList string) int {
+	requestList.Request = nil
 	var reqList map[string]interface{}
 	err := json.Unmarshal([]byte(jsonList), &reqList)
 	if err != nil {

--- a/client/client-1.0/compress_client/compress_client_test.go
+++ b/client/client-1.0/compress_client/compress_client_test.go
@@ -21,7 +21,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/covesa/vissr/utils"
 )
+
+func init() {
+	utils.InitLog("compress_client-test.log", os.TempDir(), false, "error")
+}
 
 // TestPathToUrl converts VSS dot-paths into URL slash-paths.
 func TestPathToUrl(t *testing.T) {

--- a/client/client-1.0/csv_client/csv_client.go
+++ b/client/client-1.0/csv_client/csv_client.go
@@ -257,13 +257,10 @@ func processDataLevel5(dp map[string]interface{}, valArray *[]string, tsArray *[
 	for k, v := range dp {
 		switch vv := v.(type) {
 		case string:
-			//			utils.Info.Println(k, "is string", vv)
 			if k == "value" {
-				// valArray[arrayIndex] = vv
-				*valArray = append(*valArray, vv)
+				(*valArray)[arrayIndex] = vv
 			} else if k == "ts" {
-				// tsArray[arrayIndex] = vv
-				*tsArray = append(*tsArray, vv)
+				(*tsArray)[arrayIndex] = vv
 			}
 		default:
 			utils.Info.Println(k, "is of an unknown type")
@@ -278,19 +275,13 @@ func saveInCsv(valArray []string, tsArray []string, arrayIndex int) {
 		fmt.Printf("Could not open data.csv for writing.\n")
 		return
 	}
+	defer treeFp.Close()
 	for i := 0; i < arrayIndex; i++ {
 		treeFp.Write([]byte(tsArray[i]))
 		treeFp.Write([]byte(", "))
-	}
-	treeFp.Write([]byte("\n"))
-
-	for i := 0; i < arrayIndex; i++ {
 		treeFp.Write([]byte(valArray[i]))
-		treeFp.Write([]byte(", "))
+		treeFp.Write([]byte("\n"))
 	}
-	treeFp.Write([]byte("\n"))
-
-	treeFp.Close()
 }
 
 func performPbCommand(commandNumber int, conn *websocket.Conn, optionChannel chan string) {

--- a/client/client-1.0/csv_client/csv_client_test.go
+++ b/client/client-1.0/csv_client/csv_client_test.go
@@ -23,7 +23,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/covesa/vissr/utils"
 )
+
+func init() {
+	utils.InitLog("csv_client-test.log", os.TempDir(), false, "error")
+}
 
 func TestPathToUrl_CsvClient(t *testing.T) {
 	cases := map[string]string{

--- a/client/client-1.0/filetransfer_client/filetransfer_client.go
+++ b/client/client-1.0/filetransfer_client/filetransfer_client.go
@@ -38,11 +38,11 @@ func safeServerFilename(name string) (string, error) {
 	if name == "" {
 		return "", fmt.Errorf("empty filename from server")
 	}
-	if filepath.Base(name) != name {
-		return "", fmt.Errorf("server filename %q contains path separators", name)
-	}
 	if strings.Contains(name, "..") {
 		return "", fmt.Errorf("server filename %q contains parent-directory reference", name)
+	}
+	if filepath.Base(name) != name {
+		return "", fmt.Errorf("server filename %q contains path separators", name)
 	}
 	return name, nil
 }
@@ -337,12 +337,7 @@ func uploadFile(ctrlChannel chan string, dataChannel chan []byte) {
 }
 
 func equalByteArray(array1 []byte, array2 []byte) bool {
-	for i := 0; i < len(array1); i++ {
-		if array1[i] != array2[i] {
-			return false
-		}
-	}
-	return true
+	return bytes.Equal(array1, array2)
 }
 
 func getFileDescriptorData(value interface{}) (string, string, string) { // {"name": "xxx","hash": "yyy","uid": "zzz"}

--- a/client/client-1.0/testClient/testClient.go
+++ b/client/client-1.0/testClient/testClient.go
@@ -448,7 +448,8 @@ func performGrpcCommand(vssRequest string, client pb.VISSClient) {
 	var reqMap map[string]interface{}
 	utils.MapRequest(vssRequest, &reqMap)
 	fmt.Printf("Request=:%s\n", vssRequest)
-	ctx, _ := context.WithTimeout(context.Background(), 6*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
 	switch reqMap["action"].(string) {
 	case "get":
 		pbRequest := utils.GetRequestJsonToPb(vssRequest)

--- a/server/vissv2server/atServer/ecfSim/ecfSimulator.go
+++ b/server/vissv2server/atServer/ecfSim/ecfSimulator.go
@@ -141,7 +141,6 @@ func uiDialogue(request string) string {
 		fmt.Printf("Invalid action.")
 		return ""
 	}
-	return ""
 }
 
 func prepareCancelRequest(request string) bool {

--- a/server/vissv2server/grpcMgr/grpcMgr.go
+++ b/server/vissv2server/grpcMgr/grpcMgr.go
@@ -335,7 +335,6 @@ func (s *Server) SubscribeRequest(in *pb.SubscribeRequestMessage, stream pb.VISS
 			}
 		}
 	}
-	return nil
 }
 
 func extractClientId(killMessage string) int { // mesage contains clientId:xyz

--- a/server/vissv2server/serviceMgr/curvelog.go
+++ b/server/vissv2server/serviceMgr/curvelog.go
@@ -534,61 +534,73 @@ func getClSessionsCount() int {
 	return numOfClSessions
 }
 
+func sendToClServerChan(idx int, msg string) {
+	select {
+	case clServerChan[idx] <- msg:
+	default:
+	}
+}
+
+func handleCurveLogServerMessage(message string, routingDataList []TriggRoutingData) []TriggRoutingData {
+	if len(message) == 0 {
+		return routingDataList
+	}
+	var messageMap map[string]interface{}
+	if err := json.Unmarshal([]byte(message), &messageMap); err != nil {
+		utils.Error.Printf("Error in trigg message=%s", message)
+		return routingDataList
+	}
+	action, ok := messageMap["action"].(string)
+	if !ok {
+		utils.Error.Printf("Error in trigg message=%s", message)
+		return routingDataList
+	}
+	switch action {
+	case "subscribe":
+		if status, ok := messageMap["status"].(string); ok && status == "ok" {
+			for i := 0; i < len(routingDataList); i++ {
+				for j := 0; j < len(routingDataList[i].TriggRoutingList); j++ {
+					sendToClServerChan(routingDataList[i].TriggRoutingList[j].Index, message)
+				}
+			}
+		}
+	case "unsubscribe":
+		if subscriptionId, ok := messageMap["subscriptionId"].(string); ok {
+			for i := 0; i < len(routingDataList); i++ {
+				if routingDataList[i].SubscriptionId == subscriptionId {
+					deallocateTriggChannels(i, routingDataList)
+					routingDataList = slices.Delete(routingDataList, i, i+1)
+					i--
+				}
+			}
+		}
+	case "subscription":
+		if path, ok := messageMap["path"].(string); ok {
+			for j := 0; j < len(routingDataList); j++ {
+				for k := 0; k < len(routingDataList[j].TriggRoutingList); k++ {
+					for l := 0; l < len(routingDataList[j].TriggRoutingList[k].Path); l++ {
+						if routingDataList[j].TriggRoutingList[k].Path[l] == path {
+							sendToClServerChan(routingDataList[j].TriggRoutingList[k].Index, message)
+							break
+						}
+					}
+				}
+			}
+		}
+	default:
+		utils.Error.Printf("Unknown action=%s", action)
+	}
+	return routingDataList
+}
+
 func curveLogServer() {
 	var routingDataList []TriggRoutingData
 	for {
 		select {
-			case message := <- fromFeederCl:
-				if len(message) == 0 {
-					continue
-				}
-				var messageMap map[string]interface{}
-				err := json.Unmarshal([]byte(message), &messageMap)
-				if err != nil || messageMap["action"] == nil {
-					utils.Error.Printf("Error in trigg message=%s", message)
-					continue
-				}
-				switch messageMap["action"].(string) {
-					case "subscribe":
-						if messageMap["status"] != nil && messageMap["status"].(string) == "ok" {
-							// notify all existing compute threads
-							for i  := 0; i < len(routingDataList); i++ {
-								for j  := 0; j < len(routingDataList[i].TriggRoutingList); j++ {
-									clServerChan[routingDataList[i].TriggRoutingList[j].Index] <- message
-								}
-							}
-						}
-					case "unsubscribe":
-						if messageMap["subscriptionId"] != nil {
-							//remove from routingDataList
-							subscriptionId := messageMap["subscriptionId"].(string)
-							for i  := 0; i < len(routingDataList); i++ {
-								if routingDataList[i].SubscriptionId == subscriptionId {
-									deallocateTriggChannels(i, routingDataList)
-									routingDataList = slices.Delete(routingDataList, i, i+1)
-								}
-							}
-						}
-					case "subscription":
-						if messageMap["path"] != nil {
-							// notify all threads that use the path
-							path := messageMap["path"].(string)
-							for j  := 0; j < len(routingDataList); j++ {
-								for k  := 0; k < len(routingDataList[j].TriggRoutingList); k++ {
-									for l  := 0; l < len(routingDataList[j].TriggRoutingList[k].Path); l++ {
-										if routingDataList[j].TriggRoutingList[k].Path[l] == path {
-											clServerChan[routingDataList[j].TriggRoutingList[k].Index] <- message
-											break
-										}
-									}
-								}
-							}
-						}
-					default:
-						utils.Error.Printf("Unknown action=%s", messageMap["action"].(string))
-				}
-			case routingData := <- clRouterChan:
-				routingDataList = append(routingDataList, routingData)
+		case message := <-fromFeederCl:
+			routingDataList = handleCurveLogServerMessage(message, routingDataList)
+		case routingData := <-clRouterChan:
+			routingDataList = append(routingDataList, routingData)
 		}
 	}
 }

--- a/utils/managerhandlers_test.go
+++ b/utils/managerhandlers_test.go
@@ -11,10 +11,8 @@ package utils
 import (
 	"bytes"
 	"net/http/httptest"
-	"strings"
 	"sync"
 	"testing"
-	"time"
 )
 
 // snapshotWsClientIndexList captures and restores WsClientIndexList around a


### PR DESCRIPTION
## Summary

Post-merge cleanup after syncing to upstream `0f477b7`. Running `go vet ./...` and the full `-race` test suite against the merged code revealed 12 bugs split across two areas.

### Commit 1 — `go vet` failures (5 bugs)

| File | Bug | Fix |
|---|---|---|
| `serviceMgr/curvelog.go` | `curvelog_test.go` called `handleCurveLogServerMessage` and `sendToClServerChan` — neither existed in the source; merged test and implementation were out of sync | Extracted both from `curveLogServer()`; `sendToClServerChan` uses a non-blocking `select` to drop rather than deadlock on a full channel; all type assertions use comma-ok form; unsubscribe loop uses `i--` after `slices.Delete` so duplicate IDs are fully removed |
| `utils/managerhandlers_test.go` | `"strings"` and `"time"` imported but unused after upstream refactor | Removed both |
| `client/testClient/testClient.go:451` | `context.WithTimeout` cancel discarded → context leak | `ctx, cancel := ...; defer cancel()` |
| `atServer/ecfSim/ecfSimulator.go:144` | Unreachable `return ""` after exhaustive switch | Removed |
| `server/vissv2server/grpcMgr/grpcMgr.go:338` | Unreachable `return nil` after infinite `for/select` | Removed |

### Commit 2 — full `-race` test suite failures (7 bugs)

| File | Bug | Fix |
|---|---|---|
| `compress_client/compress_client.go` | Package-level `requestList` not reset between calls; the `default` switch case returned stale length from a prior call | Reset `requestList.Request = nil` at the top of `jsonToStructList` |
| `compress_client/compress_client_test.go` | `utils.Error` nil → panic before `recover()` fires | Added `init()` calling `utils.InitLog` |
| `csv_client/csv_client.go` (`processDataLevel5`) | Used `append()` on pre-allocated slices; values landed past the end of the slice instead of at `arrayIndex` | Switched to indexed write `(*valArray)[arrayIndex] = vv` |
| `csv_client/csv_client.go` (`saveInCsv`) | Wrote two horizontal lines (ts row, val row) instead of one row-per-datapoint; `csv.Reader` returned 2 rows where the test expected ≥3 | Write one `ts, val\n` line per datapoint |
| `csv_client/csv_client_test.go` | Same nil-logger panic as compress_client | Added `init()` calling `utils.InitLog` |
| `filetransfer_client/filetransfer_client.go` (`equalByteArray`) | Hand-rolled loop accessed `array2[i]` without a length guard → panic on unequal-length slices | Replaced with `bytes.Equal` |
| `filetransfer_client/filetransfer_client.go` (`safeServerFilename`) | `filepath.Base` check fired before `..` check; `"../etc/passwd"` triggered "path separators" error instead of "parent-directory" | Moved `..` check first |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race -count=1 ./...` — all 25 testable packages pass
- [ ] `paho-mqtt/TestTcpLocalHost` — skipped; requires a live MQTT broker on `:8883` (test self-documents this)