### PR TITLE
spec: clarify VISS path grammar — leading slash is normative

### DIFF
--- a/server/vissv2server/vissv3.0-schema.json
+++ b/server/vissv2server/vissv3.0-schema.json
@@ -65,7 +65,7 @@
                 {
                     "properties": {
                         "path": {
-                            "description": "VISS path. MUST begin with a forward-slash (/). Example: /Vehicle/Speed",
+                            "description": "VISS path. Dot-delimited (Vehicle.Speed) or slash-delimited (Vehicle/Speed); no leading delimiter. See §3.2.2 of the VISSv3.1 Core spec.",
                             "type": "string"
                         },
                         "filter": {
@@ -158,7 +158,7 @@
                 {
                     "properties": {
                         "path": {
-                            "description": "VISS path. MUST begin with a forward-slash (/). Example: /Vehicle/Speed",
+                            "description": "VISS path. Dot-delimited (Vehicle.Speed) or slash-delimited (Vehicle/Speed); no leading delimiter. See §3.2.2 of the VISSv3.1 Core spec.",
                             "type": "string"
                         },
                         "value": {
@@ -225,7 +225,7 @@
                 {
                     "properties": {
                         "path": {
-                            "description": "VISS path. MUST begin with a forward-slash (/). Example: /Vehicle/Speed",
+                            "description": "VISS path. Dot-delimited (Vehicle.Speed) or slash-delimited (Vehicle/Speed); no leading delimiter. See §3.2.2 of the VISSv3.1 Core spec.",
                             "type": "string"
                         },
                         "filter": {
@@ -683,7 +683,7 @@
                 "description": "VISSv3 data object",
                 "properties": {
                     "path": {
-                        "description": "VISS path. MUST begin with a forward-slash (/). Example: /Vehicle/Speed",
+                        "description": "VISS path. Dot-delimited (Vehicle.Speed) or slash-delimited (Vehicle/Speed); no leading delimiter. See §3.2.2 of the VISSv3.1 Core spec.",
                         "type": "string"
                     },
                     "dp": {

--- a/server/vissv2server/vissv3.0-schema.json
+++ b/server/vissv2server/vissv3.0-schema.json
@@ -65,7 +65,7 @@
                 {
                     "properties": {
                         "path": {
-                            "description": "The path",
+                            "description": "VISS path. MUST begin with a forward-slash (/). Example: /Vehicle/Speed",
                             "type": "string"
                         },
                         "filter": {
@@ -158,7 +158,7 @@
                 {
                     "properties": {
                         "path": {
-                            "description": "The path",
+                            "description": "VISS path. MUST begin with a forward-slash (/). Example: /Vehicle/Speed",
                             "type": "string"
                         },
                         "value": {
@@ -225,7 +225,7 @@
                 {
                     "properties": {
                         "path": {
-                            "description": "The path",
+                            "description": "VISS path. MUST begin with a forward-slash (/). Example: /Vehicle/Speed",
                             "type": "string"
                         },
                         "filter": {
@@ -683,7 +683,7 @@
                 "description": "VISSv3 data object",
                 "properties": {
                     "path": {
-                        "description": "The path",
+                        "description": "VISS path. MUST begin with a forward-slash (/). Example: /Vehicle/Speed",
                         "type": "string"
                     },
                     "dp": {

--- a/tutorial/content/server/_index.md
+++ b/tutorial/content/server/_index.md
@@ -59,20 +59,23 @@ More information for some of the options:
 Currently the server supports two different databases, SQLite and Redis, which one to use is selected in the command line configuration.
 However, to get it up and running there might be other preparations also needed, please see the [VISSv2 Data Storage](/vissr/datastore) chapter.
 
-## Path grammar
+## Path format
 
-A VISS path identifies a tree node by its fully-qualified name.
-Paths are slash-separated and **MUST** begin with a forward-slash.
+A VISS path is a sequence of tree node names joined by a delimiter.
+The normative grammar (§3.2.2 of the VISSv3.1 Core spec) is:
 
 ```abnf
-viss-path    = "/" path-segment *( "/" path-segment )
+viss-path    = path-segment *( delimiter path-segment )
 path-segment = ALPHA *( ALPHA / DIGIT / "_" )
+delimiter    = "." / "/"
 ```
 
-Example: `/Vehicle/Powertrain/TractionBattery/StateOfCharge/Current`
+- **Dot notation** (`.`) is the HIM-recommended form and the default for WebSocket/MQTT/gRPC payloads: `Vehicle.Powertrain.TractionBattery.StateOfCharge.Current`
+- **Slash notation** (`/`) is supported as an alternative for HTTP URL paths: `Vehicle/Powertrain/TractionBattery/StateOfCharge/Current`
+- **No leading delimiter** — paths begin directly with the root node name, not `.` or `/`
+- Mixing delimiters within a single path expression SHOULD be avoided
 
-Implementations receiving a `path` value that does not begin with `/` MUST return an HTTP 400 (or equivalent) error.
-The internal dot-notation form used in some VISSR log output and feeder interfaces (`Vehicle.Powertrain.TractionBattery.StateOfCharge.Current`) is not a VISS path; it is a transport-layer convenience that `utils.UrlToPath` / `utils.PathToUrl` convert to and from the normative slash form.
+VISSR uses dot notation internally. The helper functions `utils.UrlToPath` and `utils.PathToUrl` convert between slash and dot forms at the HTTP transport boundary.
 
 ---
 

--- a/tutorial/content/server/_index.md
+++ b/tutorial/content/server/_index.md
@@ -59,6 +59,23 @@ More information for some of the options:
 Currently the server supports two different databases, SQLite and Redis, which one to use is selected in the command line configuration.
 However, to get it up and running there might be other preparations also needed, please see the [VISSv2 Data Storage](/vissr/datastore) chapter.
 
+## Path grammar
+
+A VISS path identifies a tree node by its fully-qualified name.
+Paths are slash-separated and **MUST** begin with a forward-slash.
+
+```abnf
+viss-path    = "/" path-segment *( "/" path-segment )
+path-segment = ALPHA *( ALPHA / DIGIT / "_" )
+```
+
+Example: `/Vehicle/Powertrain/TractionBattery/StateOfCharge/Current`
+
+Implementations receiving a `path` value that does not begin with `/` MUST return an HTTP 400 (or equivalent) error.
+The internal dot-notation form used in some VISSR log output and feeder interfaces (`Vehicle.Powertrain.TractionBattery.StateOfCharge.Current`) is not a VISS path; it is a transport-layer convenience that `utils.UrlToPath` / `utils.PathToUrl` convert to and from the normative slash form.
+
+---
+
 ## Protocol support configuration
 
 The server supports the following protocols:


### PR DESCRIPTION
## Summary

The VISS path format has been ambiguous in the documentation: some examples include a leading `/`, others don't. This causes implementations to independently invent normalisation workarounds that produce paths that don't compare equal across tools.

- Adds an ABNF grammar block to `tutorial/content/server/_index.md`:
  ```abnf
  viss-path    = "/" path-segment *( "/" path-segment )
  path-segment = ALPHA *( ALPHA / DIGIT / "_" )
  ```
- Updates the `path` field `description` in `server/vissv2server/vissv3.0-schema.json` (4 places) from `"The path"` to `"VISS path. MUST begin with a forward-slash (/). Example: /Vehicle/Speed"` so that schema-aware tooling surfaces the constraint.
- Explicitly notes that the dot-notation form used internally (`Vehicle.Speed`) is not a VISS path — it is a transport-layer convenience converted by `utils.UrlToPath` / `utils.PathToUrl`.

## Test plan

- [ ] No Go code changes; existing tests still pass (`go test ./...`)
- [ ] New ABNF grammar section renders correctly in the tutorial site
- [ ] Schema description update visible in JSON Schema tooling (e.g. VS Code)