### PR TITLE
fix(mqtt): repair VIN-init echo bug and add MQTT_VIN env-var fallback

### DIFF
--- a/server/vissv2server/mqttMgr/mqttMgr.go
+++ b/server/vissv2server/mqttMgr/mqttMgr.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/covesa/vissr/utils"
 	MQTT "github.com/eclipse/paho.mqtt.golang"
@@ -201,22 +202,49 @@ func publishMessage(client MQTT.Client, topic, payload string) {
 	}
 }
 
-func getVissV2Topic(transportMgrChan chan string, mgrId int) string {
-	vinRequest := "{\"RouterId\":\"" + strconv.Itoa(mgrId) + `?0", "action":"get",
-	"path":"Vehicle.VehicleIdentification.VIN", "requestId":"570415", "origin":"internal"}`
-	transportMgrChan <- vinRequest
-	response := <-transportMgrChan
-	vin := extractVin(string(response))
-	utils.Info.Printf("VIN=%s", vin)
-	if !isValidVin(vin) {
-		// MQTT topic-name injection guard: a VIN containing '+', '#',
-		// or '/' would let the manager subscribe to wildcard topics
-		// outside this vehicle's scope. Refuse to build a topic from
-		// an invalid VIN.
-		utils.Error.Printf("getVissV2Topic: refusing to build topic from invalid VIN=%q", vin)
+// getVissV2TopicFromEnv checks MQTT_VIN env var and returns the MQTT topic if set.
+func getVissV2TopicFromEnv() string {
+	vin := os.Getenv("MQTT_VIN")
+	if vin == "" {
 		return ""
 	}
+	if !isValidVin(vin) {
+		utils.Error.Printf("getVissV2Topic: MQTT_VIN=%q is not a valid VIN (alphanumeric + - _)", vin)
+		return ""
+	}
+	utils.Info.Printf("getVissV2Topic: using MQTT_VIN env var, topic=/%s/Vehicle", vin)
 	return "/" + vin + "/Vehicle"
+}
+
+func getVissV2Topic(transportMgrChan chan string, mgrId int) string {
+	// Fast path: MQTT_VIN env var bypasses the channel round-trip (useful for
+	// local development where state storage has no VIN populated yet).
+	if topic := getVissV2TopicFromEnv(); topic != "" {
+		return topic
+	}
+
+	vinRequest := "{\"RouterId\":\"" + strconv.Itoa(mgrId) + `?0", "action":"get", "path":"Vehicle.VehicleIdentification.VIN", "requestId":"570415", "origin":"internal"}`
+	transportMgrChan <- vinRequest
+
+	// transportMgrChan is bidirectional (requests go server-ward, responses
+	// come back on the same channel via transportDataSession). We rely on the
+	// channel being unbuffered: if it were buffered our own send would sit in
+	// the buffer and we'd echo-read it before transportDataSession consumes it.
+	// vissv2server.initChannels explicitly keeps transportMgrChannel[2] unbuffered
+	// for exactly this reason.
+	select {
+	case response := <-transportMgrChan:
+		vin := extractVin(string(response))
+		utils.Info.Printf("VIN=%s", vin)
+		if !isValidVin(vin) {
+			utils.Error.Printf("getVissV2Topic: refusing to build topic from invalid VIN=%q (set MQTT_VIN env var to override)", vin)
+			return ""
+		}
+		return "/" + vin + "/Vehicle"
+	case <-time.After(5 * time.Second):
+		utils.Error.Printf("getVissV2Topic: timed out waiting for VIN response after 5s (set MQTT_VIN env var to override)")
+		return ""
+	}
 }
 
 // extractVin parses the VIN out of a server-core get response. The

--- a/server/vissv2server/vissv2server.go
+++ b/server/vissv2server/vissv2server.go
@@ -978,6 +978,12 @@ func initChannels() {
 		transportDataChan[i] = make(chan map[string]interface{}, pipelineBuf)
 		backendChan[i] = make(chan map[string]interface{}, pipelineBuf)
 	}
+	// MQTT's channel must stay unbuffered. MqttMgrInit performs a synchronous
+	// VIN-fetch by sending on and receiving from the same channel in one
+	// goroutine. A buffered channel causes an echo: the goroutine reads its own
+	// send before transportDataSession can consume it. Unbuffered forces the
+	// send to block until transportDataSession reads, preserving ordering.
+	transportMgrChannel[2] = make(chan string)
 	atsChannel = make([]chan string, 2)
 	atsChannel[0] = make(chan string) // access token verification (serialized by atsChannelMu)
 	atsChannel[1] = make(chan string) // token cancellation

--- a/server/vissv2server/vissv2server_test.go
+++ b/server/vissv2server/vissv2server_test.go
@@ -347,8 +347,18 @@ func TestInitChannels_BuffersPipeline(t *testing.T) {
 		t.Errorf("serviceDataChan[0] should be buffered")
 	}
 	for i := 0; i < NUMOFTRANSPORTMGRS; i++ {
-		if cap(transportMgrChannel[i]) == 0 {
-			t.Errorf("transportMgrChannel[%d] should be buffered", i)
+		// MQTT (index 2) is intentionally unbuffered: MqttMgrInit performs a
+		// synchronous VIN-fetch handshake in one goroutine. A buffered channel
+		// causes the goroutine to echo-read its own send before
+		// transportDataSession can consume it.
+		if i == 2 {
+			if cap(transportMgrChannel[i]) != 0 {
+				t.Errorf("transportMgrChannel[%d] (MQTT) should be unbuffered", i)
+			}
+		} else {
+			if cap(transportMgrChannel[i]) == 0 {
+				t.Errorf("transportMgrChannel[%d] should be buffered", i)
+			}
 		}
 		if cap(transportDataChan[i]) == 0 {
 			t.Errorf("transportDataChan[%d] should be buffered", i)


### PR DESCRIPTION
## Problem

`MqttMgrInit` performs a synchronous handshake at startup to derive its MQTT topic: it sends a VISS GET for `Vehicle.VehicleIdentification.VIN` on `transportMgrChan` and then reads the server-core response from the **same channel**.

This worked when `transportMgrChannel` was **unbuffered** — the send blocked until `transportDataSession` read the message, so the correct goroutine consumed the request before `getVissV2Topic` tried to read the response.

A later performance PR buffered all five `transportMgrChannel` slots to 32 items. With a **buffered** channel the send is **non-blocking**: the request lands in the buffer and the same goroutine immediately executes `response := <-transportMgrChan`. Because the buffer still holds the request, the goroutine reads its **own message back** (the echo). `transportDataSession` never sees it, the server never processes it, `extractVin` finds no value, and `MqttMgrInit` refuses to start — silently from an operator's perspective.

There are two compounding issues:

| # | Issue | Symptom |
|---|-------|---------|
| 1 | `transportMgrChannel[2]` buffered: `getVissV2Topic` echoes its own request | MQTT manager never starts, even if VIN is in state storage |
| 2 | VIN not in state storage on a fresh install / no feeder | Even with #1 fixed, manager refuses (correct behaviour, but no local workaround) |

## Changes

### `vissv2server/vissv2server.go` — one line

After the loop that buffers all transport channels, explicitly reset the MQTT slot back to unbuffered:

```go
// MQTT's channel must stay unbuffered. MqttMgrInit performs a synchronous
// VIN-fetch handshake by sending on and receiving from the same channel in
// one goroutine. A buffered channel causes an echo: the goroutine reads its
// own send before transportDataSession can consume it.
transportMgrChannel[2] = make(chan string)
```

The other four transport managers keep their buffered channels; only MQTT requires the blocking-send semantics.

### `vissv2server/mqttMgr/mqttMgr.go` — two additions to `getVissV2Topic`

**Fast path** (`MQTT_VIN` env var): skips the channel round-trip entirely. Useful for local development, CI, and any deployment where the VIN is configured statically.

**Timeout** on the slow path: `select` / `time.After(5s)` so the function fails fast if the service manager is temporarily unavailable, with an actionable error message in both cases.

### `vissv2server/vissv2server_test.go` — updated assertion

`TestInitChannels_BuffersPipeline` previously asserted that **all** transport channels are buffered. Updated to assert that `transportMgrChannel[2]` is specifically **unbuffered** and documents why.

## How to run the MQTT stack locally

```bash
# 1. Start a plain-TCP broker (anonymous, port 1883)
brew install mosquitto          # one-time
mosquitto -c <(printf 'listener 1883\nallow_anonymous true\n') &

# 2. Start the server with MQTT enabled + a test VIN
cd server/vissv2server
go build && MQTT_VIN=TESTVIN001 ./vissv2server -m

# 3. Send a VISS request
mosquitto_pub -h 127.0.0.1 -p 1883 -t /TESTVIN001/Vehicle \
  -m '{"topic":"myreply","request":{"action":"get","path":"Vehicle.Speed","requestId":"1"}}'

# Subscribe for the response on a second terminal
mosquitto_sub -h 127.0.0.1 -p 1883 -t myreply
```

The TLS broker (`paho-mqtt/` Docker image, port 8883) is unaffected — `getBrokerSocket(true)` is unchanged.

## Validation performed

```
go test -race ./server/vissv2server/... ./server/vissv2server/mqttMgr/...
# all pass

# Integration (env-var fast path)
MQTT_VIN=TESTVIN001 ./vissv2server -m
# "using MQTT_VIN env var, topic=/TESTVIN001/Vehicle"
# "**** MQTT manager hub entering server loop... ****"

# Integration (echo fix, no MQTT_VIN, no Redis)
./vissv2server -m
# Response has "infoType":"Data" (reached issueServiceRequest — no echo)
# Graceful refusal with hint to set MQTT_VIN

# End-to-end round-trip (see mosquitto commands above)
# Request received → routed to server core → response published back
```

## ⚠️ Recommended maintainer validation before merge

This patch touches the channel-initialisation critical path shared by all five transport managers. Please validate before accepting:

1. **Full stack with VIN in state storage** (`-s redis` or `-s sqlite`, feeder running so VIN is populated): confirm the slow-path channel round-trip correctly retrieves the VIN and the manager subscribes to `/<VIN>/Vehicle`.

2. **Multi-client MQTT throughput burst**: send concurrent VISS requests over MQTT and verify no responses are dropped or mis-routed. `transportMgrChannel[2]` is intentionally unbuffered; a slow service manager *will* back-pressure the MQTT main loop. If throughput regression is observed, the preferred resolution is a dedicated VIN-init channel rather than re-buffering.

3. **TLS broker** (`paho-mqtt/` Docker image, port 8883): exercise the existing certificate fixtures to confirm TLS connections are unaffected.

4. **Race detector**: `go test -race ./server/vissv2server/...` — the pre-existing bidirectional use of `transportMgrChannel` between `transportDataSession` and `vissV2Receiver` should produce no new races.

---
_Note: `TestFrontendHttpAppSession_GetForwards` in `utils` is a pre-existing flaky test (port conflict when run concurrently); it fails on `master` too and is unrelated to this PR._