### PR TITLE
chore(.copilot): add modular PR review skill guides

### DIFF
--- a/.copilot/guides/generic/ARCHITECTURE.md
+++ b/.copilot/guides/generic/ARCHITECTURE.md
@@ -12,11 +12,11 @@ utils.DeregisterServiceTree(rootName)
 ```
 
 **Review checklist:**
-- ✅ New components providing trees use `RegisterServiceTree()`
-- ✅ `rootName` is unique across all sources
-- ✅ Service trees have `.Service` domain suffix
-- ✅ Cleanup calls `DeregisterServiceTree()` on shutdown
-- ❌ Red flag: same `rootName` registered from two sources
+- New components providing trees use `RegisterServiceTree()`
+- `rootName` is unique across all sources
+- Service trees have `.Service` domain suffix
+- Cleanup calls `DeregisterServiceTree()` on shutdown
+- Red flag: same `rootName` registered from two sources
 
 ## HIM Forest vs Dynamic Registration
 
@@ -32,34 +32,34 @@ utils.DeregisterServiceTree(rootName)
 
 ```
 server/vissv2server/
-├── vdmloader/         → VDM-specific parsing logic
-├── webdash/           → Web UI/dashboard components
-├── vissServiceMgr/    → Service registration protocol
-├── wsMgr/             → WebSocket transport
-├── httpMgr/           → HTTP transport
-└── smoketest/         → Integration tests (//go:build smoke)
+├── vdmloader/       -- VDM-specific parsing logic
+├── webdash/         -- Web UI/dashboard components
+├── vissServiceMgr/  -- Service registration protocol
+├── wsMgr/           -- WebSocket transport
+├── httpMgr/         -- HTTP transport
+└── smoketest/       -- Integration tests (//go:build smoke)
 ```
 
 **Review checklist:**
-- ✅ Single responsibility per package
-- ✅ Public APIs minimal (< 5 exported symbols)
-- ✅ Integration tests use `//go:build` tags
-- ✅ Implementation details private (lowercase names)
+- Single responsibility per package
+- Public APIs minimal (< 5 exported symbols)
+- Integration tests use `//go:build` tags
+- Implementation details private (lowercase names)
 
 ## Interface-Driven Design
 
 ```go
-// ✅ GOOD: Focused, stateless function
+// GOOD: Focused, stateless function
 func Start(addr string) error
 
-// ✅ GOOD: Fluent builder
+// GOOD: Fluent builder
 svc, err := NewService(addr, path).
     WithInput("Param", "uint32").
     WithOutput("Result", "string").
     OnInvoke(handler).
     Register()
 
-// ❌ BAD: Large, god-like interface
+// BAD: Large, god-like interface
 func NewManager(conf Config, logger Logger, registry Registry, ...) *Manager
 ```
 
@@ -78,11 +78,11 @@ func NewManager(conf Config, logger Logger, registry Registry, ...) *Manager
 ### Issue: Missing Input Validation
 
 ```go
-// ❌ BAD
+// BAD
 sig, _ := msg["signature"].(map[string]interface{})
 root := buildTree(sig)  // Could fail silently
 
-// ✅ GOOD
+// GOOD
 sig, ok := msg["signature"].(map[string]interface{})
 if !ok || len(sig) == 0 {
     return fmt.Errorf("signature must be non-empty map")
@@ -94,12 +94,12 @@ if !ok || len(sig) == 0 {
 ### Issue: Non-Atomic I/O Operations
 
 ```go
-// ❌ BAD: Multiple writes (partial write risk)
+// BAD: Multiple writes (partial write risk)
 w.Write(jsonBytes)
 w.WriteByte('\n')
 w.Flush()
 
-// ✅ GOOD: Atomic frame
+// GOOD: Atomic frame
 frame := append(jsonBytes, '\n')
 w.Write(frame)
 w.Flush()
@@ -110,11 +110,11 @@ w.Flush()
 ### Issue: Missing Mutual Exclusivity Checks
 
 ```go
-// ❌ BAD: Could specify both flags
+// BAD: Could specify both flags
 if *vdmDir != "" { vdmloader.LoadDir(*vdmDir) }
 if *himFile != "" { loadHIM(*himFile) }
 
-// ✅ GOOD: Validates exclusivity
+// GOOD: Validates exclusivity
 if *vdmDir != "" && *himFile != "" {
     return fmt.Errorf("--vdm and --him are mutually exclusive")
 }
@@ -132,7 +132,7 @@ Currently tree building is in 2 places: `serviceReg.go` and `vdmloader.go`.
 ### Flag Validation
 
 ```go
-// ✅ GOOD: Explicit mutual exclusivity at startup
+// GOOD: Explicit mutual exclusivity at startup
 if *vdmDir != "" && *himFile != "" {
     utils.Error.Printf("fatal: --vdm and --him are mutually exclusive")
     os.Exit(1)
@@ -140,30 +140,30 @@ if *vdmDir != "" && *himFile != "" {
 ```
 
 **Review checklist:**
-- ✅ Mutually exclusive flags validated early
-- ✅ Required flags checked (not just defaulted to empty)
-- ✅ Flag names follow conventions (`--vdm`, `--web-addr`)
-- ✅ Help strings explain mutual exclusivity
+- Mutually exclusive flags validated early
+- Required flags checked (not just defaulted to empty)
+- Flag names follow conventions (`--vdm`, `--web-addr`)
+- Help strings explain mutual exclusivity
 
 ### Timeout & Interval Values
 
 ```go
-// ✅ GOOD: Exported, overridable in tests
+// GOOD: Exported, overridable in tests
 var HeartbeatInterval = 15 * time.Second
 var HeartbeatTimeout  =  5 * time.Second
 ```
 
 **Review checklist:**
-- ✅ Timeout variables exported (not hardcoded)
-- ✅ Default values reasonable for production
-- ✅ Documented with comments explaining purpose
+- Timeout variables exported (not hardcoded)
+- Default values reasonable for production
+- Documented with comments explaining purpose
 
 ## Error Handling & Recovery
 
 ### Graceful Degradation
 
 ```go
-// ✅ GOOD: Optional component failure is non-fatal
+// GOOD: Optional component failure is non-fatal
 if *webAddr != "" {
     if err := webdash.Start(*webAddr); err != nil {
         utils.Error.Printf("webdash: failed to start: %v", err)
@@ -171,7 +171,7 @@ if *webAddr != "" {
     }
 }
 
-// ❌ BAD: Optional component kills server
+// BAD: Optional component kills server
 if err := webdash.Start(*webAddr); err != nil {
     log.Fatalf("webdash: %v", err)
 }
@@ -195,10 +195,10 @@ VISS responses use standard error objects:
 ```
 
 **Review checklist:**
-- ✅ Errors use `number` + `reason` + `description` format
-- ✅ `reason` is machine-readable (snake_case)
-- ✅ `description` is human-readable
-- ✅ Internal paths/types not leaked
+- Errors use `number` + `reason` + `description` format
+- `reason` is machine-readable (snake_case)
+- `description` is human-readable
+- Internal paths/types not leaked
 
 ## Logging Standards
 
@@ -209,37 +209,37 @@ VISS responses use standard error objects:
 | `utils.Warning` | Degraded but functional |
 
 **Review checklist:**
-- ✅ `utils.Error` not used for expected cases
-- ✅ `utils.Info` used for service lifecycle
-- ✅ No sensitive data (tokens, secrets) logged
-- ✅ Log messages include relevant context
-- ❌ Red flag: `fmt.Println` used instead of `utils.Info/Error`
+- `utils.Error` not used for expected cases
+- `utils.Info` used for service lifecycle
+- No sensitive data (tokens, secrets) logged
+- Log messages include relevant context
+- Red flag: `fmt.Println` used instead of `utils.Info/Error`
 
 ## VDM / GraphQL SDL
 
 ### Directive Correctness
 
 **Review checklist:**
-- ✅ `@vspec(element: BRANCH|SENSOR|ACTUATOR|ATTRIBUTE)` on all types/fields
-- ✅ `@vspec(fqn: "Dot.Separated.Path")` matches expected signal path
-- ✅ `@range(min:, max:)` values numerically valid (min ≤ max)
-- ✅ `@unit(value: ...)` uses correct VSS unit strings
-- ✅ `@defaultValue(value: ...)` valid for field type
+- `@vspec(element: BRANCH|SENSOR|ACTUATOR|ATTRIBUTE)` on all types/fields
+- `@vspec(fqn: "Dot.Separated.Path")` matches expected signal path
+- `@range(min:, max:)` values numerically valid (min ≤ max)
+- `@unit(value: ...)` uses correct VSS unit strings
+- `@defaultValue(value: ...)` valid for field type
 
 ### Instance Tag Expansion
 
 **Review checklist:**
-- ✅ Types named `*_InstanceTag` have `@instanceTag` directive
-- ✅ Each dimension is an enum with `@vspec(originalName: ...)` on values
-- ✅ Expanded paths are unique (no collisions)
-- ✅ Deep clone of signal subtree correct (test: leaf nodes × instance count)
+- Types named `*_InstanceTag` have `@instanceTag` directive
+- Each dimension is an enum with `@vspec(originalName: ...)` on values
+- Expanded paths are unique (no collisions)
+- Deep clone of signal subtree correct (test: leaf nodes × instance count)
 
 ## DRY (Don't Repeat Yourself)
 
 **Pattern to watch:**
-- Tree building logic in multiple packages → extract
-- Configuration parsing in multiple places → centralize
-- Error handling patterns → use helpers
+- Tree building logic in multiple packages -- extract
+- Configuration parsing in multiple places -- centralize
+- Error handling patterns -- use helpers
 
 ## Concurrency & Synchronization
 

--- a/.copilot/guides/generic/ARCHITECTURE.md
+++ b/.copilot/guides/generic/ARCHITECTURE.md
@@ -1,0 +1,301 @@
+# VISSR Architecture & Design Guide
+
+Architectural patterns, design principles, and code organization standards for VISSR PRs.
+
+## Service Manager Registry Pattern
+
+All tree sources (static, dynamic, VDM) register via the unified registry:
+
+```go
+utils.RegisterServiceTree(rootName, domain, version, root)
+utils.DeregisterServiceTree(rootName)
+```
+
+**Review checklist:**
+- ✅ New components providing trees use `RegisterServiceTree()`
+- ✅ `rootName` is unique across all sources
+- ✅ Service trees have `.Service` domain suffix
+- ✅ Cleanup calls `DeregisterServiceTree()` on shutdown
+- ❌ Red flag: same `rootName` registered from two sources
+
+## HIM Forest vs Dynamic Registration
+
+| Use Case | Mechanism | File |
+|----------|-----------|------|
+| Static VSS tree | `viss.him` file | `server/vissv2server/viss.him` |
+| VDM SDL files (v4.0) | `--vdm` flag | `vdmloader.LoadDir()` |
+| Dynamic service procedures | TCP port 8300 | `vissServiceMgr/serviceReg.go` |
+
+**Key constraint:** `--vdm` and `--him` are mutually exclusive — validate early!
+
+## Package Organization
+
+```
+server/vissv2server/
+├── vdmloader/         → VDM-specific parsing logic
+├── webdash/           → Web UI/dashboard components
+├── vissServiceMgr/    → Service registration protocol
+├── wsMgr/             → WebSocket transport
+├── httpMgr/           → HTTP transport
+└── smoketest/         → Integration tests (//go:build smoke)
+```
+
+**Review checklist:**
+- ✅ Single responsibility per package
+- ✅ Public APIs minimal (< 5 exported symbols)
+- ✅ Integration tests use `//go:build` tags
+- ✅ Implementation details private (lowercase names)
+
+## Interface-Driven Design
+
+```go
+// ✅ GOOD: Focused, stateless function
+func Start(addr string) error
+
+// ✅ GOOD: Fluent builder
+svc, err := NewService(addr, path).
+    WithInput("Param", "uint32").
+    WithOutput("Result", "string").
+    OnInvoke(handler).
+    Register()
+
+// ❌ BAD: Large, god-like interface
+func NewManager(conf Config, logger Logger, registry Registry, ...) *Manager
+```
+
+## SOLID Principles
+
+| Principle | Application | Red Flags |
+|-----------|-------------|-----------|
+| **SRP** | Each package has one reason to change | Multiple concerns mixed |
+| **OCP** | Extensible for new tree sources | Hardcoded sources, no registry |
+| **LSP** | Subtypes can replace supertypes | Type assertions on interfaces |
+| **ISP** | Minimal, focused public APIs | Large interfaces with many methods |
+| **DIP** | Depends on abstractions, not concretions | Direct dependencies on implementations |
+
+## Common Issues
+
+### Issue: Missing Input Validation
+
+```go
+// ❌ BAD
+sig, _ := msg["signature"].(map[string]interface{})
+root := buildTree(sig)  // Could fail silently
+
+// ✅ GOOD
+sig, ok := msg["signature"].(map[string]interface{})
+if !ok || len(sig) == 0 {
+    return fmt.Errorf("signature must be non-empty map")
+}
+```
+
+**Flag:** Any user-provided data (JSON, GraphQL, files) processed without validation.
+
+### Issue: Non-Atomic I/O Operations
+
+```go
+// ❌ BAD: Multiple writes (partial write risk)
+w.Write(jsonBytes)
+w.WriteByte('\n')
+w.Flush()
+
+// ✅ GOOD: Atomic frame
+frame := append(jsonBytes, '\n')
+w.Write(frame)
+w.Flush()
+```
+
+**Flag:** Network I/O in protocol handlers, especially line-delimited JSON.
+
+### Issue: Missing Mutual Exclusivity Checks
+
+```go
+// ❌ BAD: Could specify both flags
+if *vdmDir != "" { vdmloader.LoadDir(*vdmDir) }
+if *himFile != "" { loadHIM(*himFile) }
+
+// ✅ GOOD: Validates exclusivity
+if *vdmDir != "" && *himFile != "" {
+    return fmt.Errorf("--vdm and --him are mutually exclusive")
+}
+```
+
+**Flag:** Multiple configuration options that could conflict.
+
+### Issue: Tree Building Code Duplication (Preventive)
+
+Currently tree building is in 2 places: `serviceReg.go` and `vdmloader.go`.  
+**Do NOT flag** unless a **third** tree source appears — then extract shared logic.
+
+## Configuration Management
+
+### Flag Validation
+
+```go
+// ✅ GOOD: Explicit mutual exclusivity at startup
+if *vdmDir != "" && *himFile != "" {
+    utils.Error.Printf("fatal: --vdm and --him are mutually exclusive")
+    os.Exit(1)
+}
+```
+
+**Review checklist:**
+- ✅ Mutually exclusive flags validated early
+- ✅ Required flags checked (not just defaulted to empty)
+- ✅ Flag names follow conventions (`--vdm`, `--web-addr`)
+- ✅ Help strings explain mutual exclusivity
+
+### Timeout & Interval Values
+
+```go
+// ✅ GOOD: Exported, overridable in tests
+var HeartbeatInterval = 15 * time.Second
+var HeartbeatTimeout  =  5 * time.Second
+```
+
+**Review checklist:**
+- ✅ Timeout variables exported (not hardcoded)
+- ✅ Default values reasonable for production
+- ✅ Documented with comments explaining purpose
+
+## Error Handling & Recovery
+
+### Graceful Degradation
+
+```go
+// ✅ GOOD: Optional component failure is non-fatal
+if *webAddr != "" {
+    if err := webdash.Start(*webAddr); err != nil {
+        utils.Error.Printf("webdash: failed to start: %v", err)
+        // Do NOT os.Exit(1) — server continues
+    }
+}
+
+// ❌ BAD: Optional component kills server
+if err := webdash.Start(*webAddr); err != nil {
+    log.Fatalf("webdash: %v", err)
+}
+```
+
+**Mandatory components** (fatal on failure): transport managers, atServer  
+**Optional components** (log + continue): webdash, serviceReg TLS, vdminfo CLI
+
+### Error Response Format
+
+VISS responses use standard error objects:
+
+```json
+{
+  "error": {
+    "number": "404",
+    "reason": "unavailable_data",
+    "description": "The requested data was not found."
+  }
+}
+```
+
+**Review checklist:**
+- ✅ Errors use `number` + `reason` + `description` format
+- ✅ `reason` is machine-readable (snake_case)
+- ✅ `description` is human-readable
+- ✅ Internal paths/types not leaked
+
+## Logging Standards
+
+| Level | Usage |
+|-------|-------|
+| `utils.Error` | Unexpected failures requiring attention |
+| `utils.Info` | Normal lifecycle events |
+| `utils.Warning` | Degraded but functional |
+
+**Review checklist:**
+- ✅ `utils.Error` not used for expected cases
+- ✅ `utils.Info` used for service lifecycle
+- ✅ No sensitive data (tokens, secrets) logged
+- ✅ Log messages include relevant context
+- ❌ Red flag: `fmt.Println` used instead of `utils.Info/Error`
+
+## VDM / GraphQL SDL
+
+### Directive Correctness
+
+**Review checklist:**
+- ✅ `@vspec(element: BRANCH|SENSOR|ACTUATOR|ATTRIBUTE)` on all types/fields
+- ✅ `@vspec(fqn: "Dot.Separated.Path")` matches expected signal path
+- ✅ `@range(min:, max:)` values numerically valid (min ≤ max)
+- ✅ `@unit(value: ...)` uses correct VSS unit strings
+- ✅ `@defaultValue(value: ...)` valid for field type
+
+### Instance Tag Expansion
+
+**Review checklist:**
+- ✅ Types named `*_InstanceTag` have `@instanceTag` directive
+- ✅ Each dimension is an enum with `@vspec(originalName: ...)` on values
+- ✅ Expanded paths are unique (no collisions)
+- ✅ Deep clone of signal subtree correct (test: leaf nodes × instance count)
+
+## DRY (Don't Repeat Yourself)
+
+**Pattern to watch:**
+- Tree building logic in multiple packages → extract
+- Configuration parsing in multiple places → centralize
+- Error handling patterns → use helpers
+
+## Concurrency & Synchronization
+
+### Mutex vs Channel
+
+Use **mutex** for shared state (maps, slices). Use **channels** for event signaling/fan-out.
+
+```go
+// Mutex: protect shared state
+var regMu sync.Mutex
+var registrations = map[string]*serviceConn{}
+
+regMu.Lock()
+registrations[path] = sc
+regMu.Unlock()
+
+// Channel: communicate between goroutines
+backendChans []chan map[string]interface{}
+```
+
+**Review checklist:**
+- Use `sync.Mutex` for maps/slices shared across goroutines
+- Use channels for event fan-out (e.g., `backendChans`)
+- Lock held for minimum duration (no I/O inside lock)
+- Red flag: `map` accessed without mutex from concurrent goroutines
+- Red flag: mutex held across network calls
+
+### Goroutine Lifecycle
+
+Every goroutine must have a known exit condition:
+
+```go
+// GOOD: Exits when connection closes
+func startHeartbeat(sc *serviceConn) {
+    for {
+        time.Sleep(HeartbeatInterval)
+        if err := sc.sendJSON(ping); err != nil {
+            return  // connection gone — goroutine exits
+        }
+    }
+}
+
+// GOOD: Respects context cancellation
+func (m *Manager) run(ctx context.Context) {
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case msg := <-m.events:
+            m.process(msg)
+        }
+    }
+}
+```
+
+**Review checklist:**
+- Every goroutine has a known exit condition
+- Long-running goroutines respect `context.Context` or `done` chan
+- Red flag: `go func() { for { ... } }()` with no exit

--- a/.copilot/guides/generic/CHECKLIST.md
+++ b/.copilot/guides/generic/CHECKLIST.md
@@ -10,6 +10,7 @@ Checklist for reviewing pull requests to the VISSR repository.
 - [ ] SOLID principles respected
 - [ ] `--vdm` / `--him` mutual exclusivity preserved
 - [ ] Correct package structure (vdmloader, webdash, vissServiceMgr, etc.)
+- [ ] Public API changes are backward-compatible (or breaking change justified)
 
 ## Security
 - [ ] No hardcoded secrets, tokens, or credentials
@@ -57,7 +58,7 @@ Checklist for reviewing pull requests to the VISSR repository.
 
 ## PR & Repo Hygiene
 - [ ] PR has single concern (not mixing features, fixes, refactors)
-- [ ] PR size reasonable (< 500 lines, excluding testdata/generated)
+- [ ] PR size reasonable (excluding testdata/generated)
 - [ ] No dead code, commented-out blocks, or orphaned files
 - [ ] No stale dependencies or unused imports
 - [ ] Branch name follows convention (`feat/`, `fix/`, `chore/`)
@@ -66,7 +67,6 @@ Checklist for reviewing pull requests to the VISSR repository.
 ## Documentation
 - [ ] Package comment on all new packages
 - [ ] Doc comment on all exported functions
-- [ ] Commit messages follow `type(scope): description` convention
 
 ## Error Handling
 - [ ] Optional components (webdash, serviceReg TLS) fail gracefully

--- a/.copilot/guides/generic/CHECKLIST.md
+++ b/.copilot/guides/generic/CHECKLIST.md
@@ -55,6 +55,14 @@ Checklist for reviewing pull requests to the VISSR repository.
 - [ ] Indirect deps reviewed for supply chain risk
 - [ ] No unnecessary new dependencies (stdlib alternative exists?)
 
+## PR & Repo Hygiene
+- [ ] PR has single concern (not mixing features, fixes, refactors)
+- [ ] PR size reasonable (< 500 lines, excluding testdata/generated)
+- [ ] No dead code, commented-out blocks, or orphaned files
+- [ ] No stale dependencies or unused imports
+- [ ] Branch name follows convention (`feat/`, `fix/`, `chore/`)
+- [ ] Commit messages follow `type(scope): description`
+
 ## Documentation
 - [ ] Package comment on all new packages
 - [ ] Doc comment on all exported functions

--- a/.copilot/guides/generic/CHECKLIST.md
+++ b/.copilot/guides/generic/CHECKLIST.md
@@ -1,0 +1,74 @@
+# VISSR PR Review Checklist
+
+Checklist for reviewing pull requests to the VISSR repository.
+
+## Architecture & Design
+- [ ] Single responsibility per package
+- [ ] Minimal public API surface (< 5 exported symbols per new package)
+- [ ] Follows Registry pattern (`RegisterServiceTree`) if providing trees
+- [ ] No code duplication (flag if 3rd tree source introduces same logic)
+- [ ] SOLID principles respected
+- [ ] `--vdm` / `--him` mutual exclusivity preserved
+- [ ] Correct package structure (vdmloader, webdash, vissServiceMgr, etc.)
+
+## Security
+- [ ] No hardcoded secrets, tokens, or credentials
+- [ ] Secrets accessed via env vars only
+- [ ] TLS not weakened (no InsecureSkipVerify, minVersion ≥ TLS 1.2)
+- [ ] Auth tokens forwarded, not validated server-side
+- [ ] No sensitive data in logs
+- [ ] No `.env`, `.key`, or `.pem` files committed
+
+## Concurrency
+- [ ] Shared maps/slices protected by mutex
+- [ ] No I/O inside mutex lock
+- [ ] All goroutines have exit conditions
+- [ ] Passes `go test -race`
+- [ ] No goroutine leaks (confirmed exit paths)
+
+## Testing
+- [ ] All tests pass (`go test -race`)
+- [ ] New public functions have tests
+- [ ] Integration tests use `//go:build` tags
+- [ ] Tests use net.Pipe/fixtures, not live external services
+- [ ] Test overrides of timeout/interval vars use t.Cleanup
+- [ ] No test requires real Redis, MQTT, or external process without build tag
+
+## Code Quality
+- [ ] Input validation for all user-provided data (JSON, GraphQL, flags)
+- [ ] Atomic I/O frames (append newline before single Write)
+- [ ] Proper error handling — no silent drops of errors
+- [ ] Resource cleanup with `defer` on every conn/file open
+- [ ] `utils.Info/Error` used (not `fmt.Println`)
+- [ ] No `//nolint` directives suppressing real safety issues
+
+## VDM / GraphQL (when applicable)
+- [ ] All types have `@vspec(element:, fqn:)` directives
+- [ ] `@range(min:, max:)` values are numerically valid (min ≤ max)
+- [ ] Instance tag types follow `*_InstanceTag` convention
+- [ ] Testdata updated for new directive patterns
+- [ ] `go run ./tools/vdminfo ./testdata/` output reviewed
+
+## Dependencies (when go.mod changes)
+- [ ] New dependencies have compatible licenses (MIT, Apache-2.0, BSD)
+- [ ] Versions pinned (not floating tags)
+- [ ] Indirect deps reviewed for supply chain risk
+- [ ] No unnecessary new dependencies (stdlib alternative exists?)
+
+## Documentation
+- [ ] Package comment on all new packages
+- [ ] Doc comment on all exported functions
+- [ ] Commit messages follow `type(scope): description` convention
+
+## Error Handling
+- [ ] Optional components (webdash, serviceReg TLS) fail gracefully
+- [ ] HeartbeatTimeout < HeartbeatInterval
+- [ ] Errors include human-readable description + machine reason code
+- [ ] Service disconnections handled (invocations marked FAILED)
+- [ ] Server continues on optional component failure
+
+## Summary
+
+**Approve if:** All items checked
+**Request changes if:** Any items flagged
+**Reject if:** Security, test failure, or architectural violation

--- a/.copilot/guides/generic/PROCESS.md
+++ b/.copilot/guides/generic/PROCESS.md
@@ -1,0 +1,198 @@
+# VISSR Repository & PR Process Guide
+
+Repo hygiene, PR practices, release management, and content organization for VISSR.
+
+## PR Practices
+
+### PR Scope & Size
+
+- One concern per PR (don't mix features, fixes, and refactors)
+- Target < 500 lines changed (excluding generated files, testdata)
+- Large changes: split into stacked PRs (A → B → C)
+- PR description must explain: what, why, and how to test
+
+### PR Lifecycle
+
+1. **Draft PR** — WIP, not ready for review (use for early feedback)
+2. **Ready for Review** — All tests pass, description complete
+3. **Approved** — Merge after CI green + 1 approval
+4. **Merged** — Squash-merge to master (clean linear history)
+
+### Labeling
+
+| Label | When |
+|-------|------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `breaking` | Breaks backward compatibility |
+| `docs` | Documentation only |
+| `needs-review` | Awaiting reviewer |
+
+### Commit Hygiene
+
+- Each commit should build and pass tests independently
+- Squash fixup commits before marking ready
+- Commit messages follow `type(scope): description` convention
+- Atomic commits: one logical change per commit
+
+## Branch Management
+
+### Branch Naming
+
+```
+feat/<short-description>       — New feature
+fix/<issue-number>-<desc>      — Bug fix
+chore/<description>            — Maintenance
+docs/<description>             — Documentation
+```
+
+### Merge Strategy
+
+- **Squash merge** to master (default) — clean history
+- **Rebase** for stacked PRs (A → B → C)
+- Never force-push to shared branches
+- Delete branch after merge
+
+### Protected Branch: `master`
+
+- All PRs must pass CI before merge
+- At least 1 approval required
+- No direct commits to master
+
+## File Organization
+
+### Where Things Go
+
+```
+server/vissv2server/           — Server implementation
+├── <package>/                 — One package per concern
+├── <package>/testdata/        — Test fixtures for that package
+├── viss.him                   — HIM forest configuration
+└── forest/                    — Compiled binary trees
+
+utils/                         — Shared utilities (Node_t, crypto, logging)
+client/                        — Client implementations
+spec/                          — Specification documents (HTML, Quickstart.md)
+tools/                         — CLI tools (vdminfo, etc.)
+resources/                     — VSS spec files, Makefile
+.copilot/                      — Copilot skills and guides
+.github/workflows/             — CI/CD pipeline definitions
+```
+
+### Naming Conventions
+
+| Item | Convention | Example |
+|------|-----------|---------|
+| Packages | lowercase, single word | `vdmloader`, `webdash` |
+| Go files | lowercase, underscore | `service_reg.go`, `tree_utils.go` |
+| Test files | `*_test.go` | `vdmloader_test.go` |
+| Testdata | `testdata/` directory | `vdmloader/testdata/vehicle.graphql` |
+| Specs | `VISSv<version>_<topic>` | `VISSv4.0_VDM.html` |
+| Scripts | lowercase, descriptive | `runstack.sh`, `runtest.sh` |
+
+### Stale File Cleanup
+
+Flag in reviews:
+- Dead code (unreachable functions, commented-out blocks)
+- Orphaned test files (tests for deleted code)
+- Unused dependencies in `go.mod`
+- Generated files committed without regeneration instructions
+- Temporary/debug files (`*.log`, `*.tmp`, `*.bak`)
+
+## Release Management
+
+### Versioning
+
+VISSR follows semantic versioning aligned with spec versions:
+- **Major**: VISSv2 → VISSv3 → VISSv4 (breaking protocol changes)
+- **Minor**: New features within a spec version
+- **Patch**: Bug fixes, no new features
+
+### Tagging
+
+```bash
+git tag -a v4.0.0 -m "VISSv4.0: VDM GraphQL SDL support"
+git push origin v4.0.0
+```
+
+### Changelog
+
+- Maintain `CHANGELOG.md` or use GitHub Releases
+- Group by: Added, Changed, Fixed, Removed, Security
+- Reference PR numbers and issue numbers
+
+### Release Checklist
+
+- [ ] All tests pass on master (including smoke)
+- [ ] `go.mod` dependencies are pinned (no floating versions)
+- [ ] Spec docs updated (`spec/VISSv*.html`)
+- [ ] README updated if public API changed
+- [ ] Tag created and pushed
+- [ ] GitHub Release created with changelog
+
+## CI/CD Practices
+
+### Workflow File Review
+
+When reviewing `.github/workflows/` changes:
+- Jobs run only necessary steps (no wasted compute)
+- Secrets accessed via GitHub secrets (not hardcoded)
+- Cache configured for Go modules (`actions/setup-go` with `cache: true`)
+- Timeouts set on all jobs (prevent hanging builds)
+- Build matrix covers target platforms
+
+### Required CI Checks
+
+| Check | Blocks Merge? |
+|-------|--------------|
+| `go build ./...` | Yes |
+| `go vet ./...` | Yes |
+| Unit tests with `-race` | Yes |
+| Smoke test | Yes (when relevant) |
+| Lint (if configured) | Advisory |
+
+## Documentation Standards
+
+### README
+
+- Build/run instructions always current
+- Quick start example works out of the box
+- Links to specs and guides for deeper info
+
+### Code Documentation
+
+- Package comment on every package (first line of any `.go` file)
+- Doc comment on all exported functions, types, constants
+- Non-obvious algorithms get inline comments explaining "why"
+- No commented-out code (use version control instead)
+
+### Spec Documents
+
+- `spec/` contains canonical HTML specs
+- Quickstart `.md` files for developer onboarding
+- Keep specs in sync with implementation (flag drift in reviews)
+
+## Dependency Management
+
+### Adding Dependencies
+
+Before adding a new `go.mod` dependency:
+1. Check if stdlib has an alternative
+2. Verify license compatibility (MIT, Apache-2.0, BSD preferred)
+3. Check maintenance status (last commit, open issues)
+4. Pin to specific version (not `latest`)
+5. Run `go mod tidy` to clean up
+
+### Updating Dependencies
+
+- Update regularly (security patches)
+- One dependency update per PR (easy to revert)
+- Run full test suite after updates
+- Check for breaking changes in changelogs
+
+### Red Flags
+
+- Dependency with no commits in 2+ years
+- License change in new version
+- Dependency that pulls in 50+ transitive deps
+- `replace` directives pointing to local paths (test only)

--- a/.copilot/guides/generic/PROCESS.md
+++ b/.copilot/guides/generic/PROCESS.md
@@ -7,26 +7,9 @@ Repo hygiene, PR practices, release management, and content organization for VIS
 ### PR Scope & Size
 
 - One concern per PR (don't mix features, fixes, and refactors)
-- Target < 500 lines changed (excluding generated files, testdata)
+- Target reasonable lines changed (excluding generated files, testdata)
 - Large changes: split into stacked PRs (A → B → C)
 - PR description must explain: what, why, and how to test
-
-### PR Lifecycle
-
-1. **Draft PR** — WIP, not ready for review (use for early feedback)
-2. **Ready for Review** — All tests pass, description complete
-3. **Approved** — Merge after CI green + 1 approval
-4. **Merged** — Squash-merge to master (clean linear history)
-
-### Labeling
-
-| Label | When |
-|-------|------|
-| `feat` | New feature |
-| `fix` | Bug fix |
-| `breaking` | Breaks backward compatibility |
-| `docs` | Documentation only |
-| `needs-review` | Awaiting reviewer |
 
 ### Commit Hygiene
 
@@ -52,12 +35,6 @@ docs/<description>             — Documentation
 - **Rebase** for stacked PRs (A → B → C)
 - Never force-push to shared branches
 - Delete branch after merge
-
-### Protected Branch: `master`
-
-- All PRs must pass CI before merge
-- At least 1 approval required
-- No direct commits to master
 
 ## File Organization
 
@@ -99,37 +76,6 @@ Flag in reviews:
 - Generated files committed without regeneration instructions
 - Temporary/debug files (`*.log`, `*.tmp`, `*.bak`)
 
-## Release Management
-
-### Versioning
-
-VISSR follows semantic versioning aligned with spec versions:
-- **Major**: VISSv2 → VISSv3 → VISSv4 (breaking protocol changes)
-- **Minor**: New features within a spec version
-- **Patch**: Bug fixes, no new features
-
-### Tagging
-
-```bash
-git tag -a v4.0.0 -m "VISSv4.0: VDM GraphQL SDL support"
-git push origin v4.0.0
-```
-
-### Changelog
-
-- Maintain `CHANGELOG.md` or use GitHub Releases
-- Group by: Added, Changed, Fixed, Removed, Security
-- Reference PR numbers and issue numbers
-
-### Release Checklist
-
-- [ ] All tests pass on master (including smoke)
-- [ ] `go.mod` dependencies are pinned (no floating versions)
-- [ ] Spec docs updated (`spec/VISSv*.html`)
-- [ ] README updated if public API changed
-- [ ] Tag created and pushed
-- [ ] GitHub Release created with changelog
-
 ## CI/CD Practices
 
 ### Workflow File Review
@@ -165,12 +111,6 @@ When reviewing `.github/workflows/` changes:
 - Doc comment on all exported functions, types, constants
 - Non-obvious algorithms get inline comments explaining "why"
 - No commented-out code (use version control instead)
-
-### Spec Documents
-
-- `spec/` contains canonical HTML specs
-- Quickstart `.md` files for developer onboarding
-- Keep specs in sync with implementation (flag drift in reviews)
 
 ## Dependency Management
 

--- a/.copilot/guides/generic/PROCESS.md
+++ b/.copilot/guides/generic/PROCESS.md
@@ -8,7 +8,7 @@ Repo hygiene, PR practices, release management, and content organization for VIS
 
 - One concern per PR (don't mix features, fixes, and refactors)
 - Target reasonable lines changed (excluding generated files, testdata)
-- Large changes: split into stacked PRs (A → B → C)
+- Large changes: split into stacked PRs (A then B then C)
 - PR description must explain: what, why, and how to test
 
 ### Commit Hygiene
@@ -32,7 +32,7 @@ docs/<description>             — Documentation
 ### Merge Strategy
 
 - **Squash merge** to master (default) — clean history
-- **Rebase** for stacked PRs (A → B → C)
+- **Rebase** for stacked PRs (A then B then C)
 - Never force-push to shared branches
 - Delete branch after merge
 

--- a/.copilot/guides/generic/REFERENCE.md
+++ b/.copilot/guides/generic/REFERENCE.md
@@ -92,26 +92,26 @@ For input validation, atomic I/O, and error handling patterns, see [ARCHITECTURE
 
 ### Environment Variable Secrets
 ```go
-// ✅ GOOD: Load from env var
+// GOOD: Load from env var
 secret := os.Getenv("VISSR_AT_SECRET")
 if secret == "" {
     utils.Warning.Printf("VISSR_AT_SECRET not set; using ephemeral key")
     secret = generateEphemeralKey()
 }
 
-// ❌ BAD: Hardcoded
+// BAD: Hardcoded
 const secret = "super-secret-12345"
 ```
 
 ### Logging Patterns
 ```go
-// ✅ GOOD: Structured, contextual
+// GOOD: Structured, contextual
 utils.Info.Printf("Service registered: path=%s domain=%s", path, domain)
 utils.Error.Printf("Connection failed: %v", err)
 
-// ❌ BAD: Too verbose or leaks secrets
-utils.Info.Printf("Connecting with token: %s", token)  // ← LEAK!
-fmt.Println("Service started")  // ← Should use utils.Info
+// BAD: Too verbose or leaks secrets
+utils.Info.Printf("Connecting with token: %s", token)  // LEAK!
+fmt.Println("Service started")  // Should use utils.Info
 ```
 
 ## Commit Message Examples

--- a/.copilot/guides/generic/REFERENCE.md
+++ b/.copilot/guides/generic/REFERENCE.md
@@ -1,0 +1,182 @@
+# VISSR Reference & Examples
+
+Quick reference for commands, code patterns, useful examples, and resources.
+
+## Quick Commands
+
+### Verification
+```bash
+# Quick check
+go build ./...
+go vet ./...
+
+# All unit tests (excludes paho-mqtt + smoketest)
+go list ./... | grep -v 'paho-mqtt' | grep -v 'smoketest' | xargs go test -race -count=1 -timeout 5m
+
+# Specific package
+go test -race ./server/vissv2server/...
+```
+
+### Smoke & Integration Tests
+```bash
+# End-to-end WebSocket test
+mkdir -p /var/tmp/vissv2
+go test -v -tags smoke -timeout 120s ./server/vissv2server/smoketest/
+
+# VDM loader validation
+go run ./tools/vdminfo ./server/vissv2server/vdmloader/testdata/
+```
+
+### Local Development
+```bash
+# MQTT broker (local testing)
+docker compose -f docker-compose.test.yml up -d
+docker compose -f docker-compose.test.yml ps
+
+# Server startup
+go build -o /tmp/vissv2server ./server/vissv2server/
+/tmp/vissv2server --vdm ./server/vissv2server/vdmloader/testdata/
+
+# Connect WebSocket client
+curl http://localhost:8200
+```
+
+### Scanning & Analysis
+```bash
+# Code coverage
+go test -cover ./...
+
+# Scan for common issues
+go vet ./...
+staticcheck ./... 2>/dev/null || true
+
+# Scan for secrets in diff
+git diff | grep -iE 'secret|apikey|password|token\s*=|insecureskipverify'
+```
+
+## Code Patterns
+
+### Registry Pattern (All Tree Sources)
+```go
+// Providing a tree? Register it.
+import "github.com/covesa/vissr/utils"
+
+func (m *VDMManager) Start() error {
+    trees, err := vdmloader.LoadDir(vdmPath)
+    if err != nil {
+        return err
+    }
+    
+    for name, root := range trees {
+        domain := "Vehicle.VDM.Service"
+        version := "1.0"
+        utils.RegisterServiceTree(name, domain, version, root)
+        
+        // On shutdown:
+        defer utils.DeregisterServiceTree(name)
+    }
+    
+    return nil
+}
+```
+
+### Mutex Protection (Shared State)
+
+See [ARCHITECTURE.md](ARCHITECTURE.md#concurrency--synchronization) for full concurrency patterns.
+
+### Goroutine Lifecycle
+
+See [ARCHITECTURE.md](ARCHITECTURE.md#goroutine-lifecycle) for goroutine exit patterns.
+
+For input validation, atomic I/O, and error handling patterns, see [ARCHITECTURE.md](ARCHITECTURE.md#common-issues).
+
+### Environment Variable Secrets
+```go
+// ✅ GOOD: Load from env var
+secret := os.Getenv("VISSR_AT_SECRET")
+if secret == "" {
+    utils.Warning.Printf("VISSR_AT_SECRET not set; using ephemeral key")
+    secret = generateEphemeralKey()
+}
+
+// ❌ BAD: Hardcoded
+const secret = "super-secret-12345"
+```
+
+### Logging Patterns
+```go
+// ✅ GOOD: Structured, contextual
+utils.Info.Printf("Service registered: path=%s domain=%s", path, domain)
+utils.Error.Printf("Connection failed: %v", err)
+
+// ❌ BAD: Too verbose or leaks secrets
+utils.Info.Printf("Connecting with token: %s", token)  // ← LEAK!
+fmt.Println("Service started")  // ← Should use utils.Info
+```
+
+## Commit Message Examples
+
+### Feature
+```
+feat(vdmloader): add support for @unit directive parsing
+
+Adds parsing of @unit(value: "km/h") annotations on leaf nodes,
+mapping to Node_t unit metadata. Integrates with treeutils.NewSignalNode.
+
+Closes #42
+```
+
+### Bug Fix
+```
+fix(serviceReg): validate signature before building tree
+
+Service registration now validates that signature maps are non-empty
+before constructing procedure trees. Prevents silent creation of
+unreachable services with no input/output parameters.
+
+Closes #84
+```
+
+### Test
+```
+test(vdmloader): add instance tag expansion test cases
+
+Adds comprehensive tests for multi-dimensional instance tag expansion
+(Seat: Row × Side) and single-dimension cases (Door: Row).
+Validates path generation and leaf node cloning.
+```
+
+### Refactor
+```
+refactor(common): extract tree building validation
+
+Extracts common validation logic from serviceReg and vdmloader
+into a shared utils.ValidateSignature() helper. No behavior change.
+```
+
+## Resource Links
+
+- **Specification**: `spec/VISSv4.0_VDM.html`, `spec/VISSv3.3_Service_Quickstart.md`
+- **Service Protocol**: Top of `server/vissv2server/vissServiceMgr/serviceReg.go`
+- **Code Examples**: Merged PRs #157–#159 (service integration patterns)
+- **Testing Guide**: `TESTING.md`
+- **MQTT Setup**: `docker-compose.test.yml`
+- **CI Pipeline**: `.github/workflows/test.yml`
+- **HIM Forest**: `server/vissv2server/viss.him` + `utils/treeutils.go`
+
+## Common Questions
+
+**Q: When should I use mutex vs channel?**  
+A: Use **mutex** for shared state (maps, slices). Use **channel** for signaling/event distribution.
+
+**Q: How do I test goroutines without live services?**  
+A: Use `net.Pipe()` for bidirectional connection tests, or mock interfaces and channels for behavioral tests.
+
+**Q: Can I use `fmt.Println` in my code?**  
+A: No. Use `utils.Info.Printf()` for normal events or `utils.Error.Printf()` for failures.
+
+**Q: What's the difference between `--vdm` and `--him`?**  
+A: `--vdm` loads GraphQL SDL files (VISSv4.0). `--him` uses static HIM forest file. Mutually exclusive.
+
+**Q: Do I need to worry about tree duplication?**  
+A: Not until we have a 3rd tree source (beyond serviceReg + vdmloader). Current status: OK.

--- a/.copilot/guides/generic/SECURITY.md
+++ b/.copilot/guides/generic/SECURITY.md
@@ -1,0 +1,159 @@
+# VISSR Security & Secrets Management Guide
+
+Security best practices, secret management, and authorization patterns for VISSR PRs.
+
+## Environment Variables
+
+VISSR requires these env vars in production. Flag PRs that mishandle them:
+
+| Variable | Purpose | Risk if Missing |
+|----------|---------|----------------|
+| `VISSR_AT_SECRET` | Access token signing key | Ephemeral key (restarts invalidate tokens) |
+| `VISSR_ECF_SECRET` | ECF consent HMAC key | HMAC verification disabled |
+| `VISSR_ECF_CERT_PATH` / `VISSR_ECF_KEY_PATH` | TLS cert for ECF WebSocket | Plaintext connections accepted |
+| `VISSR_ECF_ALLOWED_ORIGIN` | CORS origin allowlist | Any origin accepted |
+
+**Review checklist:**
+- ✅ No hardcoded secrets, tokens, or passwords in code
+- ✅ Secrets accessed only via `os.Getenv()` or config
+- ✅ Warning logs emitted when env vars are unset
+- ✅ Test fixtures use dummy/ephemeral secrets only
+- ✅ Scan diff: `git diff | grep -iE 'secret|apikey|password|token\s*='`
+- ❌ Red flag: any `.env`, `.key`, or `.pem` file committed
+
+## TLS & Transport Security
+
+```go
+// ✅ GOOD: Strict TLS config
+cfg := &tls.Config{
+    Certificates: []tls.Certificate{cert},
+    MinVersion:   tls.VersionTLS12,
+    // InsecureSkipVerify omitted (defaults false)
+}
+
+// ❌ BAD: Disabled verification
+cfg := &tls.Config{InsecureSkipVerify: true}
+```
+
+**Review checklist:**
+- ✅ `StartServiceRegServerTLS` used in production paths (not plain TCP)
+- ✅ Minimum TLS version is 1.2 (`tls.VersionTLS12`)
+- ✅ Certificate validation not disabled (`InsecureSkipVerify: false`)
+- ✅ Cipher suite restrictions appropriate for use case
+
+## Authorization in Service Invocations
+
+```go
+// ✅ GOOD: Auth token forwarded, service decides
+msg := map[string]interface{}{
+    "action":        "invoke",
+    "sessionId":     serviceId,
+    "input":         input,
+    "authorization": authToken, // ← forwarded, not validated server-side
+}
+```
+
+**Review checklist:**
+- ✅ `authorization` token forwarded from client to service
+- ✅ Service can reject unauthorized invocations
+- ✅ Error messages don't expose internal paths or system state
+- ✅ JWT/token contents not logged at info level
+
+## Common Security Violations to Flag
+
+### Hardcoded Secrets
+```go
+// ❌ NEVER DO THIS
+const SecretKey = "my-super-secret-key-12345"
+password := "admin123"
+apiToken := "ghp_xxxxxxxxxxxxxxxxxxxx"
+```
+
+**Fix:** Move to environment variables:
+```go
+secretKey := os.Getenv("VISSR_AT_SECRET")
+if secretKey == "" {
+    utils.Warning.Printf("VISSR_AT_SECRET not set; using ephemeral key")
+    // generate ephemeral key for tests only
+}
+```
+
+### Disabled TLS Verification
+```go
+// ❌ NEVER DO THIS
+cfg := &tls.Config{InsecureSkipVerify: true}
+```
+
+**Impact:** Man-in-the-middle attacks possible. Always validate certificates.
+
+### Logging Secrets
+```go
+// ❌ NEVER DO THIS
+token := os.Getenv("AUTH_TOKEN")
+utils.Info.Printf("Connecting with token: %s", token)  // ← LEAKED
+
+// ✅ GOOD: Log without sensitive data
+utils.Info.Printf("Connecting to service")  // ← Safe
+```
+
+**Rule:** Never log tokens, keys, passwords, or full request bodies at any log level.
+
+### Exposed Error Details
+```go
+// ❌ BAD: Exposes internal paths
+return fmt.Errorf("config file not found at /etc/vissr/secret.key")
+
+// ✅ GOOD: Generic error
+return fmt.Errorf("configuration error")
+```
+
+**Impact:** Don't leak filesystem paths, internal IPs, or system state in error messages to clients.
+
+## Service Connection Security
+
+For heartbeat/health protocol patterns and timeout configuration, see [ARCHITECTURE.md](ARCHITECTURE.md#timeout--interval-values).
+
+**Key security checks:**
+- Missed heartbeat pong closes connection (triggers deregister)
+- Connection loss detected in finite time (no indefinite waits)
+- All ONGOING invocations marked FAILED on disconnect
+- Service path deregistered from HIM forest on disconnect
+
+## Secrets Scanning
+
+Before committing, scan for secrets:
+
+```bash
+# Scan diff for common patterns
+git diff | grep -iE 'secret|apikey|password|token\s*=|insecureskipverify'
+
+# Scan staged files
+git diff --cached | grep -iE 'secret|apikey|password|token\s*='
+```
+
+**Red flags to block:**
+- `SECRET = "..."`
+- `PASSWORD: "..."`
+- `API_KEY = "..."`
+- `InsecureSkipVerify: true`
+- `.env` files
+- `.key` or `.pem` files
+- Private key contents
+
+## Test Fixtures & Dummy Secrets
+
+For tests, use ephemeral/dummy values only:
+
+```go
+// ✅ GOOD: Test-only dummy secret
+const testSecret = "dummy-test-key-do-not-use"
+
+// ✅ GOOD: Ephemeral key for each test
+func TestWithAuth(t *testing.T) {
+    secret := generateEphemeralKey()  // New key per test
+    defer func() { secret = nil }()   // Cleanup
+    // ... test code
+}
+```
+
+Never commit real secrets or use production credentials in tests.

--- a/.copilot/guides/generic/SECURITY.md
+++ b/.copilot/guides/generic/SECURITY.md
@@ -14,56 +14,56 @@ VISSR requires these env vars in production. Flag PRs that mishandle them:
 | `VISSR_ECF_ALLOWED_ORIGIN` | CORS origin allowlist | Any origin accepted |
 
 **Review checklist:**
-- ✅ No hardcoded secrets, tokens, or passwords in code
-- ✅ Secrets accessed only via `os.Getenv()` or config
-- ✅ Warning logs emitted when env vars are unset
-- ✅ Test fixtures use dummy/ephemeral secrets only
-- ✅ Scan diff: `git diff | grep -iE 'secret|apikey|password|token\s*='`
-- ❌ Red flag: any `.env`, `.key`, or `.pem` file committed
+- No hardcoded secrets, tokens, or passwords in code
+- Secrets accessed only via `os.Getenv()` or config
+- Warning logs emitted when env vars are unset
+- Test fixtures use dummy/ephemeral secrets only
+- Scan diff: `git diff | grep -iE 'secret|apikey|password|token\s*='`
+- Red flag: any `.env`, `.key`, or `.pem` file committed
 
 ## TLS & Transport Security
 
 ```go
-// ✅ GOOD: Strict TLS config
+// GOOD: Strict TLS config
 cfg := &tls.Config{
     Certificates: []tls.Certificate{cert},
     MinVersion:   tls.VersionTLS12,
     // InsecureSkipVerify omitted (defaults false)
 }
 
-// ❌ BAD: Disabled verification
+// BAD: Disabled verification
 cfg := &tls.Config{InsecureSkipVerify: true}
 ```
 
 **Review checklist:**
-- ✅ `StartServiceRegServerTLS` used in production paths (not plain TCP)
-- ✅ Minimum TLS version is 1.2 (`tls.VersionTLS12`)
-- ✅ Certificate validation not disabled (`InsecureSkipVerify: false`)
-- ✅ Cipher suite restrictions appropriate for use case
+- `StartServiceRegServerTLS` used in production paths (not plain TCP)
+- Minimum TLS version is 1.2 (`tls.VersionTLS12`)
+- Certificate validation not disabled (`InsecureSkipVerify: false`)
+- Cipher suite restrictions appropriate for use case
 
 ## Authorization in Service Invocations
 
 ```go
-// ✅ GOOD: Auth token forwarded, service decides
+// GOOD: Auth token forwarded, service decides
 msg := map[string]interface{}{
     "action":        "invoke",
     "sessionId":     serviceId,
     "input":         input,
-    "authorization": authToken, // ← forwarded, not validated server-side
+    "authorization": authToken, // forwarded, not validated server-side
 }
 ```
 
 **Review checklist:**
-- ✅ `authorization` token forwarded from client to service
-- ✅ Service can reject unauthorized invocations
-- ✅ Error messages don't expose internal paths or system state
-- ✅ JWT/token contents not logged at info level
+- `authorization` token forwarded from client to service
+- Service can reject unauthorized invocations
+- Error messages don't expose internal paths or system state
+- JWT/token contents not logged at info level
 
 ## Common Security Violations to Flag
 
 ### Hardcoded Secrets
 ```go
-// ❌ NEVER DO THIS
+// NEVER DO THIS
 const SecretKey = "my-super-secret-key-12345"
 password := "admin123"
 apiToken := "ghp_xxxxxxxxxxxxxxxxxxxx"
@@ -80,7 +80,7 @@ if secretKey == "" {
 
 ### Disabled TLS Verification
 ```go
-// ❌ NEVER DO THIS
+// NEVER DO THIS
 cfg := &tls.Config{InsecureSkipVerify: true}
 ```
 
@@ -88,22 +88,22 @@ cfg := &tls.Config{InsecureSkipVerify: true}
 
 ### Logging Secrets
 ```go
-// ❌ NEVER DO THIS
+// NEVER DO THIS
 token := os.Getenv("AUTH_TOKEN")
-utils.Info.Printf("Connecting with token: %s", token)  // ← LEAKED
+utils.Info.Printf("Connecting with token: %s", token)  // LEAKED
 
-// ✅ GOOD: Log without sensitive data
-utils.Info.Printf("Connecting to service")  // ← Safe
+// GOOD: Log without sensitive data
+utils.Info.Printf("Connecting to service")  // Safe
 ```
 
 **Rule:** Never log tokens, keys, passwords, or full request bodies at any log level.
 
 ### Exposed Error Details
 ```go
-// ❌ BAD: Exposes internal paths
+// BAD: Exposes internal paths
 return fmt.Errorf("config file not found at /etc/vissr/secret.key")
 
-// ✅ GOOD: Generic error
+// GOOD: Generic error
 return fmt.Errorf("configuration error")
 ```
 
@@ -124,10 +124,10 @@ For heartbeat/health protocol patterns and timeout configuration, see [ARCHITECT
 File-loading flags (`--vdm`, `--him`) accept user-supplied paths.
 
 ```go
-// ❌ BAD: No validation — can escape intended directory
+// BAD: No validation — can escape intended directory
 root := vdmloader.LoadDir(userSuppliedPath)
 
-// ✅ GOOD: Resolve and verify path stays within allowed base
+// GOOD: Resolve and verify path stays within allowed base
 absPath, _ := filepath.Abs(userSuppliedPath)
 if !strings.HasPrefix(absPath, allowedBase) {
     return fmt.Errorf("path %q escapes allowed directory", userSuppliedPath)
@@ -135,28 +135,28 @@ if !strings.HasPrefix(absPath, allowedBase) {
 ```
 
 **Review checklist:**
-- ✅ File paths cleaned with `filepath.Clean` / `filepath.Abs`
-- ✅ Resolved path checked against allowed base directory
-- ✅ Symlinks resolved before check (`filepath.EvalSymlinks`)
-- ❌ Red flag: user-supplied path used directly in `os.Open` or `os.ReadDir`
+- File paths cleaned with `filepath.Clean` / `filepath.Abs`
+- Resolved path checked against allowed base directory
+- Symlinks resolved before check (`filepath.EvalSymlinks`)
+- Red flag: user-supplied path used directly in `os.Open` or `os.ReadDir`
 
 ## Input Size Limits
 
 Unbounded reads enable denial-of-service.
 
 ```go
-// ❌ BAD: Unlimited read
+// BAD: Unlimited read
 body, _ := io.ReadAll(r.Body)
 
-// ✅ GOOD: Bounded read
+// GOOD: Bounded read
 body, _ := io.ReadAll(io.LimitReader(r.Body, maxBodySize))
 ```
 
 **Review checklist:**
-- ✅ HTTP/WebSocket payloads bounded (`io.LimitReader`, `MaxBytesReader`)
-- ✅ GraphQL SDL files checked for size before parsing
-- ✅ Recursive structures (instance tag expansion) bounded by depth/count limit
-- ❌ Red flag: `io.ReadAll` without size cap on network input
+- HTTP/WebSocket payloads bounded (`io.LimitReader`, `MaxBytesReader`)
+- GraphQL SDL files checked for size before parsing
+- Recursive structures (instance tag expansion) bounded by depth/count limit
+- Red flag: `io.ReadAll` without size cap on network input
 
 ## Secrets Scanning
 
@@ -184,10 +184,10 @@ git diff --cached | grep -iE 'secret|apikey|password|token\s*='
 For tests, use ephemeral/dummy values only:
 
 ```go
-// ✅ GOOD: Test-only dummy secret
+// GOOD: Test-only dummy secret
 const testSecret = "dummy-test-key-do-not-use"
 
-// ✅ GOOD: Ephemeral key for each test
+// GOOD: Ephemeral key for each test
 func TestWithAuth(t *testing.T) {
     secret := generateEphemeralKey()  // New key per test
     defer func() { secret = nil }()   // Cleanup

--- a/.copilot/guides/generic/SECURITY.md
+++ b/.copilot/guides/generic/SECURITY.md
@@ -119,6 +119,45 @@ For heartbeat/health protocol patterns and timeout configuration, see [ARCHITECT
 - All ONGOING invocations marked FAILED on disconnect
 - Service path deregistered from HIM forest on disconnect
 
+## Path Traversal
+
+File-loading flags (`--vdm`, `--him`) accept user-supplied paths.
+
+```go
+// ❌ BAD: No validation — can escape intended directory
+root := vdmloader.LoadDir(userSuppliedPath)
+
+// ✅ GOOD: Resolve and verify path stays within allowed base
+absPath, _ := filepath.Abs(userSuppliedPath)
+if !strings.HasPrefix(absPath, allowedBase) {
+    return fmt.Errorf("path %q escapes allowed directory", userSuppliedPath)
+}
+```
+
+**Review checklist:**
+- ✅ File paths cleaned with `filepath.Clean` / `filepath.Abs`
+- ✅ Resolved path checked against allowed base directory
+- ✅ Symlinks resolved before check (`filepath.EvalSymlinks`)
+- ❌ Red flag: user-supplied path used directly in `os.Open` or `os.ReadDir`
+
+## Input Size Limits
+
+Unbounded reads enable denial-of-service.
+
+```go
+// ❌ BAD: Unlimited read
+body, _ := io.ReadAll(r.Body)
+
+// ✅ GOOD: Bounded read
+body, _ := io.ReadAll(io.LimitReader(r.Body, maxBodySize))
+```
+
+**Review checklist:**
+- ✅ HTTP/WebSocket payloads bounded (`io.LimitReader`, `MaxBytesReader`)
+- ✅ GraphQL SDL files checked for size before parsing
+- ✅ Recursive structures (instance tag expansion) bounded by depth/count limit
+- ❌ Red flag: `io.ReadAll` without size cap on network input
+
 ## Secrets Scanning
 
 Before committing, scan for secrets:

--- a/.copilot/guides/generic/TESTING.md
+++ b/.copilot/guides/generic/TESTING.md
@@ -1,0 +1,188 @@
+# VISSR Testing Requirements Guide
+
+Mandatory tests, conditional tests, and testing best practices for VISSR PRs.
+
+## Mandatory Tests
+
+Every PR must pass:
+
+### 1. Build Check
+```bash
+go build ./...
+```
+- ✅ Compile all packages successfully
+- ✅ No missing imports or syntax errors
+
+### 2. Vet Check
+```bash
+go vet ./...
+```
+- ✅ No obvious bugs or type errors
+- ✅ No unused variables or imports
+- ✅ Correct format strings
+
+### 3. Unit Tests with Race Detector
+```bash
+go list ./... | grep -v 'paho-mqtt' | grep -v 'smoketest' | xargs go test -race -count=1 -timeout 5m
+```
+- ✅ All tests pass
+- ✅ **No race detector warnings**
+- ✅ Race detector is non-optional
+
+## Conditional Tests (Run When Relevant)
+
+### Smoke Test
+
+**Run when:** PRs touching server startup, WebSocket, or serviceReg  
+**Command:**
+```bash
+mkdir -p /var/tmp/vissv2
+go test -v -tags smoke -timeout 120s ./server/vissv2server/smoketest/
+```
+
+**Verifies:** End-to-end WebSocket communication without external services
+
+### VDM Loader Validation
+
+**Run when:** PRs touching `vdmloader/` or `.graphql` files  
+**Command:**
+```bash
+go run ./tools/vdminfo ./server/vissv2server/vdmloader/testdata/
+```
+
+**Verifies:** GraphQL SDL parsing, instance tag expansion, tree structure
+
+### MQTT Tests
+
+**Run when:** PRs touching `paho-mqtt` or `mqttMgr`  
+**Command:**
+```bash
+docker compose -f docker-compose.test.yml up -d
+go test -race -count=1 ./paho-mqtt/...
+docker compose -f docker-compose.test.yml down
+```
+
+**Verifies:** MQTT integration with live Mosquitto broker
+
+## Race Detector
+
+All tests **must** pass `-race`. When a race is reported:
+
+1. **Identify** the unsynchronized map/slice/variable
+2. **Protect** reads AND writes with the same mutex
+3. **Verify** the fix doesn't introduce deadlocks
+4. Never use `go test -race` as optional
+
+```bash
+# If race detected, investigate with verbose output
+go test -race -v -run TestName ./package/
+```
+
+## Testing Best Practices
+
+### Use Fixtures, Not Live Services
+
+```go
+// ✅ GOOD: net.Pipe for isolated tests
+client, server := net.Pipe()
+go handleConnection(server)
+// ... test client behavior
+
+// ❌ BAD: Requires live external service
+conn, err := net.Dial("tcp", "localhost:8300")  // ← What if port taken?
+```
+
+### Isolation with //go:build Tags
+
+```go
+//go:build smoke
+
+package smoketest
+
+// This test only runs with: go test -tags smoke
+// Excluded from standard test suite: go test ./...
+```
+
+**Review checklist:**
+- ✅ Integration tests use `//go:build` tags
+- ✅ Smoke tests don't run in CI by default
+- ✅ Standard `go test ./...` only runs unit tests
+
+### Test-Only Configuration
+
+```go
+// ✅ GOOD: Exported vars allow test overrides
+var HeartbeatInterval = 15 * time.Second
+
+func TestFastHeartbeat(t *testing.T) {
+    oldInterval := HeartbeatInterval
+    HeartbeatInterval = 100 * time.Millisecond
+    t.Cleanup(func() { HeartbeatInterval = oldInterval })
+    
+    // ... test code runs with fast heartbeat
+}
+```
+
+**Review checklist:**
+- ✅ Timeout/interval variables exported (not hardcoded)
+- ✅ Tests override with small values for speed (< 100ms)
+- ✅ `t.Cleanup()` resets after test
+
+### All New Public Functions Have Tests
+
+```go
+// If PR adds this public function:
+func NewService(addr string, path string) (*Service, error)
+
+// There must be tests like:
+func TestNewService_Valid(t *testing.T)
+func TestNewService_InvalidAddr(t *testing.T)
+func TestNewService_InvalidPath(t *testing.T)
+```
+
+### No Real External Dependencies
+
+```go
+// ❌ BAD: Requires real Redis
+func TestCacheWrite(t *testing.T) {
+    client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+    // ... test fails if Redis not running
+}
+
+// ✅ GOOD: Mock or fixture
+func TestCacheWrite(t *testing.T) {
+    cache := &MockCache{}
+    // ... test runs anywhere
+}
+```
+
+**Red flags:**
+- ❌ Tests require real Redis, MQTT, or external process without build tag
+- ❌ Tests hardcode localhost ports
+- ❌ Integration tests in standard test suite (should use `//go:build`)
+
+## Coverage Report
+
+Generate coverage to identify gaps:
+
+```bash
+# Unit test coverage (excludes paho-mqtt, smoketest)
+go list ./... | grep -v 'paho-mqtt' | grep -v 'smoketest' | xargs go test -cover ./
+
+# Full coverage with HTML report
+go test -coverprofile=coverage.out ./... && go tool cover -html=coverage.out
+```
+
+**Goal:** New public functions and critical paths should have test coverage.
+
+## Common Test Issues to Flag
+
+| Issue | Pattern | Fix |
+|-------|---------|-----|
+| **Missing validation** | No error checks in test | Add test cases for error paths |
+| **Hardcoded ports** | `localhost:8300` in tests | Use `net.Pipe()` or `net.Listener` |
+| **Race conditions** | Works locally but fails in CI | Run with `-race` flag |
+| **Flaky tests** | Time-dependent assertions | Use channels or mocks, not `time.Sleep()` |
+| **Incomplete cleanup** | Goroutines left running | Use `t.Cleanup()` or context cancellation |
+
+For all test commands, see [REFERENCE.md](REFERENCE.md#quick-commands).

--- a/.copilot/guides/generic/TESTING.md
+++ b/.copilot/guides/generic/TESTING.md
@@ -10,24 +10,24 @@ Every PR must pass:
 ```bash
 go build ./...
 ```
-- ✅ Compile all packages successfully
-- ✅ No missing imports or syntax errors
+- Compile all packages successfully
+- No missing imports or syntax errors
 
 ### 2. Vet Check
 ```bash
 go vet ./...
 ```
-- ✅ No obvious bugs or type errors
-- ✅ No unused variables or imports
-- ✅ Correct format strings
+- No obvious bugs or type errors
+- No unused variables or imports
+- Correct format strings
 
 ### 3. Unit Tests with Race Detector
 ```bash
 go list ./... | grep -v 'paho-mqtt' | grep -v 'smoketest' | xargs go test -race -count=1 -timeout 5m
 ```
-- ✅ All tests pass
-- ✅ **No race detector warnings**
-- ✅ Race detector is non-optional
+- All tests pass
+- **No race detector warnings**
+- Race detector is non-optional
 
 ## Conditional Tests (Run When Relevant)
 
@@ -83,13 +83,13 @@ go test -race -v -run TestName ./package/
 ### Use Fixtures, Not Live Services
 
 ```go
-// ✅ GOOD: net.Pipe for isolated tests
+// GOOD: net.Pipe for isolated tests
 client, server := net.Pipe()
 go handleConnection(server)
 // ... test client behavior
 
-// ❌ BAD: Requires live external service
-conn, err := net.Dial("tcp", "localhost:8300")  // ← What if port taken?
+// BAD: Requires live external service
+conn, err := net.Dial("tcp", "localhost:8300")  // What if port taken?
 ```
 
 ### Isolation with //go:build Tags
@@ -104,14 +104,14 @@ package smoketest
 ```
 
 **Review checklist:**
-- ✅ Integration tests use `//go:build` tags
-- ✅ Smoke tests don't run in CI by default
-- ✅ Standard `go test ./...` only runs unit tests
+- Integration tests use `//go:build` tags
+- Smoke tests don't run in CI by default
+- Standard `go test ./...` only runs unit tests
 
 ### Test-Only Configuration
 
 ```go
-// ✅ GOOD: Exported vars allow test overrides
+// GOOD: Exported vars allow test overrides
 var HeartbeatInterval = 15 * time.Second
 
 func TestFastHeartbeat(t *testing.T) {
@@ -124,9 +124,9 @@ func TestFastHeartbeat(t *testing.T) {
 ```
 
 **Review checklist:**
-- ✅ Timeout/interval variables exported (not hardcoded)
-- ✅ Tests override with small values for speed (< 100ms)
-- ✅ `t.Cleanup()` resets after test
+- Timeout/interval variables exported (not hardcoded)
+- Tests override with small values for speed (< 100ms)
+- `t.Cleanup()` resets after test
 
 ### All New Public Functions Have Tests
 
@@ -143,13 +143,13 @@ func TestNewService_InvalidPath(t *testing.T)
 ### No Real External Dependencies
 
 ```go
-// ❌ BAD: Requires real Redis
+// BAD: Requires real Redis
 func TestCacheWrite(t *testing.T) {
     client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
     // ... test fails if Redis not running
 }
 
-// ✅ GOOD: Mock or fixture
+// GOOD: Mock or fixture
 func TestCacheWrite(t *testing.T) {
     cache := &MockCache{}
     // ... test runs anywhere
@@ -157,9 +157,9 @@ func TestCacheWrite(t *testing.T) {
 ```
 
 **Red flags:**
-- ❌ Tests require real Redis, MQTT, or external process without build tag
-- ❌ Tests hardcode localhost ports
-- ❌ Integration tests in standard test suite (should use `//go:build`)
+- Tests require real Redis, MQTT, or external process without build tag
+- Tests hardcode localhost ports
+- Integration tests in standard test suite (should use `//go:build`)
 
 ## Coverage Report
 

--- a/.copilot/skills/pr-review/SKILL.md
+++ b/.copilot/skills/pr-review/SKILL.md
@@ -26,6 +26,7 @@ Then follow the **[PR Review Checklist](CHECKLIST.md)** in your review.
 | **[SECURITY.md](../../guides/generic/SECURITY.md)** | Secrets, TLS, authorization | Reviewing security-related changes |
 | **[TESTING.md](../../guides/generic/TESTING.md)** | Test requirements, commands | Verifying test coverage |
 | **[REFERENCE.md](../../guides/generic/REFERENCE.md)** | Useful commands, examples, resources | Quick lookup |
+| **[PROCESS.md](../../guides/generic/PROCESS.md)** | PR practices, repo hygiene, releases | Reviewing PR process or repo changes |
 
 ## Core Principles
 

--- a/.copilot/skills/pr-review/SKILL.md
+++ b/.copilot/skills/pr-review/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: vissr-pr-review
+description: Comprehensive PR review guidelines for VISSR (Vehicle Information and Signals Server). Modular guides covering architecture, security, testing, and best practices for all COVESA/vissr PRs.
+applyTo: "**"
+---
+
+# VISSR Pull Request Review Skill
+
+Modular review guidance for **all pull requests** to the COVESA/vissr repository.
+
+## Quick Start
+
+**Use this skill for any VISSR PR:**
+```
+review PR https://github.com/COVESA/vissr/pull/XXX with #file:vissr-pr-review skill
+```
+
+Then follow the **[PR Review Checklist](CHECKLIST.md)** in your review.
+
+## Complete Guides
+
+| Guide | Purpose | Use When |
+|-------|---------|----------|
+| **[CHECKLIST.md](../../guides/generic/CHECKLIST.md)** | Copy-paste PR review checklist | Reviewing every PR |
+| **[ARCHITECTURE.md](../../guides/generic/ARCHITECTURE.md)** | Architectural patterns, SOLID, design | Evaluating new packages or design |
+| **[SECURITY.md](../../guides/generic/SECURITY.md)** | Secrets, TLS, authorization | Reviewing security-related changes |
+| **[TESTING.md](../../guides/generic/TESTING.md)** | Test requirements, commands | Verifying test coverage |
+| **[REFERENCE.md](../../guides/generic/REFERENCE.md)** | Useful commands, examples, resources | Quick lookup |
+
+## Core Principles
+
+1. **Registry Pattern** — All tree sources use `RegisterServiceTree()` / `DeregisterServiceTree()`
+2. **Mutual Exclusivity** — Conflicting flags (e.g., `--vdm` / `--him`) validated early
+3. **Input Validation** — All user-provided data validated before use
+4. **Concurrency Safety** — Shared state protected by mutex; tests pass `-race`
+5. **Graceful Degradation** — Optional components fail non-fatally
+6. **No Secrets in Code** — All credentials via environment variables
+7. **Goroutine Lifecycle** — Every goroutine has a known exit condition
+8. **Atomic I/O** — Network writes are atomic frames
+
+## Common Issues to Flag
+
+- **Missing input validation** on user-provided JSON, GraphQL, or flags
+- **Mutually exclusive flags** not validated at startup
+- **Hardcoded secrets** or credentials in code
+- **Goroutine leaks** — loops without exit conditions
+- **Race conditions** — shared maps/slices accessed without mutex
+- **Silent errors** — discarded error returns or failed type assertions
+- **Non-atomic I/O** — multiple writes when one atomic write needed
+
+## Approval Criteria
+
+**Approve:** All tests pass, validates input, no secrets, follows patterns  
+**Request changes:** Test coverage gaps, validation missing, concurrency concerns  
+**Reject:** Test failures, hardcoded secrets, race detector failures, TLS weakened
+
+---
+
+See each guide for detailed patterns, examples, and checklists.


### PR DESCRIPTION
## Summary

Adds a modular Copilot PR review skill for VISSR with standalone reusable guides.

### Structure

```
.copilot/skills/pr-review/
└── SKILL.md              ← Skill entry point (invoked via #file:vissr-pr-review)

.copilot/guides/generic/
├── CHECKLIST.md          ← Copy-paste PR review checklist
├── ARCHITECTURE.md       ← Architectural patterns, SOLID, concurrency
├── SECURITY.md           ← Secrets, TLS, authorization
├── TESTING.md            ← Testing requirements, race detector
└── REFERENCE.md          ← Commands, code examples, resources
```

### Why modular?

- **SKILL.md** is the only skill entry point — minimal, links to guides
- **Guides are standalone** — reusable for onboarding, audits, CI docs
- **No token waste** — each guide is focused; no duplication across files
- **Easy to maintain** — update one concern without touching others

### Coverage

- Registry pattern, HIM forest, package organization
- Secrets management, TLS, authorization
- Mutex, channels, goroutine lifecycle, race detector
- Mandatory tests, smoke tests, VDM validation
- SOLID principles, error handling, logging
- VDM/GraphQL directives, configuration management
- Dependency review (go.mod license/version checks)

### Usage

```
review PR https://github.com/COVESA/vissr/pull/XXX with #file:pr-review skill
```
