### PR TITLE
feat(sbom): SPDX 2.2/2.3/3.0.1 SBOM generator + CI workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,71 @@
+name: SPDX SBOM
+
+on:
+  push:
+    branches: [master, v4.1]
+  pull_request:
+  release:
+    types: [published]
+
+jobs:
+  build-test:
+    name: Build & test sbom tool
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run unit tests
+        run: go test -race -count=1 ./tools/sbom/
+
+  generate:
+    name: Generate SBOMs
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Generate SPDX 2.2 (tag-value)
+        run: >
+          go run ./tools/sbom
+          --version 2.2 --format tv
+          --name vissr
+          --ns "https://spdx.org/spdxdocs/vissr-${{ github.sha }}-2.2"
+          --out sbom/vissr-2.2.spdx
+
+      - name: Generate SPDX 2.3 (JSON)
+        run: >
+          go run ./tools/sbom
+          --version 2.3 --format json
+          --name vissr
+          --ns "https://spdx.org/spdxdocs/vissr-${{ github.sha }}-2.3"
+          --out sbom/vissr-2.3.spdx.json
+
+      - name: Generate SPDX 3.0.1 (JSON)
+        run: >
+          go run ./tools/sbom
+          --version 3.0.1 --format json
+          --name vissr
+          --ns "https://spdx.org/spdxdocs/vissr-${{ github.sha }}-3.0.1"
+          --out sbom/vissr-3.0.1.spdx.json
+
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ github.sha }}
+          path: sbom/
+          retention-days: 90
+
+      - name: Attach SBOMs to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            sbom/vissr-2.2.spdx
+            sbom/vissr-2.3.spdx.json
+            sbom/vissr-3.0.1.spdx.json

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ A tutorial can be found <a href="https://covesa.github.io/vissr/">here</a>.
 ## VISSv3.2 new features (EXPERIMENTAL)
 * Support for the HIM Service data profile.
 
+## Tooling
+* **SPDX SBOM**: `tools/sbom` CLI generates SPDX 2.2 (tag-value), 2.3 (JSON), and 3.0.1 (JSON) SBOMs from `go list -m`; a CI workflow attaches them to every release.
+
 ## VISSv3.1 new features
 * Support for the HIM Vehicle data profile.
 * This enables VISS to support not only the VSS tree but also other trees that are defined using the vspec syntax.

--- a/TESTING.md
+++ b/TESTING.md
@@ -80,6 +80,13 @@ fuzzers=(
     'FuzzGetRangeBoundaries     ./server/vissv2server'
     'FuzzGetValueForKey         ./server/vissv2server/wsMgr'
     'FuzzCompressTs             ./server/vissv2server/wsMgr'
+    'FuzzValidateSetValue       ./utils'
+    'FuzzIsGraphQL              ./server/vissv2server/vdmloader'
+    'FuzzPathFromURL            ./server/vissv2server/restMgr'
+    'FuzzJsonEscapeString       ./server/vissv2server/restMgr'
+    'FuzzWriteTV                ./tools/sbom'
+    'FuzzWriteJSON              ./tools/sbom'
+    'FuzzDownloadURL            ./tools/sbom'
 )
 for entry in "${fuzzers[@]}"; do
     set -- $entry
@@ -194,6 +201,23 @@ points are tested via runtest.sh integration.
 Covers `fileExists`, `deSerializeUInt` (1/2/4-byte), `inFeederScope`,
 `splitToDomainDataAndTs`, `convertToDomainData`, `makeDataPoint`,
 `calcInputValue`, `incDpIndex`, `enumConversion`, `linearConversion`.
+
+### SBOM generator (`tools/sbom`)
+
+| Function / area | Test |
+|---|---|
+| `noassertion` | `TestNoassertion_*` |
+| `downloadURL` | `TestDownloadURL_*` |
+| `timestamp` format | `TestTimestamp_Format` |
+| `packageVerificationCode` determinism + hex + uniqueness | `TestPackageVerificationCode_*` |
+| `writeTV` — header fields, all three spec versions, package fields, license, empty input, no-version omission | `TestWriteTV_*`, `TestAllVersions_TV` |
+| `writeTV` — 3.0.1 adds `PackageVerificationCode`; 2.2 omits it | `TestWriteTV_Version301*`, `TestWriteTV_Version22*` |
+| `writeJSON` — valid JSON, header, creation-info, packages, relationships, license, indentation | `TestWriteJSON_*`, `TestAllVersions_JSON` |
+| `writeJSON` — 3.0.1 sets `primaryPackagePurpose: LIBRARY`; 2.2 omits it | `TestWriteJSON_Version301*`, `TestWriteJSON_Version22*` |
+| Fuzz: `writeTV`, `writeJSON`, `downloadURL` must not panic on arbitrary input | `FuzzWriteTV`, `FuzzWriteJSON`, `FuzzDownloadURL` |
+
+Note: `goListPackages` is an integration-only entry point (executes `go list -m -json all`)
+and is excluded from unit tests; it is exercised by the CI `generate` job on every push.
 
 ## Functions that need code refactoring to be unit-testable
 

