### PR TITLE
fix(service): resolve full service paths so invoke/monitor/discover route correctly

### DIFF
--- a/server/vissv2server/viss.him
+++ b/server/vissv2server/viss.him
@@ -10,7 +10,7 @@ HIM.Vehicle:
   https://github.com/COVESA/vehicle_signal_specification/releases/tag/v5.0
   description: The VSS v5.0 tree.
 
-HIM.VehicleServices:
+HIM.VehicleService:
   type: direct
   domain: Vehicle.Car.Service
   version: 5.0.0

--- a/server/vissv2server/vissServiceMgr/vissServiceMgr.go
+++ b/server/vissv2server/vissServiceMgr/vissServiceMgr.go
@@ -36,11 +36,46 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/covesa/vissr/utils"
 )
+
+// maxServiceNodes caps the result set when resolving a service path. A service
+// request addresses a single procedure (or, for discover, a single branch), so
+// a small cap is sufficient.
+const maxServiceNodes = 50
+
+// resolveServiceNode walks the HIM forest to the node addressed by the full
+// dot-delimited path and returns it, or nil if the path does not resolve to
+// exactly one node.
+//
+// utils.SetRootNodePointer only returns the *tree root* (it matches on the
+// first path segment), so it cannot address a procedure node deeper in the
+// tree. Callers that need the addressed node (invoke/monitor/discover) must
+// walk the full path from the root — using SetRootNodePointer alone made every
+// multi-segment service path resolve to the root branch, which then failed the
+// "must address a procedure node" check.
+func resolveServiceNode(path string) *utils.Node_t {
+	root := utils.SetRootNodePointer(path)
+	if root == nil {
+		return nil
+	}
+	// VSSsearchNodes (with leafNodesOnly=false) records every node along the
+	// matched path — root, intermediate branches, and the addressed node — so
+	// we pick the entry whose full path equals the request path exactly. This
+	// resolves both procedure targets (invoke/monitor) and branch targets
+	// (discover), unlike SetRootNodePointer which only ever returns the root.
+	searchData, matches := utils.VSSsearchNodes(path, root, maxServiceNodes, true, false, 0, nil, nil)
+	for i := 0; i < matches; i++ {
+		if searchData[i].NodePath == path {
+			return searchData[i].NodeHandle
+		}
+	}
+	return nil
+}
 
 // ServiceStatus is the set of allowed status values from VISSv3.2 §2.
 type ServiceStatus string
