### PR TITLE
fix(service): validate service requests against the VISSv3.2 service schema

### DIFF
--- a/spec/VISSv3.2_Service_Quickstart.md
+++ b/spec/VISSv3.2_Service_Quickstart.md
@@ -239,6 +239,19 @@ Common error numbers: `400` (bad request), `404` (path not found), `503` (servic
 
 ---
 
+## Request validation
+
+Service requests (`invoke`, `monitor`, `cancel`, `discover`) are validated against
+`server/vissv2server/vissv3.2-service-schema.json` before they reach the service
+manager. Data requests (`get`, `set`, `subscribe`, …) continue to be validated
+against the base `vissv3.0-schema.json`. The server selects the schema from the
+request's `action` field, so a malformed service request — e.g. an `invoke`
+missing the required `path` or `filter` — is rejected with a `400` schema error
+rather than being forwarded. No configuration is needed; both schema files ship
+alongside the server binary.
+
+---
+
 ## Running the test suite
 
 Unit tests (with race detector) for the service manager:

--- a/utils/common.go
+++ b/utils/common.go
@@ -31,6 +31,12 @@ const IpEnvVarName = "GEN2MODULEIP"
 
 var jsonSchema *jsonschema.Schema
 
+// serviceSchema validates VISSv3.2 service requests (invoke / monitor /
+// cancel / discover). These actions are absent from the base data
+// schema, so without this they were silently validated against
+// vissv3.0-schema.json — i.e. the service schema was never applied.
+var serviceSchema *jsonschema.Schema
+
 // Access control values: none=0, write-only=1. read-write=2, consent +=10
 // matrix preserving inherited value with read-write having priority over write-only and consent over no consent
 var validationMatrix [5][5]int = [5][5]int{{0, 1, 2, 11, 12}, {1, 1, 2, 11, 12}, {2, 2, 2, 12, 12}, {11, 11, 12, 11, 12}, {12, 12, 12, 12, 12}}
@@ -525,39 +531,81 @@ var jsonSchemaOnce sync.Once
 
 func JsonSchemaInit() {
 	jsonSchemaOnce.Do(func() {
-		if jsonSchema != nil {
-			Info.Printf("JSON schema already initiated")
-			return
-		}
-		jsonSchemaStr := readSchema()
-		if len(jsonSchemaStr) > 0 {
-			jsonSchema = jsonschema.Must(jsonSchemaStr) // jsonSchema string read from file
+		if jsonSchemaStr := readSchema(); len(jsonSchemaStr) > 0 {
+			jsonSchema = jsonschema.Must(jsonSchemaStr) // base data schema
 			Info.Printf("JSON schema initiated")
+		}
+		// VISSv3.2: service requests are validated against a separate
+		// service schema. Load it here so JsonSchemaValidate can route
+		// invoke/monitor/cancel/discover to it.
+		if serviceSchemaStr := readServiceSchema(); len(serviceSchemaStr) > 0 {
+			serviceSchema = jsonschema.Must(serviceSchemaStr)
+			Info.Printf("Service JSON schema initiated")
 		}
 	})
 }
 
 func readSchema() string {
-	data, err := os.ReadFile("vissv3.0-schema.json")
+	return readSchemaFile("vissv3.0-schema.json")
+}
+
+func readServiceSchema() string {
+	return readSchemaFile("vissv3.2-service-schema.json")
+}
+
+func readSchemaFile(filename string) string {
+	data, err := os.ReadFile(filename)
 	if err != nil {
-		Error.Printf("JSON schema could not be read, error=%s", err)
+		Error.Printf("JSON schema %q could not be read, error=%s", filename, err)
 		return ""
 	}
 	return string(data)
 }
 
-// JsonSchemaValidate validates request against the loaded schema.
-// Bug-6 fix: previously the function called jsonSchema.ValidateBytes
+// serviceActions are the VISSv3.2 service operations. Requests carrying
+// one of these actions are validated against serviceSchema rather than
+// the base data schema.
+var serviceActions = map[string]bool{
+	"invoke":   true,
+	"monitor":  true,
+	"cancel":   true,
+	"discover": true,
+}
+
+// schemaActionField returns the request's "action" value, used to pick
+// which schema applies. It parses the JSON properly (the request may be
+// arbitrarily ordered); on malformed input it returns "" so the request
+// falls through to the base schema, which then reports the syntax error.
+func schemaActionField(request string) string {
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(request), &m); err != nil {
+		return ""
+	}
+	action, _ := m["action"].(string)
+	return action
+}
+
+// JsonSchemaValidate validates request against the appropriate schema:
+// the VISSv3.2 service schema for service actions, otherwise the base
+// data schema.
+//
+// Bug-6 fix: previously the function called ValidateBytes
 // unconditionally, panicking with a nil-pointer dereference when
 // schema-file loading had failed at init() (e.g. running from the
 // wrong working directory in tests). Now we surface the unavailable
 // state as a returned error string so callers can decide how to
 // degrade.
 func JsonSchemaValidate(request string) string {
-	if jsonSchema == nil {
-		return "JSON schema not loaded (call JsonSchemaInit and ensure the schema file is reachable)"
+	schema := jsonSchema
+	schemaName := "JSON"
+	if serviceActions[schemaActionField(request)] {
+		schema = serviceSchema
+		schemaName = "service JSON"
 	}
-	errs, err := jsonSchema.ValidateBytes(context.Background(), []byte(request))
+	if schema == nil {
+		return schemaName + " schema not loaded (call JsonSchemaInit and ensure the schema file is reachable)"
+	}
+	errs, err := schema.ValidateBytes(context.Background(), []byte(request))
 	if err != nil {
 		return fixSyntax(err.Error())
 	}

--- a/utils/service_schema_test.go
+++ b/utils/service_schema_test.go
@@ -1,0 +1,181 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* Tests for VISSv3.2 service-schema routing in JsonSchemaValidate.
+*
+* Regression context: vissv3.2-service-schema.json was added to the repo
+* but never wired into the validation pipeline — service requests
+* (invoke/monitor/cancel/discover) were validated against the base
+* vissv3.0-schema.json, which has no service-action branches. The result
+* was that the service schema was never applied. These tests load both
+* schemas the way JsonSchemaInit does and assert that service actions are
+* routed to the service schema while data actions stay on the base schema.
+*
+* JsonSchemaInit uses sync.Once, so (as in schema_test.go) we read the
+* schema files directly and assign the package globals to exercise the
+* loaded branches deterministically.
+**/
+package utils
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/qri-io/jsonschema"
+)
+
+const serviceSchemaSourceRelPath = "../server/vissv2server/vissv3.2-service-schema.json"
+
+// loadServiceSchema reads and compiles the production service schema,
+// assigning it to the package global for the duration of t. Skips if the
+// source file is unreadable.
+func loadServiceSchema(t *testing.T) {
+	t.Helper()
+	data, err := os.ReadFile(serviceSchemaSourceRelPath)
+	if err != nil {
+		t.Skipf("service schema %s not readable (%v); skipping", serviceSchemaSourceRelPath, err)
+	}
+	prev := serviceSchema
+	serviceSchema = jsonschema.Must(string(data))
+	t.Cleanup(func() { serviceSchema = prev })
+}
+
+// loadBaseSchema reads and compiles the production base schema into the
+// package global for the duration of t. Skips if unreadable.
+func loadBaseSchema(t *testing.T) {
+	t.Helper()
+	data, err := os.ReadFile(schemaSourceRelPath)
+	if err != nil {
+		t.Skipf("base schema %s not readable (%v); skipping", schemaSourceRelPath, err)
+	}
+	prev := jsonSchema
+	jsonSchema = jsonschema.Must(string(data))
+	t.Cleanup(func() { jsonSchema = prev })
+}
+
+// TestReadServiceSchema_WithFile exercises readServiceSchema when the file
+// is present (copied into a temp CWD).
+func TestReadServiceSchema_WithFile(t *testing.T) {
+	data, err := os.ReadFile(serviceSchemaSourceRelPath)
+	if err != nil {
+		t.Skipf("service schema source not readable (%v); skipping", err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(dir+"/vissv3.2-service-schema.json", data, 0644); err != nil {
+		t.Fatalf("write service schema: %v", err)
+	}
+	chdirTemp(t, dir)
+
+	if got := readServiceSchema(); got == "" {
+		t.Error("readServiceSchema returned empty string with file present")
+	}
+}
+
+// TestReadServiceSchema_WithoutFile exercises the missing-file branch.
+func TestReadServiceSchema_WithoutFile(t *testing.T) {
+	chdirTemp(t, t.TempDir())
+	if got := readServiceSchema(); got != "" {
+		t.Errorf("readServiceSchema with no file = %q; want \"\"", got)
+	}
+}
+
+// TestSchemaActionField checks the action extraction used to pick a schema.
+func TestSchemaActionField(t *testing.T) {
+	cases := []struct {
+		name, req, want string
+	}{
+		{"invoke", `{"action":"invoke","path":"X"}`, "invoke"},
+		{"action not first", `{"requestId":"1","action":"get"}`, "get"},
+		{"missing action", `{"path":"X"}`, ""},
+		{"malformed json", `{not json`, ""},
+		{"action not a string", `{"action":42}`, ""},
+		{"empty", ``, ""},
+	}
+	for _, c := range cases {
+		if got := schemaActionField(c.req); got != c.want {
+			t.Errorf("%s: schemaActionField(%q) = %q; want %q", c.name, c.req, got, c.want)
+		}
+	}
+}
+
+// TestJsonSchemaValidate_ValidInvokeRoutedToServiceSchema is the core
+// regression for the wiring bug: a well-formed invoke request is valid
+// under the service schema but INVALID under the base schema (which has
+// no invoke branch). If routing works, validation passes; if the base
+// schema were still used, it would fail.
+func TestJsonSchemaValidate_ValidInvokeRoutedToServiceSchema(t *testing.T) {
+	loadBaseSchema(t)
+	loadServiceSchema(t)
+
+	invoke := `{"action":"invoke","path":"Vehicle.Cabin.SeatService.MoveSeat","filter":{"variant":"all"},"requestId":"1"}`
+
+	if got := JsonSchemaValidate(invoke); got != "" {
+		t.Errorf("valid invoke rejected = %q; want \"\" (should validate against service schema)", got)
+	}
+
+	// Prove the disagreement: the same request fails the base schema,
+	// confirming routing — not a permissive base schema — is what passes it.
+	if errs, err := jsonSchema.ValidateBytes(context.Background(), []byte(invoke)); err == nil && len(errs) == 0 {
+		t.Error("base schema accepted an invoke request; routing test is not meaningful")
+	}
+}
+
+// TestJsonSchemaValidate_InvalidInvokeRejected confirms the service schema
+// is actually applied: an invoke missing the required "path" must be
+// rejected. This is the behaviour whose absence the bug report described
+// ("the server did not use the service json scheme").
+func TestJsonSchemaValidate_InvalidInvokeRejected(t *testing.T) {
+	loadBaseSchema(t)
+	loadServiceSchema(t)
+
+	missingPath := `{"action":"invoke","filter":{"variant":"all"},"requestId":"1"}`
+	if got := JsonSchemaValidate(missingPath); got == "" {
+		t.Error("invoke missing required 'path' was accepted; service schema not applied")
+	}
+
+	badFilter := `{"action":"invoke","path":"X","filter":{"variant":"bogus"},"requestId":"1"}`
+	if got := JsonSchemaValidate(badFilter); got == "" {
+		t.Error("invoke with out-of-enum filter variant was accepted; service schema not applied")
+	}
+}
+
+// TestJsonSchemaValidate_DiscoverRoutedToServiceSchema covers a second
+// service action to confirm the routing set, not just invoke.
+func TestJsonSchemaValidate_DiscoverRoutedToServiceSchema(t *testing.T) {
+	loadBaseSchema(t)
+	loadServiceSchema(t)
+
+	if got := JsonSchemaValidate(`{"action":"discover","path":"Vehicle","requestId":"2"}`); got != "" {
+		t.Errorf("valid discover rejected = %q; want \"\"", got)
+	}
+}
+
+// TestJsonSchemaValidate_DataActionUsesBaseSchema confirms non-service
+// actions still validate against the base schema and are unaffected.
+func TestJsonSchemaValidate_DataActionUsesBaseSchema(t *testing.T) {
+	loadBaseSchema(t)
+	loadServiceSchema(t)
+
+	if got := JsonSchemaValidate(`{"action":"get","path":"Vehicle.Speed","requestId":"1"}`); got != "" {
+		t.Errorf("valid get rejected = %q; want \"\"", got)
+	}
+}
+
+// TestJsonSchemaValidate_ServiceSchemaNotLoaded confirms the graceful
+// degradation message names the service schema when it is unavailable but
+// a service action arrives.
+func TestJsonSchemaValidate_ServiceSchemaNotLoaded(t *testing.T) {
+	prevBase, prevSvc := jsonSchema, serviceSchema
+	jsonSchema, serviceSchema = nil, nil
+	defer func() { jsonSchema, serviceSchema = prevBase, prevSvc }()
+
+	got := JsonSchemaValidate(`{"action":"invoke","path":"X"}`)
+	if got == "" {
+		t.Fatal("service action with nil service schema returned no error")
+	}
+	if !strings.Contains(got, "service JSON schema not loaded") {
+		t.Errorf("got %q; want a 'service JSON schema not loaded' message", got)
+	}
+}


### PR DESCRIPTION
## Problem

`vissv3.2-service-schema.json` was added to the repo but never wired into the validation pipeline. `JsonSchemaInit` only loaded `vissv3.0-schema.json`, and `JsonSchemaValidate` validated **every** request against it — including service requests (`invoke`/`monitor`/`cancel`/`discover`), which the base data schema has no branches for. The service schema was therefore never applied, which matches the report that *"the server did not use the service json scheme when verifying the request"*.

## Fix

- Load the service schema in `JsonSchemaInit` (co-located with the base schema in the server working directory).
- Route requests in `JsonSchemaValidate` by their `action` field: service actions validate against the service schema, all other actions against the base schema.
- Action is parsed with `encoding/json`, so field ordering is irrelevant; malformed JSON falls through to the base schema (which reports the syntax error).
- The bug-6 nil-schema graceful-degradation guard is preserved and now names the service schema when that is the unavailable one.

## Tests

`utils/service_schema_test.go` covers routing both ways, including the regression:
- A valid `invoke` passes **only because** it is routed to the service schema — the base schema rejects the same request (asserted explicitly).
- A malformed `invoke` (missing `path`, out-of-enum filter `variant`) is now rejected — the behaviour whose absence was reported.
- `discover` routing, `get` still using the base schema, and the not-loaded degradation message.

`go build ./...`, `go vet`, and `go test -race ./utils/` all pass.

## Notes

Targets `v3.2` (service profile beta), per the policy that the master branch tracks released VISS spec versions.