--- a/tools/sbom/main.go
+++ b/tools/sbom/main.go
@@ -1,0 +1,334 @@
+// sbom generates SPDX Software Bill of Materials documents for the vissr
+// module and its dependencies.
+//
+// Supported formats: SPDX 2.2, SPDX 2.3, SPDX 3.0.1 (tag-value and JSON).
+//
+// Usage:
+//
+//	go run ./tools/sbom [flags]
+//
+// Flags:
+//
+//	--version  2.2 | 2.3 | 3.0.1       SPDX spec version (default: 2.3)
+//	--format   tv | json               Output format (default: tv)
+//	--out      <path>                  Output file (default: stdout)
+//	--name     <package name>          Top-level package name (default: vissr)
+//	--ns       <namespace URI>         SPDX document namespace
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/akamensky/argparse"
+)
+
+// ── model ────────────────────────────────────────────────────────────────────
+
+type Package struct {
+	Name        string
+	Version     string
+	License     string
+	SPDXID      string
+	DownloadURL string
+	Homepage    string
+	Supplier    string
+}
+
+type Document struct {
+	SpecVersion   string
+	DocumentName  string
+	SPDXID        string
+	Namespace     string
+	Created       string
+	CreatorTool   string
+	CreatorOrg    string
+	Packages      []Package
+}
+
+// ── entry point ───────────────────────────────────────────────────────────────
+
+func main() {
+	parser := argparse.NewParser("sbom", "Generate SPDX SBOM for vissr")
+
+	version := parser.String("", "version", &argparse.Options{
+		Required: false,
+		Help:     "SPDX spec version: 2.2, 2.3, 3.0.1",
+		Default:  "2.3",
+	})
+	format := parser.String("", "format", &argparse.Options{
+		Required: false,
+		Help:     "Output format: tv (tag-value) or json",
+		Default:  "tv",
+	})
+	outPath := parser.String("", "out", &argparse.Options{
+		Required: false,
+		Help:     "Output file path (default: stdout)",
+		Default:  "",
+	})
+	docName := parser.String("", "name", &argparse.Options{
+		Required: false,
+		Help:     "Document name",
+		Default:  "vissr",
+	})
+	ns := parser.String("", "ns", &argparse.Options{
+		Required: false,
+		Help:     "SPDX document namespace URI",
+		Default:  "",
+	})
+
+	if err := parser.Parse(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, parser.Usage(err))
+		os.Exit(1)
+	}
+
+	switch *version {
+	case "2.2", "2.3", "3.0.1":
+	default:
+		fmt.Fprintf(os.Stderr, "unsupported SPDX version %q (use 2.2, 2.3, or 3.0.1)\n", *version)
+		os.Exit(1)
+	}
+
+	switch *format {
+	case "tv", "json":
+	default:
+		fmt.Fprintf(os.Stderr, "unsupported format %q (use tv or json)\n", *format)
+		os.Exit(1)
+	}
+
+	pkgs, err := goListPackages()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "go list: %v\n", err)
+		os.Exit(1)
+	}
+
+	namespace := *ns
+	if namespace == "" {
+		namespace = "https://spdx.org/spdxdocs/" + *docName + "-" + timestamp()
+	}
+
+	doc := Document{
+		SpecVersion:  *version,
+		DocumentName: *docName,
+		SPDXID:       "SPDXRef-DOCUMENT",
+		Namespace:    namespace,
+		Created:      time.Now().UTC().Format(time.RFC3339),
+		CreatorTool:  "vissr/tools/sbom",
+		CreatorOrg:   "COVESA",
+		Packages:     pkgs,
+	}
+
+	var w io.Writer = os.Stdout
+	if *outPath != "" {
+		if err := os.MkdirAll(filepath.Dir(*outPath), 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "mkdir: %v\n", err)
+			os.Exit(1)
+		}
+		f, err := os.Create(*outPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "create %s: %v\n", *outPath, err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		w = f
+	}
+
+	switch *format {
+	case "json":
+		err = writeJSON(w, doc)
+	default:
+		err = writeTV(w, doc)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "write: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// ── go list integration ───────────────────────────────────────────────────────
+
+type goModule struct {
+	Path    string `json:"Path"`
+	Version string `json:"Version"`
+	License string `json:"License,omitempty"`
+}
+
+func goListPackages() ([]Package, error) {
+	cmd := exec.Command("go", "list", "-m", "-json", "all")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("go list -m -json all: %w", err)
+	}
+
+	var pkgs []Package
+	dec := json.NewDecoder(strings.NewReader(string(out)))
+	idx := 1
+	for {
+		var m goModule
+		if err := dec.Decode(&m); err != nil {
+			break
+		}
+		if m.Path == "" {
+			continue
+		}
+		pkg := Package{
+			Name:        m.Path,
+			Version:     m.Version,
+			SPDXID:      fmt.Sprintf("SPDXRef-Package-%d", idx),
+			DownloadURL: downloadURL(m.Path, m.Version),
+			License:     noassertion(m.License),
+		}
+		pkgs = append(pkgs, pkg)
+		idx++
+	}
+	return pkgs, nil
+}
+
+func downloadURL(path, version string) string {
+	if version == "" {
+		return "NOASSERTION"
+	}
+	return fmt.Sprintf("https://pkg.go.dev/%s@%s", path, version)
+}
+
+func noassertion(s string) string {
+	if s == "" {
+		return "NOASSERTION"
+	}
+	return s
+}
+
+// ── writers ──────────────────────────────────────────────────────────────────
+
+func writeTV(w io.Writer, doc Document) error {
+	// Header
+	fmt.Fprintf(w, "SPDXVersion: SPDX-%s\n", doc.SpecVersion)
+	fmt.Fprintf(w, "DataLicense: CC0-1.0\n")
+	fmt.Fprintf(w, "SPDXID: %s\n", doc.SPDXID)
+	fmt.Fprintf(w, "DocumentName: %s\n", doc.DocumentName)
+	fmt.Fprintf(w, "DocumentNamespace: %s\n", doc.Namespace)
+	fmt.Fprintf(w, "Creator: Tool: %s\n", doc.CreatorTool)
+	fmt.Fprintf(w, "Creator: Organization: %s\n", doc.CreatorOrg)
+	fmt.Fprintf(w, "Created: %s\n", doc.Created)
+
+	for _, pkg := range doc.Packages {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "PackageName: %s\n", pkg.Name)
+		fmt.Fprintf(w, "SPDXID: %s\n", pkg.SPDXID)
+		if pkg.Version != "" {
+			fmt.Fprintf(w, "PackageVersion: %s\n", pkg.Version)
+		}
+		fmt.Fprintf(w, "PackageDownloadLocation: %s\n", noassertion(pkg.DownloadURL))
+		fmt.Fprintf(w, "FilesAnalyzed: false\n")
+		fmt.Fprintf(w, "PackageLicenseConcluded: %s\n", noassertion(pkg.License))
+		fmt.Fprintf(w, "PackageLicenseDeclared: %s\n", noassertion(pkg.License))
+		fmt.Fprintf(w, "PackageCopyrightText: NOASSERTION\n")
+
+		if doc.SpecVersion == "3.0.1" {
+			fmt.Fprintf(w, "PackageVerificationCode: %s\n", packageVerificationCode(pkg))
+		}
+
+		// Relationship: document describes this package.
+		fmt.Fprintf(w, "Relationship: %s DESCRIBES %s\n", doc.SPDXID, pkg.SPDXID)
+	}
+	return nil
+}
+
+// ── JSON writer ───────────────────────────────────────────────────────────────
+
+type spdxDocJSON struct {
+	SpdxVersion     string            `json:"spdxVersion"`
+	DataLicense     string            `json:"dataLicense"`
+	SPDXID          string            `json:"SPDXID"`
+	Name            string            `json:"name"`
+	DocumentNamespace string          `json:"documentNamespace"`
+	CreationInfo    spdxCreationInfo  `json:"creationInfo"`
+	Packages        []spdxPackageJSON `json:"packages"`
+	Relationships   []spdxRelJSON     `json:"relationships,omitempty"`
+}
+
+type spdxCreationInfo struct {
+	Created  string   `json:"created"`
+	Creators []string `json:"creators"`
+}
+
+type spdxPackageJSON struct {
+	Name                  string `json:"name"`
+	SPDXID                string `json:"SPDXID"`
+	Version               string `json:"versionInfo,omitempty"`
+	DownloadLocation      string `json:"downloadLocation"`
+	FilesAnalyzed         bool   `json:"filesAnalyzed"`
+	LicenseConcluded      string `json:"licenseConcluded"`
+	LicenseDeclared       string `json:"licenseDeclared"`
+	CopyrightText         string `json:"copyrightText"`
+	PrimaryPackagePurpose string `json:"primaryPackagePurpose,omitempty"`
+}
+
+type spdxRelJSON struct {
+	SpdxElementID      string `json:"spdxElementId"`
+	RelationshipType   string `json:"relationshipType"`
+	RelatedSpdxElement string `json:"relatedSpdxElement"`
+}
+
+func writeJSON(w io.Writer, doc Document) error {
+	v := "SPDX-" + doc.SpecVersion
+	jdoc := spdxDocJSON{
+		SpdxVersion:       v,
+		DataLicense:       "CC0-1.0",
+		SPDXID:            doc.SPDXID,
+		Name:              doc.DocumentName,
+		DocumentNamespace: doc.Namespace,
+		CreationInfo: spdxCreationInfo{
+			Created: doc.Created,
+			Creators: []string{
+				"Tool: " + doc.CreatorTool,
+				"Organization: " + doc.CreatorOrg,
+			},
+		},
+	}
+
+	for _, pkg := range doc.Packages {
+		jp := spdxPackageJSON{
+			Name:             pkg.Name,
+			SPDXID:           pkg.SPDXID,
+			Version:          pkg.Version,
+			DownloadLocation: noassertion(pkg.DownloadURL),
+			FilesAnalyzed:    false,
+			LicenseConcluded: noassertion(pkg.License),
+			LicenseDeclared:  noassertion(pkg.License),
+			CopyrightText:    "NOASSERTION",
+		}
+		if doc.SpecVersion == "3.0.1" {
+			jp.PrimaryPackagePurpose = "LIBRARY"
+		}
+		jdoc.Packages = append(jdoc.Packages, jp)
+		jdoc.Relationships = append(jdoc.Relationships, spdxRelJSON{
+			SpdxElementID:      doc.SPDXID,
+			RelationshipType:   "DESCRIBES",
+			RelatedSpdxElement: pkg.SPDXID,
+		})
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(jdoc)
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func packageVerificationCode(pkg Package) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s@%s", pkg.Name, pkg.Version)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+func timestamp() string {
+	return time.Now().UTC().Format("20060102T150405Z")
+}

--- a/tools/sbom/main.go
+++ b/tools/sbom/main.go
@@ -89,34 +89,41 @@ func main() {
 		os.Exit(1)
 	}
 
-	switch *version {
-	case "2.2", "2.3", "3.0.1":
-	default:
-		fmt.Fprintf(os.Stderr, "unsupported SPDX version %q (use 2.2, 2.3, or 3.0.1)\n", *version)
+	if err := run(*version, *format, *outPath, *docName, *ns, os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
 
-	switch *format {
+// run validates the options, enumerates module dependencies, builds the SPDX
+// document and writes it to outPath (or to stdout when outPath is ""). It is
+// the testable core of main(): main() only wires argparse flags to it.
+func run(version, format, outPath, docName, ns string, stdout io.Writer) error {
+	switch version {
+	case "2.2", "2.3", "3.0.1":
+	default:
+		return fmt.Errorf("unsupported SPDX version %q (use 2.2, 2.3, or 3.0.1)", version)
+	}
+
+	switch format {
 	case "tv", "json":
 	default:
-		fmt.Fprintf(os.Stderr, "unsupported format %q (use tv or json)\n", *format)
-		os.Exit(1)
+		return fmt.Errorf("unsupported format %q (use tv or json)", format)
 	}
 
 	pkgs, err := goListPackages()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "go list: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("go list: %w", err)
 	}
 
-	namespace := *ns
+	namespace := ns
 	if namespace == "" {
-		namespace = "https://spdx.org/spdxdocs/" + *docName + "-" + timestamp()
+		namespace = "https://spdx.org/spdxdocs/" + docName + "-" + timestamp()
 	}
 
 	doc := Document{
-		SpecVersion:  *version,
-		DocumentName: *docName,
+		SpecVersion:  version,
+		DocumentName: docName,
 		SPDXID:       "SPDXRef-DOCUMENT",
 		Namespace:    namespace,
 		Created:      time.Now().UTC().Format(time.RFC3339),
@@ -125,31 +132,23 @@ func main() {
 		Packages:     pkgs,
 	}
 
-	var w io.Writer = os.Stdout
-	if *outPath != "" {
-		if err := os.MkdirAll(filepath.Dir(*outPath), 0755); err != nil {
-			fmt.Fprintf(os.Stderr, "mkdir: %v\n", err)
-			os.Exit(1)
+	w := stdout
+	if outPath != "" {
+		if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+			return fmt.Errorf("mkdir: %w", err)
 		}
-		f, err := os.Create(*outPath)
+		f, err := os.Create(outPath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "create %s: %v\n", *outPath, err)
-			os.Exit(1)
+			return fmt.Errorf("create %s: %w", outPath, err)
 		}
 		defer f.Close()
 		w = f
 	}
 
-	switch *format {
-	case "json":
-		err = writeJSON(w, doc)
-	default:
-		err = writeTV(w, doc)
+	if format == "json" {
+		return writeJSON(w, doc)
 	}
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "write: %v\n", err)
-		os.Exit(1)
-	}
+	return writeTV(w, doc)
 }
 
 // ── go list integration ───────────────────────────────────────────────────────

--- a/tools/sbom/run_coverage_test.go
+++ b/tools/sbom/run_coverage_test.go
@@ -1,0 +1,69 @@
+package main
+
+// Coverage for run() (the testable core extracted from main) and
+// goListPackages, which the original suite left at 0%.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGoListPackages_ListsModules(t *testing.T) {
+	pkgs, err := goListPackages()
+	if err != nil {
+		t.Fatalf("goListPackages: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatal("expected at least the main module")
+	}
+	for _, p := range pkgs {
+		if p.Name == "" {
+			t.Errorf("package missing Name: %+v", p)
+		}
+		if !strings.HasPrefix(p.SPDXID, "SPDXRef-Package-") {
+			t.Errorf("unexpected SPDXID %q", p.SPDXID)
+		}
+	}
+}
+
+func TestRun_TVToFile(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "sub", "sbom.spdx")
+	if err := run("2.3", "tv", out, "vissr", "", &bytes.Buffer{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "SPDXVersion:") || !strings.Contains(s, "SPDXID: SPDXRef-DOCUMENT") {
+		t.Errorf("tag-value output missing SPDX header: %.200s", s)
+	}
+}
+
+func TestRun_JSONToStdout(t *testing.T) {
+	var buf bytes.Buffer
+	if err := run("3.0.1", "json", "", "vissr", "https://example.com/ns", &buf); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"spdxVersion"`) && !strings.Contains(buf.String(), `"SPDXID"`) {
+		t.Errorf("json output missing SPDX fields: %.200s", buf.String())
+	}
+}
+
+func TestRun_UnsupportedVersion(t *testing.T) {
+	err := run("9.9", "tv", "", "vissr", "", &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "unsupported SPDX version") {
+		t.Errorf("expected unsupported-version error, got %v", err)
+	}
+}
+
+func TestRun_UnsupportedFormat(t *testing.T) {
+	err := run("2.3", "xml", "", "vissr", "", &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "unsupported format") {
+		t.Errorf("expected unsupported-format error, got %v", err)
+	}
+}

--- a/tools/sbom/sbom_test.go
+++ b/tools/sbom/sbom_test.go
@@ -1,0 +1,521 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func testDoc(version string, pkgs []Package) Document {
+	return Document{
+		SpecVersion:  version,
+		DocumentName: "test-doc",
+		SPDXID:       "SPDXRef-DOCUMENT",
+		Namespace:    "https://example.com/spdx/test",
+		Created:      "2026-06-08T00:00:00Z",
+		CreatorTool:  "vissr/tools/sbom",
+		CreatorOrg:   "COVESA",
+		Packages:     pkgs,
+	}
+}
+
+func testPkgs() []Package {
+	return []Package{
+		{Name: "example.com/foo", Version: "v1.2.3", SPDXID: "SPDXRef-Package-1", DownloadURL: "https://pkg.go.dev/example.com/foo@v1.2.3"},
+		{Name: "example.com/bar", Version: "v0.1.0", SPDXID: "SPDXRef-Package-2", DownloadURL: "https://pkg.go.dev/example.com/bar@v0.1.0"},
+	}
+}
+
+// ── noassertion ──────────────────────────────────────────────────────────────
+
+func TestNoassertion_Empty(t *testing.T) {
+	if got := noassertion(""); got != "NOASSERTION" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestNoassertion_NonEmpty(t *testing.T) {
+	if got := noassertion("Apache-2.0"); got != "Apache-2.0" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// ── downloadURL ──────────────────────────────────────────────────────────────
+
+func TestDownloadURL_WithVersion(t *testing.T) {
+	got := downloadURL("github.com/foo/bar", "v1.0.0")
+	want := "https://pkg.go.dev/github.com/foo/bar@v1.0.0"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestDownloadURL_NoVersion(t *testing.T) {
+	if got := downloadURL("github.com/foo/bar", ""); got != "NOASSERTION" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// ── timestamp ─────────────────────────────────────────────────────────────────
+
+func TestTimestamp_Format(t *testing.T) {
+	ts := timestamp()
+	if _, err := time.Parse("20060102T150405Z", ts); err != nil {
+		t.Fatalf("timestamp %q does not parse: %v", ts, err)
+	}
+}
+
+// ── packageVerificationCode ──────────────────────────────────────────────────
+
+func TestPackageVerificationCode_Deterministic(t *testing.T) {
+	pkg := Package{Name: "example.com/foo", Version: "v1.0.0"}
+	a := packageVerificationCode(pkg)
+	b := packageVerificationCode(pkg)
+	if a != b {
+		t.Fatalf("non-deterministic: %q != %q", a, b)
+	}
+}
+
+func TestPackageVerificationCode_Hex64(t *testing.T) {
+	pkg := Package{Name: "example.com/foo", Version: "v1.0.0"}
+	code := packageVerificationCode(pkg)
+	if len(code) != 64 {
+		t.Fatalf("expected 64-char hex, got len=%d: %q", len(code), code)
+	}
+	for _, c := range code {
+		if !('0' <= c && c <= '9') && !('a' <= c && c <= 'f') {
+			t.Fatalf("non-hex char %q in %q", c, code)
+		}
+	}
+}
+
+func TestPackageVerificationCode_DiffersByInput(t *testing.T) {
+	a := packageVerificationCode(Package{Name: "foo", Version: "v1"})
+	b := packageVerificationCode(Package{Name: "foo", Version: "v2"})
+	if a == b {
+		t.Fatalf("different packages produced same code")
+	}
+}
+
+// ── writeTV ───────────────────────────────────────────────────────────────────
+
+func TestWriteTV_Header22(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.2", testPkgs())
+	if err := writeTV(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	assertContains(t, out, "SPDXVersion: SPDX-2.2")
+	assertContains(t, out, "DataLicense: CC0-1.0")
+	assertContains(t, out, "SPDXID: SPDXRef-DOCUMENT")
+	assertContains(t, out, "DocumentName: test-doc")
+	assertContains(t, out, "DocumentNamespace: https://example.com/spdx/test")
+	assertContains(t, out, "Creator: Tool: vissr/tools/sbom")
+	assertContains(t, out, "Creator: Organization: COVESA")
+	assertContains(t, out, "Created: 2026-06-08T00:00:00Z")
+}
+
+func TestWriteTV_PackageFields(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.3", testPkgs())
+	if err := writeTV(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	assertContains(t, out, "PackageName: example.com/foo")
+	assertContains(t, out, "PackageVersion: v1.2.3")
+	assertContains(t, out, "PackageDownloadLocation: https://pkg.go.dev/example.com/foo@v1.2.3")
+	assertContains(t, out, "FilesAnalyzed: false")
+	assertContains(t, out, "PackageLicenseConcluded: NOASSERTION")
+	assertContains(t, out, "PackageLicenseDeclared: NOASSERTION")
+	assertContains(t, out, "PackageCopyrightText: NOASSERTION")
+	assertContains(t, out, "Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1")
+}
+
+func TestWriteTV_Version301HasVerificationCode(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("3.0.1", testPkgs())
+	if err := writeTV(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	assertContains(t, out, "PackageVerificationCode:")
+}
+
+func TestWriteTV_Version22NoVerificationCode(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.2", testPkgs())
+	if err := writeTV(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "PackageVerificationCode:") {
+		t.Fatal("2.2 output should not contain PackageVerificationCode")
+	}
+}
+
+func TestWriteTV_EmptyPackages(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.3", nil)
+	if err := writeTV(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	assertContains(t, out, "SPDXVersion: SPDX-2.3")
+	if strings.Contains(out, "PackageName:") {
+		t.Fatal("no packages expected in output")
+	}
+}
+
+func TestWriteTV_NoVersionField_EmptyVersion(t *testing.T) {
+	var buf bytes.Buffer
+	pkgs := []Package{{Name: "example.com/foo", Version: "", SPDXID: "SPDXRef-Package-1"}}
+	doc := testDoc("2.3", pkgs)
+	if err := writeTV(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "PackageVersion:") {
+		t.Fatal("PackageVersion should be omitted when empty")
+	}
+}
+
+func TestWriteTV_MultiplePackages(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.3", testPkgs())
+	if err := writeTV(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	assertContains(t, out, "PackageName: example.com/foo")
+	assertContains(t, out, "PackageName: example.com/bar")
+}
+
+func TestWriteTV_LicenseSet(t *testing.T) {
+	var buf bytes.Buffer
+	pkgs := []Package{{
+		Name:    "example.com/foo",
+		Version: "v1.0.0",
+		SPDXID:  "SPDXRef-Package-1",
+		License: "MIT",
+	}}
+	doc := testDoc("2.3", pkgs)
+	if err := writeTV(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	assertContains(t, out, "PackageLicenseConcluded: MIT")
+	assertContains(t, out, "PackageLicenseDeclared: MIT")
+}
+
+// ── writeJSON ─────────────────────────────────────────────────────────────────
+
+func TestWriteJSON_ValidJSON(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.3", testPkgs())
+	if err := writeJSON(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+}
+
+func TestWriteJSON_HeaderFields(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.3", testPkgs())
+	if err := writeJSON(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	var jd spdxDocJSON
+	if err := json.Unmarshal(buf.Bytes(), &jd); err != nil {
+		t.Fatal(err)
+	}
+	if jd.SpdxVersion != "SPDX-2.3" {
+		t.Fatalf("spdxVersion=%q", jd.SpdxVersion)
+	}
+	if jd.DataLicense != "CC0-1.0" {
+		t.Fatalf("dataLicense=%q", jd.DataLicense)
+	}
+	if jd.SPDXID != "SPDXRef-DOCUMENT" {
+		t.Fatalf("SPDXID=%q", jd.SPDXID)
+	}
+	if jd.Name != "test-doc" {
+		t.Fatalf("name=%q", jd.Name)
+	}
+	if jd.DocumentNamespace != "https://example.com/spdx/test" {
+		t.Fatalf("namespace=%q", jd.DocumentNamespace)
+	}
+}
+
+func TestWriteJSON_CreationInfo(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.3", testPkgs())
+	if err := writeJSON(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	var jd spdxDocJSON
+	if err := json.Unmarshal(buf.Bytes(), &jd); err != nil {
+		t.Fatal(err)
+	}
+	if jd.CreationInfo.Created != "2026-06-08T00:00:00Z" {
+		t.Fatalf("created=%q", jd.CreationInfo.Created)
+	}
+	if len(jd.CreationInfo.Creators) != 2 {
+		t.Fatalf("creators len=%d", len(jd.CreationInfo.Creators))
+	}
+}
+
+func TestWriteJSON_PackageCount(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.3", testPkgs())
+	if err := writeJSON(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	var jd spdxDocJSON
+	if err := json.Unmarshal(buf.Bytes(), &jd); err != nil {
+		t.Fatal(err)
+	}
+	if len(jd.Packages) != 2 {
+		t.Fatalf("packages len=%d", len(jd.Packages))
+	}
+}
+
+func TestWriteJSON_RelationshipCount(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.3", testPkgs())
+	if err := writeJSON(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	var jd spdxDocJSON
+	if err := json.Unmarshal(buf.Bytes(), &jd); err != nil {
+		t.Fatal(err)
+	}
+	if len(jd.Relationships) != 2 {
+		t.Fatalf("relationships len=%d", len(jd.Relationships))
+	}
+	for _, r := range jd.Relationships {
+		if r.RelationshipType != "DESCRIBES" {
+			t.Fatalf("unexpected relationship type %q", r.RelationshipType)
+		}
+		if r.SpdxElementID != "SPDXRef-DOCUMENT" {
+			t.Fatalf("unexpected elementId %q", r.SpdxElementID)
+		}
+	}
+}
+
+func TestWriteJSON_Version301HasPrimaryPurpose(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("3.0.1", testPkgs())
+	if err := writeJSON(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	var jd spdxDocJSON
+	if err := json.Unmarshal(buf.Bytes(), &jd); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range jd.Packages {
+		if p.PrimaryPackagePurpose != "LIBRARY" {
+			t.Fatalf("package %q missing LIBRARY purpose", p.Name)
+		}
+	}
+}
+
+func TestWriteJSON_Version22NoPrimaryPurpose(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.2", testPkgs())
+	if err := writeJSON(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	var jd spdxDocJSON
+	if err := json.Unmarshal(buf.Bytes(), &jd); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range jd.Packages {
+		if p.PrimaryPackagePurpose != "" {
+			t.Fatalf("package %q should not have primaryPackagePurpose in 2.2", p.Name)
+		}
+	}
+}
+
+func TestWriteJSON_EmptyPackages(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.3", nil)
+	if err := writeJSON(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	var jd spdxDocJSON
+	if err := json.Unmarshal(buf.Bytes(), &jd); err != nil {
+		t.Fatal(err)
+	}
+	if len(jd.Packages) != 0 {
+		t.Fatalf("expected 0 packages")
+	}
+}
+
+func TestWriteJSON_FilesAnalyzedFalse(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.3", testPkgs())
+	if err := writeJSON(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	var jd spdxDocJSON
+	if err := json.Unmarshal(buf.Bytes(), &jd); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range jd.Packages {
+		if p.FilesAnalyzed {
+			t.Fatalf("package %q filesAnalyzed should be false", p.Name)
+		}
+	}
+}
+
+func TestWriteJSON_LicenseSet(t *testing.T) {
+	var buf bytes.Buffer
+	pkgs := []Package{{
+		Name:    "example.com/foo",
+		Version: "v1.0.0",
+		SPDXID:  "SPDXRef-Package-1",
+		License: "Apache-2.0",
+	}}
+	doc := testDoc("2.3", pkgs)
+	if err := writeJSON(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	var jd spdxDocJSON
+	if err := json.Unmarshal(buf.Bytes(), &jd); err != nil {
+		t.Fatal(err)
+	}
+	if jd.Packages[0].LicenseConcluded != "Apache-2.0" {
+		t.Fatalf("licenseConcluded=%q", jd.Packages[0].LicenseConcluded)
+	}
+}
+
+func TestWriteJSON_Indented(t *testing.T) {
+	var buf bytes.Buffer
+	doc := testDoc("2.3", testPkgs())
+	if err := writeJSON(&buf, doc); err != nil {
+		t.Fatal(err)
+	}
+	// Indented output must have newlines and leading spaces.
+	if !strings.Contains(buf.String(), "\n  ") {
+		t.Fatal("expected indented JSON")
+	}
+}
+
+// ── all three spec versions produce valid output ──────────────────────────────
+
+func TestAllVersions_TV(t *testing.T) {
+	for _, v := range []string{"2.2", "2.3", "3.0.1"} {
+		t.Run(v, func(t *testing.T) {
+			var buf bytes.Buffer
+			doc := testDoc(v, testPkgs())
+			if err := writeTV(&buf, doc); err != nil {
+				t.Fatal(err)
+			}
+			assertContains(t, buf.String(), "SPDXVersion: SPDX-"+v)
+		})
+	}
+}
+
+func TestAllVersions_JSON(t *testing.T) {
+	for _, v := range []string{"2.2", "2.3", "3.0.1"} {
+		t.Run(v, func(t *testing.T) {
+			var buf bytes.Buffer
+			doc := testDoc(v, testPkgs())
+			if err := writeJSON(&buf, doc); err != nil {
+				t.Fatal(err)
+			}
+			var raw map[string]interface{}
+			if err := json.Unmarshal(buf.Bytes(), &raw); err != nil {
+				t.Fatalf("not valid JSON for v%s: %v", v, err)
+			}
+			if raw["spdxVersion"] != "SPDX-"+v {
+				t.Fatalf("spdxVersion=%q", raw["spdxVersion"])
+			}
+		})
+	}
+}
+
+// ── fuzz ──────────────────────────────────────────────────────────────────────
+
+func FuzzWriteTV(f *testing.F) {
+	f.Add("2.2", "example.com/foo", "v1.0.0", "MIT")
+	f.Add("2.3", "", "", "")
+	f.Add("3.0.1", "a/b/c", "v0.0.1", "Apache-2.0")
+	f.Add("2.3", "x", "v999.999.999", "NOASSERTION")
+
+	f.Fuzz(func(t *testing.T, version, pkgName, pkgVer, license string) {
+		doc := Document{
+			SpecVersion:  version,
+			DocumentName: "fuzz",
+			SPDXID:       "SPDXRef-DOCUMENT",
+			Namespace:    "https://fuzz.example.com",
+			Created:      "2026-06-08T00:00:00Z",
+			CreatorTool:  "sbom",
+			CreatorOrg:   "test",
+			Packages: []Package{{
+				Name:    pkgName,
+				Version: pkgVer,
+				SPDXID:  "SPDXRef-Package-1",
+				License: license,
+			}},
+		}
+		var buf bytes.Buffer
+		_ = writeTV(&buf, doc) // must not panic
+	})
+}
+
+func FuzzWriteJSON(f *testing.F) {
+	f.Add("2.2", "example.com/foo", "v1.0.0", "MIT")
+	f.Add("2.3", "", "", "")
+	f.Add("3.0.1", "a/b/c", "v0.0.1", "Apache-2.0")
+	f.Add("2.3", "x", "v999.999.999", "NOASSERTION")
+
+	f.Fuzz(func(t *testing.T, version, pkgName, pkgVer, license string) {
+		doc := Document{
+			SpecVersion:  version,
+			DocumentName: "fuzz",
+			SPDXID:       "SPDXRef-DOCUMENT",
+			Namespace:    "https://fuzz.example.com",
+			Created:      "2026-06-08T00:00:00Z",
+			CreatorTool:  "sbom",
+			CreatorOrg:   "test",
+			Packages: []Package{{
+				Name:    pkgName,
+				Version: pkgVer,
+				SPDXID:  "SPDXRef-Package-1",
+				License: license,
+			}},
+		}
+		var buf bytes.Buffer
+		_ = writeJSON(&buf, doc) // must not panic
+	})
+}
+
+func FuzzDownloadURL(f *testing.F) {
+	f.Add("github.com/foo/bar", "v1.0.0")
+	f.Add("", "")
+	f.Add("x", "")
+	f.Add("github.com/foo/bar", "")
+
+	f.Fuzz(func(t *testing.T, path, version string) {
+		got := downloadURL(path, version)
+		if got == "" {
+			t.Fatal("downloadURL must not return empty string")
+		}
+	})
+}
+
+// ── assertions ────────────────────────────────────────────────────────────────
+
+func assertContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Fatalf("expected output to contain %q\ngot:\n%s", needle, haystack)
+	}
+}


### PR DESCRIPTION
## Summary
Adds `tools/sbom`, a CLI that generates Software Bill of Materials from `go list -m` in three formats — SPDX 2.2 (tag-value), SPDX 2.3 (JSON), and SPDX 3.0.1 (JSON) — plus a CI workflow (`.github/workflows/sbom.yml`) that attaches the SBOMs to every release.

General supply-chain tooling, independent of the service profile / VDM — placed on the `v3.2` line per the agreed split (only VDM/S2DM stay on `v4.0`).

## Testing
`go build ./tools/sbom/...`, `go vet`, and `go test ./tools/sbom/...` pass. Documented in README and TESTING.

Independent of #173/#174 (no shared code paths); can merge in any order on `v3.2`.