@@ -219,7 +254,7 @@ func HandleInvoke(requestMap map[string]interface{}, backendChans []chan map[str
 	}
 	bc := backendChans[tDChanIndex]
 
-	node := utils.SetRootNodePointer(path)
+	node := resolveServiceNode(path)
 	if node == nil || utils.VSSgetType(node) != utils.PROCEDURE {
 		sendServiceError(bc, "invoke", requestId, "", StatusFailed,
 			"400", "bad_request", "path must address a procedure node")
@@ -302,7 +337,7 @@ func HandleMonitor(requestMap map[string]interface{}, backendChans []chan map[st
 	}
 	bc := backendChans[tDChanIndex]
 
-	node := utils.SetRootNodePointer(path)
+	node := resolveServiceNode(path)
 	if node == nil || utils.VSSgetType(node) != utils.PROCEDURE {
 		sendServiceError(bc, "monitor", requestId, "", StatusFailed,
 			"400", "bad_request", "path must address a procedure node")
@@ -444,7 +479,7 @@ func HandleDiscover(requestMap map[string]interface{}, backendChan chan map[stri
 	path, _ := requestMap["path"].(string)
 	requestId, _ := requestMap["requestId"].(string)
 
-	node := utils.SetRootNodePointer(path)
+	node := resolveServiceNode(path)
 	if node == nil {
 		sendServiceError(backendChan, "discover", requestId, "", StatusUnknown,
 			"400", "bad_request", "path not found in service tree")
@@ -773,11 +808,27 @@ func validateIoParams(iostructNode *utils.Node_t, params map[string]interface{})
 			continue
 		}
 		name := utils.VSSgetName(child)
-		if _, ok := params[name]; !ok {
-			missing = append(missing, name)
+		if _, ok := params[name]; ok {
+			continue
 		}
+		if isOptionalParam(child) {
+			continue // optional parameters may be omitted (e.g. MoveSeat.Credentials)
+		}
+		missing = append(missing, name)
 	}
 	return len(missing) == 0, missing
+}
+
+// isOptionalParam reports whether an Input/Output parameter node is optional.
+//
+// The HIM Node_t model has no structured "optional" flag, so optionality is
+// currently only expressed in the node description prose (the COVESA HIM
+// service example marks MoveSeat.Credentials as "Optional parameter."). Until a
+// structured directive (e.g. @optional) is added to the vspec/HIM tooling and a
+// corresponding Node_t field, we honour that convention so a request omitting
+// an optional parameter is not rejected as missing a required field.
+func isOptionalParam(node *utils.Node_t) bool {
+	return strings.Contains(strings.ToLower(utils.VSSgetDescr(node)), "optional")
 }
 
 // ---- filter helpers --------------------------------------------------------

--- a/server/vissv2server/vissServiceMgr/vissServiceMgr_e2e_test.go
+++ b/server/vissv2server/vissServiceMgr/vissServiceMgr_e2e_test.go
@@ -1,0 +1,208 @@
+package vissServiceMgr
+
+// End-to-end routing tests for the VISSv3.2 service profile.
+//
+// These exercise the path that the package-level unit tests deliberately skip
+// (see the header of vissServiceMgr_test.go): resolving a full service path
+// against a real binary HIM tree loaded into the forest. They reproduce the
+// invoke request from client/client-1.0/Javascript/appclient_service_commands.txt
+// (requestId 8756) that previously failed with a 400 "The request is malformed."
+//
+// Root causes covered:
+//   1. viss.him registered the tree as "VehicleServices" (plural) while the
+//      tree root and the client path use "VehicleService" — so the request
+//      never routed to vissServiceMgr.
+//   2. HandleInvoke/Monitor/Discover used SetRootNodePointer (which only
+//      returns the tree root) instead of walking the full path, so a valid
+//      procedure path resolved to the root branch and was rejected as "must
+//      address a procedure node".
+//   3. validateIoParams required every Input child, including the optional
+//      MoveSeat.Credentials parameter.
+
+import (
+	"os"
+	"testing"
+
+	"github.com/covesa/vissr/utils"
+)
+
+const serviceTreeBinary = "../forest/VehicleServices.v1.0.binary"
+
+const moveSeatPath = "VehicleService.Seating.Row1.DriverSide.MoveSeat"
+
+// loadVehicleServiceTree loads the bundled HIM service example tree and
+// registers it under the "VehicleService" root, matching the (fixed)
+// server/vissv2server/viss.him configuration. The test is skipped when the
+// binary is unavailable (e.g. a sparse checkout).
+func loadVehicleServiceTree(t *testing.T) *utils.Node_t {
+	t.Helper()
+	if _, err := os.Stat(serviceTreeBinary); err != nil {
+		t.Skipf("service tree binary not present (%s): %v", serviceTreeBinary, err)
+	}
+	root := utils.VSSReadTree(serviceTreeBinary)
+	if root == nil {
+		t.Fatalf("VSSReadTree(%s) returned nil", serviceTreeBinary)
+	}
+	utils.DeregisterServiceTree("VehicleService")
+	if !utils.RegisterServiceTree("VehicleService", "Vehicle.Car.Service", "1.0.0", root) {
+		t.Fatal("RegisterServiceTree(VehicleService) failed")
+	}
+	t.Cleanup(func() { utils.DeregisterServiceTree("VehicleService") })
+	return root
+}
+
+// stopServiceGoroutines stops the timeout watchdogs and time-based monitoring
+// tickers spawned by HandleInvoke so they do not outlive the test.
+func stopServiceGoroutines() {
+	mu.Lock()
+	defer mu.Unlock()
+	for _, inv := range invocations {
+		if inv.cancelFn != nil {
+			inv.cancelFn()
+			inv.cancelFn = nil
+		}
+	}
+	for _, sess := range sessions {
+		if sess.cancelTicker != nil {
+			sess.cancelTicker()
+			sess.cancelTicker = nil
+		}
+	}
+}
+
+func TestResolveServiceNode_FullPathReachesProcedure(t *testing.T) {
+	loadVehicleServiceTree(t)
+
+	// SetRootNodePointer alone returns the tree root branch, never the
+	// addressed procedure — the bug that broke invoke routing.
+	root := utils.SetRootNodePointer(moveSeatPath)
+	if root == nil {
+		t.Fatal("SetRootNodePointer returned nil for a known root")
+	}
+	if utils.VSSgetType(root) == utils.PROCEDURE {
+		t.Fatal("precondition failed: tree root should be a branch, not a procedure")
+	}
+
+	node := resolveServiceNode(moveSeatPath)
+	if node == nil {
+		t.Fatalf("resolveServiceNode(%q) = nil; want the MoveSeat procedure", moveSeatPath)
+	}
+	if got := utils.VSSgetType(node); got != utils.PROCEDURE {
+		t.Errorf("resolved node type = %q, want PROCEDURE", got)
+	}
+	if got := utils.VSSgetName(node); got != "MoveSeat" {
+		t.Errorf("resolved node name = %q, want MoveSeat", got)
+	}
+}
+
+func TestResolveServiceNode_BadPathsReturnNil(t *testing.T) {
+	loadVehicleServiceTree(t)
+
+	cases := map[string]string{
+		"plural root (the viss.him typo)": "VehicleServices.Seating.Row1.DriverSide.MoveSeat",
+		"unknown mid segment":             "VehicleService.Nope.MoveSeat",
+		"unknown leaf":                    "VehicleService.Seating.Row1.DriverSide.NoSuchProc",
+	}
+	for name, path := range cases {
+		if n := resolveServiceNode(path); n != nil {
+			t.Errorf("%s: resolveServiceNode(%q) = %v, want nil", name, path, utils.VSSgetName(n))
+		}
+	}
+}
+
+func TestHandleInvoke_AppclientRequest_RoutesAndReturnsOngoing(t *testing.T) {
+	resetState()
+	loadVehicleServiceTree(t)
+	t.Cleanup(stopServiceGoroutines)
+
+	bc := make(chan map[string]interface{}, 8)
+	bcs := []chan map[string]interface{}{bc}
+
+	// Exactly the appclient invoke request (requestId 8756).
+	req := map[string]interface{}{
+		"action": "invoke",
+		"path":   moveSeatPath,
+		"input": map[string]interface{}{
+			"MovementType": "longitudinal",
+			"Position":     "40",
+		},
+		"filter": map[string]interface{}{
+			"variant":   "timebased",
+			"parameter": map[string]interface{}{"period": "250"},
+		},
+		"requestId":   "8756",
+		"routerIndex": 0,
+	}
+
+	HandleInvoke(req, bcs)
+
+	select {
+	case resp := <-bc:
+		if e, ok := resp["error"]; ok {
+			t.Fatalf("invoke returned an error response: %v", e)
+		}
+		if resp["action"] != "invoke" {
+			t.Errorf("action = %v, want invoke", resp["action"])
+		}
+		if resp["status"] != string(StatusOngoing) {
+			t.Errorf("status = %v, want ONGOING", resp["status"])
+		}
+		if resp["requestId"] != "8756" {
+			t.Errorf("requestId = %v, want 8756", resp["requestId"])
+		}
+		if _, ok := resp["serviceId"].(string); !ok {
+			t.Error("expected a serviceId for the monitoring session")
+		}
+	default:
+		t.Fatal("HandleInvoke produced no response")
+	}
+}
+
+func TestHandleDiscover_BranchPath_ReturnsMetadata(t *testing.T) {
+	resetState()
+	loadVehicleServiceTree(t)
+
+	bc := make(chan map[string]interface{}, 4)
+	req := map[string]interface{}{
+		"action":    "discover",
+		"path":      "VehicleService.Seating",
+		"requestId": "5687",
+	}
+
+	HandleDiscover(req, bc)
+
+	select {
+	case resp := <-bc:
+		if e, ok := resp["error"]; ok {
+			t.Fatalf("discover returned an error response: %v", e)
+		}
+		meta, ok := resp["metadata"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("discover metadata missing/!map: %T", resp["metadata"])
+		}
+		if len(meta) == 0 {
+			t.Error("discover metadata is empty for a populated branch")
+		}
+	default:
+		t.Fatal("HandleDiscover produced no response")
+	}
+}
+
+func TestValidateInputSignature_OptionalCredentialsMayBeOmitted(t *testing.T) {
+	loadVehicleServiceTree(t)
+
+	proc := resolveServiceNode(moveSeatPath)
+	if proc == nil {
+		t.Fatal("could not resolve MoveSeat procedure")
+	}
+
+	// Ulf's input supplies MovementType + Position but omits the optional
+	// Credentials parameter.
+	ok, missing := validateInputSignature(proc, map[string]interface{}{
+		"MovementType": "longitudinal",
+		"Position":     "40",
+	})
+	if !ok {
+		t.Errorf("expected valid input (Credentials is optional); missing=%v", missing)
+	}
+}

--- a/server/vissv2server/vissv2server.go
+++ b/server/vissv2server/vissv2server.go
@@ -559,7 +559,17 @@ func issueServiceRequest(requestMap map[string]interface{}, tDChanIndex int, sDC
 	if !(rootPath == "HIM" && requestMap["action"] == "get" && requestMap["filter"] != nil) {
 		VSSTreeRoot = utils.SetRootNodePointer(rootPath)
 		if VSSTreeRoot == nil {
-			setErrorAndForward(requestMap, tDChanIndex, 0, "") //bad_request
+			// No HIM tree is rooted at the first path segment. This is a
+			// "not found", not a malformed request: returning the generic
+			// bad_request ("The request is malformed.") here previously
+			// masked a forest/path root-name mismatch as a JSON-schema
+			// problem. Report it as unavailable_data with the offending root.
+			rootName := rootPath
+			if dot := strings.Index(rootPath, "."); dot != -1 {
+				rootName = rootPath[:dot]
+			}
+			setErrorAndForward(requestMap, tDChanIndex, 6,
+				"No tree found for path root \""+rootName+"\".") //unavailable_data
 			return
 		}
 		requestMap["infoType"] = utils.GetInfoType(VSSTreeRoot)

--- a/spec/VISSv3.2_Service_Quickstart.md
+++ b/spec/VISSv3.2_Service_Quickstart.md
@@ -36,6 +36,13 @@ description: Vehicle seating service tree.
 The `domain` value **must** end in `.Service`. The server detects this suffix and routes
 `invoke`, `monitor`, `cancel`, and `discover` requests through `vissServiceMgr`.
 
+> **Root name must match the request path.** The HIM key (`HIM.<RootName>`) becomes the
+> addressable root of the tree, so client paths must begin with that exact `<RootName>`.
+> For the bundled example tree the key is `HIM.VehicleService`, so requests address
+> `VehicleService.Seating.Row1.DriverSide.MoveSeat`. A mismatch between the HIM key and
+> the path root makes the request fall through service routing and return
+> `404 unavailable_data` ("No tree found for path root …").
+
 ---
 
 ## Step 2: Add procedure nodes to the binary tree


### PR DESCRIPTION
## Summary

A VISSv3.2 service `invoke` fails at runtime with `400 bad_request "The request is malformed."` even though the request passes JSON-schema validation. Reproduced with the bundled appclient request (`requestId 8756`, path `VehicleService.Seating.Row1.DriverSide.MoveSeat`). The error originates **downstream of schema validation**, in the server core — not in the schema.

This fixes four distinct defects that together broke the service profile end-to-end:

1. **Forest/path root-name mismatch.** `viss.him` registered the bundled tree as `HIM.VehicleServices` (plural), but the binary tree root and the client path use `VehicleService` (singular). `SetRootNodePointer` matches the first path segment exactly, so the request never matched the service tree and fell through service routing into the signal pipeline — producing the generic 400.

2. **Service handlers resolved only the tree root.** `HandleInvoke`/`HandleMonitor`/`HandleDiscover` called `SetRootNodePointer(path)`, which returns the tree root branch, never the node addressed by the full path. A valid procedure path therefore resolved to the root branch and was rejected as *"path must address a procedure node"*. Added `resolveServiceNode()`, which walks the full path with `VSSsearchNodes` and selects the entry whose `NodePath` equals the request path exactly (works for procedure targets and for discover branch targets).

3. **Optional input parameters were treated as required.** `validateIoParams` required every `Input` child, including the optional `MoveSeat.Credentials`. `Node_t` has no structured optional flag, so optionality is honoured via the description marker (`isOptionalParam`) until a directive is added to the vspec/HIM tooling.

4. **Misleading diagnostic.** `issueServiceRequest` returned the generic `400 "The request is malformed."` when no tree is rooted at the path's first segment — masking the root-name mismatch as a schema problem. It now returns `404 unavailable_data` naming the offending root.

## Testing

The package unit tests explicitly skip functions that require a live binary tree, so the resolution path was never exercised. Added `vissServiceMgr_e2e_test.go`, which loads the real `VehicleServices.v1.0.binary`, registers it, and:

- replays the appclient `invoke` — asserts it routes and returns `ONGOING` (regression for the 400);
- resolves the full path to the `MoveSeat` procedure (and confirms `SetRootNodePointer` alone returns the root branch);
- rejects bad paths (plural root, unknown segments);
- runs `discover` on a branch path;
- accepts input that omits the optional `Credentials`.

`go build ./...`, `go vet ./server/vissv2server/...`, and `go test -race -count=1` for `vissServiceMgr` and `vissv2server` all pass, as do the existing v3.2 service-schema tests.

Documented the root-name requirement in `spec/VISSv3.2_Service_Quickstart.md`.

Targets `v3.2` per the branch policy (service profile is a separate beta line).