### PR TITLE
feat(vdm): live reload of VDM SDL via fsnotify (+ himForest race fix)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,32 @@ jobs:
       - name: test all packages (race)
         # paho-mqtt is excluded here; it is tested in the mqtt-tests job
         # below where a real Mosquitto broker is available.
+        # smoketest is excluded (build-tag smoke) — covered by the smoke-test job.
         run: |
-          go list ./... | grep -v 'paho-mqtt' | xargs go test -race -count=1 -timeout 5m
+          go list ./... | grep -v 'paho-mqtt' | grep -v 'smoketest' | xargs go test -race -count=1 -timeout 5m
+
+      - name: smoke - vdminfo
+        run: go run ./tools/vdminfo ./server/vissv2server/vdmloader/testdata/
+
+  # ------------------------------------------------------------------ #
+  #  End-to-end smoke test — starts vissv2server with the VDM testdata  #
+  # ------------------------------------------------------------------ #
+  smoke-test:
+    name: Smoke test (WS end-to-end)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: create /var/tmp/vissv2
+        run: mkdir -p /var/tmp/vissv2
+
+      - name: smoke test (WS end-to-end)
+        run: go test -v -tags smoke -timeout 120s ./server/vissv2server/smoketest/
 
   # ------------------------------------------------------------------ #
   #  MQTT integration tests - requires the mosquitto broker container   #

--- a/TESTING.md
+++ b/TESTING.md
@@ -76,6 +76,7 @@ fuzzers=(
     'FuzzProcessHistoryGet      ./server/vissv2server/serviceMgr'
     'FuzzMapRequest             ./utils'
     'FuzzJsonSchemaValidate     ./utils'
+    'FuzzIsGraphQL              ./server/vissv2server/vdmloader'
     'FuzzGetFileDescriptorData  ./server/vissv2server'
     'FuzzGetRangeBoundaries     ./server/vissv2server'
     'FuzzGetValueForKey         ./server/vissv2server/wsMgr'
@@ -194,6 +195,18 @@ points are tested via runtest.sh integration.
 Covers `fileExists`, `deSerializeUInt` (1/2/4-byte), `inFeederScope`,
 `splitToDomainDataAndTs`, `convertToDomainData`, `makeDataPoint`,
 `calcInputValue`, `incDpIndex`, `enumConversion`, `linearConversion`.
+
+#### VDM live-reload watcher (v4.1)
+
+| Area                                                   | Test file                                              |
+|--------------------------------------------------------|--------------------------------------------------------|
+| `isGraphQL` path filter + `FuzzIsGraphQL`              | `server/vissv2server/vdmloader/watcher_test.go`        |
+| `graphqlFiles` directory scan                          | `server/vissv2server/vdmloader/watcher_test.go`        |
+| `currentRootNames` (parse without registering)         | `server/vissv2server/vdmloader/watcher_test.go`        |
+| `NewWatcher` non-existent dir error                    | `server/vissv2server/vdmloader/watcher_test.go`        |
+| `Watcher.Stop` + stopped channel                       | `server/vissv2server/vdmloader/watcher_test.go`        |
+| Live reload on write, create, delete (end-to-end)      | `server/vissv2server/vdmloader/watcher_test.go`        |
+| `himForestMu` race — `RegisterServiceTree` + `GetForestRoot` concurrent | `server/vissv2server/vdmloader/watcher_test.go` (`-race`) |
 
 ## Functions that need code refactoring to be unit-testable
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,42 @@
+# Local test environment: starts the mosquitto TLS broker so you can run
+# all tests natively against a live MQTT broker.
+#
+# USAGE
+#   1. Start the broker:
+#        docker compose -f docker-compose.test.yml up -d
+#        docker compose -f docker-compose.test.yml ps   # wait for healthy
+#
+#   2. Trust the self-signed CA (one-time per machine):
+#        macOS:
+#          sudo security add-trusted-cert -d -r trustRoot \
+#            -k /Library/Keychains/System.keychain paho-mqtt/cert/ca.crt
+#        Linux:
+#          sudo cp paho-mqtt/cert/ca.crt /usr/local/share/ca-certificates/vissr-mqtt-ca.crt
+#          sudo update-ca-certificates
+#
+#   3. Run tests:
+#        go test -race -count=1 ./server/vissv2server/vissServiceMgr/...
+#        go test -race -count=1 ./server/vissv2server/vissServiceSDK/...
+#        go test -v  -count=1 ./paho-mqtt/...
+#
+#   4. Tear down:
+#        docker compose -f docker-compose.test.yml down
+
+version: "3.9"
+
+services:
+  mosquitto:
+    build:
+      context: ./paho-mqtt
+    ports:
+      - "8883:8883"
+    healthcheck:
+      test:
+        - CMD
+        - sh
+        - -c
+        - "mosquitto_pub -h localhost -p 8883 --cafile /etc/mosquitto/ca.crt -u homesecurity -P rocktheworld -t _ci/health -m ping --quiet"
+      interval: 3s
+      timeout: 5s
+      retries: 10
+      start_period: 5s

--- a/go.mod
+++ b/go.mod
@@ -25,10 +25,12 @@ require (
 )
 
 require (
+	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/apache/thrift v0.15.0 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.32.0 // indirect
 	github.com/qri-io/jsonpointer v0.1.1 // indirect
+	github.com/vektah/gqlparser/v2 v2.5.33 // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/covesa/vissr
 
-go 1.22.1
+go 1.23
 
 //replace github.com/COVESA/vss-tools/binary/go_parser/datamodel => /home/ubjorken/Proj/covesa/vss-tools/binary/go_parser/datamodel
 //replace github.com/COVESA/vss-tools/binary/go_parser/parserlib => /home/ubjorken/Proj/covesa/vss-tools/binary/go_parser/parserlib
@@ -27,6 +27,7 @@ require (
 require (
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/apache/thrift v0.15.0 // indirect
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.32.0 // indirect
 	github.com/qri-io/jsonpointer v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
+github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/akamensky/argparse v1.4.0 h1:YGzvsTqCvbEZhL8zZu2AiA5nq805NZh75JNj4ajn1xc=
 github.com/akamensky/argparse v1.4.0/go.mod h1:S5kwC7IuDcEr5VeXtGPRVZ5o/FdhcMlQz4IZQuw64xA=
 github.com/apache/iotdb-client-go v1.1.7 h1:MH87LJNquMxHmFKWuS06CFwxgEjxK5oug6H5lKCa74w=
@@ -62,6 +64,7 @@ github.com/qri-io/jsonschema v0.2.1 h1:NNFoKms+kut6ABPf6xiKNM5214jzxAhDBrPHCJ97W
 github.com/qri-io/jsonschema v0.2.1/go.mod h1:g7DPkiOsK1xv6T/Ao5scXRkd+yTFygcANPBaaqW+VrI=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -74,6 +77,9 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/vektah/gqlparser/v2 v2.5.33 h1:lRp8aIeNUNbimf/axZd7ETg24q06hBtPaas+TcvI/7E=
+github.com/vektah/gqlparser/v2 v2.5.33/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6OG2amkBAFmgts=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/eclipse/paho.mqtt.golang v1.4.3/go.mod h1:CSYvoAlsMkhYOXh/oKyxa8EcBci
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
 github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=

--- a/server/vissv2server/smoketest/smoke_test.go
+++ b/server/vissv2server/smoketest/smoke_test.go
@@ -1,0 +1,190 @@
+//go:build smoke
+
+// Package smoketest starts vissv2server as a subprocess and verifies
+// end-to-end VISS WebSocket responses without any external infrastructure.
+//
+// Run with:
+//
+//	go test -v -tags smoke -timeout 120s ./server/vissv2server/smoketest/
+//
+// Integration-only — NOT included in the standard unit-test sweep.
+package smoketest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+var (
+	// builtBin is the path to the pre-built vissv2server binary.
+	// Populated by TestMain so both tests share one build.
+	builtBin string
+	// serverDir is the CWD for the server subprocess — relative paths
+	// (atServer/purposelist.json, etc.) resolve from here.
+	serverDir string
+)
+
+func TestMain(m *testing.M) {
+	// Locate the repository root from this source file's path.
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "TestMain: runtime.Caller failed")
+		os.Exit(1)
+	}
+	// file is .../server/vissv2server/smoketest/smoke_test.go — walk up 3
+	root := filepath.Join(filepath.Dir(file), "..", "..", "..")
+	serverDir = filepath.Join(root, "server", "vissv2server")
+
+	// serviceMgr creates a Unix socket here; create the dir if CI doesn't
+	// have it.
+	if err := os.MkdirAll("/var/tmp/vissv2", 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "TestMain: create /var/tmp/vissv2: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Build the binary once; reuse it for every test in this package.
+	bin := filepath.Join(os.TempDir(), "vissv2server-smoke-bin")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", bin, "./server/vissv2server/")
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "build vissv2server: %v\n%s\n", err, out)
+		os.Exit(1)
+	}
+	builtBin = bin
+
+	code := m.Run()
+	os.Remove(bin)
+	os.Exit(code)
+}
+
+// waitForPort polls addr until it accepts TCP connections or the deadline passes.
+func waitForPort(t *testing.T, addr string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("server did not open %s within %s", addr, timeout)
+}
+
+// startServer launches vissv2server with the in-repo VDM testdata and
+// none backend and registers a cleanup that kills it.
+func startServer(t *testing.T) {
+	t.Helper()
+	vdmDir := filepath.Join(serverDir, "vdmloader", "testdata")
+
+	srv := exec.Command(builtBin,
+		"--vdm", vdmDir,
+		"-s", "none",
+		"--loglevel", "error",
+	)
+	// Run from the server directory so relative paths resolve correctly.
+	// logs/ in that directory is gitignored.
+	srv.Dir = serverDir
+	srv.Stdout = os.Stdout
+	srv.Stderr = os.Stderr
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("start vissv2server: %v", err)
+	}
+	t.Cleanup(func() {
+		srv.Process.Kill()
+		srv.Wait()
+	})
+
+	waitForPort(t, "localhost:8080", 30*time.Second)
+}
+
+// TestSmoke_WsGetSpeed starts vissv2server with the in-repo VDM testdata
+// and an in-memory state backend, then verifies that a VISS WebSocket GET
+// for Vehicle.Speed returns a well-formed response.
+func TestSmoke_WsGetSpeed(t *testing.T) {
+	startServer(t)
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:8080/", nil)
+	if err != nil {
+		t.Fatalf("WebSocket dial: %v", err)
+	}
+	defer conn.Close()
+
+	req := `{"action":"get","path":"Vehicle.Speed","requestId":"smoke-1"}`
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(req)); err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(msg, &resp); err != nil {
+		t.Fatalf("response is not valid JSON: %v — raw: %s", err, msg)
+	}
+
+	action, _ := resp["action"].(string)
+	if action == "" {
+		t.Errorf("response missing 'action' field: %s", msg)
+	}
+	if resp["requestId"] == nil {
+		t.Errorf("response missing 'requestId' field: %s", msg)
+	}
+	// noneBackend returns data or a 404/503 — both are valid VISS responses
+	// that prove the full pipeline (WS→core→serviceMgr) ran.
+	if resp["data"] == nil && resp["error"] == nil {
+		t.Errorf("response has neither 'data' nor 'error' field: %s", msg)
+	}
+	fmt.Printf("smoke GET response: %s\n", msg)
+}
+
+// TestSmoke_WsSetRejected verifies that a SET on the none backend returns
+// a VISS error response (the none backend never stores values).
+func TestSmoke_WsSetRejected(t *testing.T) {
+	startServer(t)
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost:8080/", nil)
+	if err != nil {
+		t.Fatalf("WebSocket dial: %v", err)
+	}
+	defer conn.Close()
+
+	req := `{"action":"set","path":"Vehicle.Speed","value":"42","requestId":"smoke-2"}`
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(req)); err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(msg, &resp); err != nil {
+		t.Fatalf("response is not valid JSON: %v — raw: %s", err, msg)
+	}
+	fmt.Printf("smoke SET response: %s\n", msg)
+
+	// none backend cannot write — expect error field in response
+	if resp["error"] == nil && resp["data"] == nil {
+		t.Errorf("expected error or data field in set response: %s", msg)
+	}
+}

--- a/server/vissv2server/vdmloader/testdata/cabin.graphql
+++ b/server/vissv2server/vdmloader/testdata/cabin.graphql
@@ -1,0 +1,52 @@
+# cabin.graphql — VDM instance tag fixture for vdmloader unit tests.
+# Models Vehicle.Cabin with multi-instance Seat (Row × Side) and
+# single-instance Door (Row only).
+
+type Vehicle @vspec(element: BRANCH, fqn: "Vehicle", description: "Top-level vehicle object") {
+  Cabin: VehicleCabin @vspec(element: BRANCH, fqn: "Vehicle.Cabin")
+}
+
+type VehicleCabin @vspec(element: BRANCH, fqn: "Vehicle.Cabin", description: "Vehicle cabin") {
+  Seat: VehicleCabinSeat @vspec(element: BRANCH, fqn: "Vehicle.Cabin.Seat")
+  Door: VehicleCabinDoor @vspec(element: BRANCH, fqn: "Vehicle.Cabin.Door")
+}
+
+# ── Seat — 2D instance (Row × Side) ──────────────────────────────────────────
+
+type VehicleCabinSeat @vspec(element: BRANCH, fqn: "Vehicle.Cabin.Seat", description: "Individual seat") {
+  IsOccupied: Boolean @vspec(element: SENSOR,   fqn: "Vehicle.Cabin.Seat.IsOccupied", description: "Seat is occupied")
+  IsBelted:   Boolean @vspec(element: SENSOR,   fqn: "Vehicle.Cabin.Seat.IsBelted",   description: "Seatbelt fastened")
+  Position:   UInt8   @vspec(element: ACTUATOR, fqn: "Vehicle.Cabin.Seat.Position",   description: "Longitudinal position") @range(min: 0, max: 100)
+}
+
+type VehicleCabinSeat_InstanceTag @instanceTag @vspec(element: BRANCH, fqn: "Vehicle.Cabin.Seat") {
+  dimension1: VehicleCabinSeat_InstanceTag_Dimension1
+  dimension2: VehicleCabinSeat_InstanceTag_Dimension2
+}
+
+enum VehicleCabinSeat_InstanceTag_Dimension1 {
+  ROW1 @vspec(originalName: "Row1")
+  ROW2 @vspec(originalName: "Row2")
+}
+
+enum VehicleCabinSeat_InstanceTag_Dimension2 {
+  DRIVER_SIDE    @vspec(originalName: "DriverSide")
+  PASSENGER_SIDE @vspec(originalName: "PassengerSide")
+}
+
+# ── Door — 1D instance (Row only) ────────────────────────────────────────────
+
+type VehicleCabinDoor @vspec(element: BRANCH, fqn: "Vehicle.Cabin.Door", description: "Individual door") {
+  IsOpen:   Boolean @vspec(element: SENSOR,   fqn: "Vehicle.Cabin.Door.IsOpen",   description: "Door is open")
+  IsLocked: Boolean @vspec(element: ACTUATOR, fqn: "Vehicle.Cabin.Door.IsLocked", description: "Door is locked")
+}
+
+type VehicleCabinDoor_InstanceTag @instanceTag @vspec(element: BRANCH, fqn: "Vehicle.Cabin.Door") {
+  dimension1: VehicleCabinDoor_InstanceTag_Dimension1
+}
+
+enum VehicleCabinDoor_InstanceTag_Dimension1 {
+  ROW1 @vspec(originalName: "Row1")
+  ROW2 @vspec(originalName: "Row2")
+  ROW3 @vspec(originalName: "Row3")
+}

--- a/server/vissv2server/vdmloader/testdata/vehicle.graphql
+++ b/server/vissv2server/vdmloader/testdata/vehicle.graphql
@@ -1,0 +1,40 @@
+# Minimal VDM SDL fixture used by vdmloader unit tests.
+# Covers: branch nodes, SENSOR/ACTUATOR/ATTRIBUTE leaves,
+# @range bounds, @unit, @defaultValue, allowed-value enums,
+# nested hierarchy, and the @viss_service extension.
+
+enum VehicleGearPosition {
+  PARK     @vspec(originalName: "Park")
+  REVERSE  @vspec(originalName: "Reverse")
+  NEUTRAL  @vspec(originalName: "Neutral")
+  DRIVE    @vspec(originalName: "Drive")
+}
+
+type Vehicle @vspec(element: BRANCH, fqn: "Vehicle", description: "Top-level vehicle object") {
+  Speed:           Float               @vspec(element: SENSOR,    fqn: "Vehicle.Speed",           description: "Current speed") @range(min: 0, max: 250) @unit(value: "km/h")
+  TripMileage:     Float               @vspec(element: SENSOR,    fqn: "Vehicle.TripMileage",      description: "Trip distance") @unit(value: "km") @defaultValue(value: "0")
+  CurrentGear:     VehicleGearPosition @vspec(element: SENSOR,    fqn: "Vehicle.CurrentGear",      description: "Current gear") @defaultValue(value: "Park")
+  CurrentLocation: VehicleCurrentLocation @vspec(element: BRANCH, fqn: "Vehicle.CurrentLocation")
+  ADAS:            VehicleADAS         @vspec(element: BRANCH,    fqn: "Vehicle.ADAS")
+  Cabin:           VehicleCabin        @vspec(element: BRANCH,    fqn: "Vehicle.Cabin")
+}
+
+type VehicleCurrentLocation @vspec(element: BRANCH, fqn: "Vehicle.CurrentLocation", description: "Current location") {
+  Latitude:  Float @vspec(element: SENSOR, fqn: "Vehicle.CurrentLocation.Latitude",  description: "Latitude")  @range(min: -90,  max: 90)  @unit(value: "degrees")
+  Longitude: Float @vspec(element: SENSOR, fqn: "Vehicle.CurrentLocation.Longitude", description: "Longitude") @range(min: -180, max: 180) @unit(value: "degrees")
+  Altitude:  Float @vspec(element: SENSOR, fqn: "Vehicle.CurrentLocation.Altitude",  description: "Altitude")  @unit(value: "m")
+}
+
+type VehicleADAS @vspec(element: BRANCH, fqn: "Vehicle.ADAS", description: "Advanced driver-assistance systems") {
+  ActiveAutonomyLevel: String @vspec(element: ATTRIBUTE, fqn: "Vehicle.ADAS.ActiveAutonomyLevel", description: "Current autonomy level")
+  ABS: VehicleADASABS @vspec(element: BRANCH, fqn: "Vehicle.ADAS.ABS")
+}
+
+type VehicleADASABS @vspec(element: BRANCH, fqn: "Vehicle.ADAS.ABS", description: "Antilock braking system") {
+  IsEnabled: Boolean @vspec(element: ACTUATOR, fqn: "Vehicle.ADAS.ABS.IsEnabled", description: "Enable or disable ABS") @defaultValue(value: "false")
+  IsActive:  Boolean @vspec(element: SENSOR,   fqn: "Vehicle.ADAS.ABS.IsActive",  description: "ABS is currently active")
+}
+
+type VehicleCabin @vspec(element: BRANCH, fqn: "Vehicle.Cabin", description: "Vehicle cabin") {
+  Temperature: Float @vspec(element: SENSOR, fqn: "Vehicle.Cabin.Temperature", description: "Cabin temperature") @range(min: -40, max: 100) @unit(value: "celsius")
+}

--- a/server/vissv2server/vdmloader/vdmloader.go
+++ b/server/vissv2server/vdmloader/vdmloader.go
@@ -1,0 +1,703 @@
+// Package vdmloader parses COVESA VDM GraphQL SDL files and builds
+// vissr Node_t signal trees that can be registered in the HIM forest.
+//
+// VDM (Vehicle Data Model) uses GraphQL SDL with custom directives:
+//   - @vspec(element: BRANCH|SENSOR|ACTUATOR|ATTRIBUTE, fqn: "Dot.Sep.Path")
+//     on OBJECT → marks a type as a VSS tree node; on FIELD_DEFINITION → marks
+//     a scalar field as a signal leaf; on ENUM_VALUE → provides originalName.
+//   - @range(min: Float, max: Float) on FIELD_DEFINITION → numeric bounds.
+//   - @instanceTag on OBJECT → marks a type as a multi-instance template.
+//     The type must also carry @vspec(fqn:) and have fields dimension1,
+//     dimension2, … each typed as an enum of allowed instance values.
+//   - @viss_service on FIELD_DEFINITION → marks a field as a service procedure
+//     entry point (v4.0 extension; not in upstream VDM yet).
+//
+// Instance tag expansion: types named *_InstanceTag and bearing @instanceTag
+// are expanded by the loader into full per-instance subtrees. For example,
+// a Seat_InstanceTag with Dimension1=[Row1,Row2] × Dimension2=[DriverSide,PassengerSide]
+// produces branch nodes at Vehicle.Cabin.Seat.Row1.DriverSide, .Row1.PassengerSide, etc.,
+// each containing a deep clone of the original Seat signal subtree.
+package vdmloader
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/covesa/vissr/utils"
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// vdmPreamble defines the directives and custom scalars needed to parse any VDM SDL.
+// It is prepended to every SDL string before parsing.
+const vdmPreamble = `
+directive @vspec(
+  element: VspecElement
+  fqn: String
+  description: String
+  comment: String
+  deprecation: String
+  originalName: String
+  unit: String
+) on OBJECT | FIELD_DEFINITION | ENUM_VALUE
+
+directive @range(min: Float, max: Float) on FIELD_DEFINITION
+directive @unit(value: String!) on FIELD_DEFINITION
+directive @defaultValue(value: String!) on FIELD_DEFINITION
+directive @instanceTag on OBJECT
+directive @viss_service on FIELD_DEFINITION
+
+enum VspecElement {
+  BRANCH
+  SENSOR
+  ACTUATOR
+  ATTRIBUTE
+  STRUCT
+  PROPERTY
+}
+
+scalar Int8
+scalar UInt8
+scalar Int16
+scalar UInt16
+scalar UInt32
+scalar Int64
+scalar UInt64
+`
+
+// TreeMeta holds the metadata extracted alongside each root Node_t.
+type TreeMeta struct {
+	RootName string // first FQN segment, e.g. "Vehicle"
+	Domain   string // same as RootName; last segment is used as vissr info type
+	Version  string // from schema @specifiedBy or directory convention
+}
+
+// dimValue pairs an enum value name with the expanded path-segment name.
+type dimValue struct {
+	origName string // e.g. "Row1", "DriverSide" — used as Node_t.Name
+}
+
+// LoadDir scans dir for *.graphql files, parses each as VDM SDL, and
+// registers the resulting Node_t trees in the vissr HIM forest via
+// utils.RegisterServiceTree. Returns the number of trees registered.
+func LoadDir(dir string) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, fmt.Errorf("vdmloader: reading %s: %w", dir, err)
+	}
+
+	total := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".graphql") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return total, fmt.Errorf("vdmloader: reading %s: %w", path, err)
+		}
+		roots, metas, err := ParseSDL(string(data))
+		if err != nil {
+			return total, fmt.Errorf("vdmloader: parsing %s: %w", path, err)
+		}
+		for i, root := range roots {
+			if !utils.RegisterServiceTree(metas[i].RootName, metas[i].Domain, metas[i].Version, root) {
+				utils.Info.Printf("vdmloader: tree %s already registered, skipping", metas[i].RootName)
+			} else {
+				total++
+			}
+		}
+	}
+	return total, nil
+}
+
+// ParseFile parses a single VDM SDL file and returns root nodes and metadata.
+func ParseFile(path string) ([]*utils.Node_t, []TreeMeta, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("vdmloader: reading %s: %w", path, err)
+	}
+	return ParseSDL(string(data))
+}
+
+// ParseSDL parses a VDM GraphQL SDL string and returns the built Node_t trees
+// (one per FQN root) together with their metadata.
+func ParseSDL(sdl string) ([]*utils.Node_t, []TreeMeta, error) {
+	src := &ast.Source{
+		Name:  "vdm.graphql",
+		Input: vdmPreamble + sdl,
+	}
+
+	schema, gqlErr := gqlparser.LoadSchema(src)
+	if gqlErr != nil {
+		return nil, nil, fmt.Errorf("vdmloader: SDL parse error: %v", gqlErr)
+	}
+
+	// fqnMap: FQN → node
+	fqnMap := make(map[string]*utils.Node_t)
+
+	for _, t := range schema.Types {
+		if t.BuiltIn {
+			continue
+		}
+		typeFQN, typeElem := vspecDirectiveArgs(t.Directives)
+		if typeFQN != "" && typeElem == "BRANCH" {
+			if _, ok := fqnMap[typeFQN]; !ok {
+				name := lastSegment(typeFQN)
+				fqnMap[typeFQN] = utils.NewBranchNode(name)
+			}
+		}
+		for _, f := range t.Fields {
+			fieldFQN, fieldElem := vspecDirectiveArgs(f.Directives)
+			if fieldFQN == "" {
+				continue
+			}
+			name := lastSegment(fieldFQN)
+
+			// @viss_service overrides element → PROCEDURE
+			if hasDirective(f.Directives, "viss_service") {
+				desc := descriptionArg(f.Directives)
+				fqnMap[fieldFQN] = utils.NewProcedureNode(name, desc)
+				continue
+			}
+
+			switch fieldElem {
+			case "SENSOR", "ACTUATOR", "ATTRIBUTE":
+				minVal, maxVal := rangeArgs(f.Directives)
+				dt := mapDatatype(f.Type.Name())
+				desc := descriptionArg(f.Directives)
+				unit := unitFromDirectives(f.Directives)
+				defVal := defaultValueArg(f.Directives)
+				nodeType := mapElement(fieldElem)
+				n := utils.NewSignalNode(name, nodeType, dt, desc, minVal, maxVal, unit)
+				n.DefaultValue = defVal
+				if av := allowedValues(schema, f.Type.Name()); len(av) > 0 {
+					n.AllowedDef = av
+					n.Allowed = uint8(len(av))
+				}
+				fqnMap[fieldFQN] = n
+			case "BRANCH":
+				if _, ok := fqnMap[fieldFQN]; !ok {
+					fqnMap[fieldFQN] = utils.NewBranchNode(name)
+				}
+			}
+		}
+	}
+
+	if len(fqnMap) == 0 {
+		return nil, nil, fmt.Errorf("vdmloader: no @vspec-annotated nodes found in SDL")
+	}
+
+	// Sort FQNs so parents are always linked before children.
+	fqns := make([]string, 0, len(fqnMap))
+	for fqn := range fqnMap {
+		fqns = append(fqns, fqn)
+	}
+	sort.Strings(fqns)
+
+	// First pass: link parent → child so every base node has its children
+	// attached before instance tag expansion clones them.
+	for _, fqn := range fqns {
+		parentFQN := parentOf(fqn)
+		if parentFQN == "" {
+			continue
+		}
+		parent, ok := fqnMap[parentFQN]
+		if !ok {
+			name := lastSegment(parentFQN)
+			parent = utils.NewBranchNode(name)
+			fqnMap[parentFQN] = parent
+			fqns = append(fqns, parentFQN)
+			sort.Strings(fqns)
+		}
+		child := fqnMap[fqn]
+		appendChild(parent, child)
+	}
+
+	// Expand instance tags after linking: baseNode.Child is now populated so
+	// deepClone correctly captures the full signal subtree for each instance.
+	expandInstanceTags(schema, fqnMap)
+
+	// Collect root nodes (FQN with no dot)
+	var roots []*utils.Node_t
+	var metas []TreeMeta
+	for fqn, node := range fqnMap {
+		if !strings.Contains(fqn, ".") {
+			metas = append(metas, TreeMeta{
+				RootName: fqn,
+				Domain:   fqn,
+				Version:  "1.0",
+			})
+			roots = append(roots, node)
+		}
+	}
+	if len(roots) == 0 {
+		return nil, nil, fmt.Errorf("vdmloader: SDL contains no root-level BRANCH type")
+	}
+	return roots, metas, nil
+}
+
+// ── Instance tag expansion ───────────────────────────────────────────────────
+
+// expandInstanceTags finds all *_InstanceTag types and expands the FQN they
+// annotate into per-combination subtrees. The original children of the base
+// FQN are deep-cloned into every instance branch.
+func expandInstanceTags(schema *ast.Schema, fqnMap map[string]*utils.Node_t) {
+	for _, t := range schema.Types {
+		if t.BuiltIn || !strings.HasSuffix(t.Name, "_InstanceTag") {
+			continue
+		}
+		if !hasDirective(t.Directives, "instanceTag") {
+			continue
+		}
+		baseFQN, _ := vspecDirectiveArgs(t.Directives)
+		if baseFQN == "" {
+			continue
+		}
+		baseNode, ok := fqnMap[baseFQN]
+		if !ok {
+			// The base type may not have been declared as a BRANCH in the SDL;
+			// create it now so the expansion has somewhere to attach.
+			baseNode = utils.NewBranchNode(lastSegment(baseFQN))
+			fqnMap[baseFQN] = baseNode
+			// Parent-child linking already ran; wire up the new node manually.
+			if pFQN := parentOf(baseFQN); pFQN != "" {
+				if pNode, pOk := fqnMap[pFQN]; pOk {
+					appendChild(pNode, baseNode)
+					baseNode.Parent = pNode
+				}
+			}
+		}
+
+		dims := collectDimensions(schema, t)
+		if len(dims) == 0 {
+			continue
+		}
+
+		// Snapshot all children of the base FQN (the template subtree).
+		// We clone the baseNode itself to capture its current child list.
+		templateRoot := deepClone(baseNode)
+
+		// Remove all descendants of baseFQN from the map; they'll be re-added
+		// under each instance path.
+		prefix := baseFQN + "."
+		for fqn := range fqnMap {
+			if strings.HasPrefix(fqn, prefix) {
+				delete(fqnMap, fqn)
+			}
+		}
+
+		// Clear base node so expansion can attach fresh instance branches.
+		baseNode.Child = nil
+		baseNode.Children = 0
+
+		// Generate every combination of dimension values.
+		for _, combo := range dimensionCombinations(dims) {
+			cur := baseNode
+			curFQN := baseFQN
+			for _, dv := range combo {
+				curFQN = curFQN + "." + dv.origName
+				// Reuse an existing branch for this segment if already created
+				// by a prior combination (e.g. Row1 already exists when we
+				// process Row1.PassengerSide after Row1.DriverSide).
+				var branch *utils.Node_t
+				for _, ch := range cur.Child {
+					if ch.Name == dv.origName {
+						branch = ch
+						break
+					}
+				}
+				if branch == nil {
+					branch = utils.NewBranchNode(dv.origName)
+					fqnMap[curFQN] = branch
+					appendChild(cur, branch)
+				}
+				cur = branch
+			}
+			// cur is now the innermost instance branch (e.g. the DriverSide node).
+			// Clone the template's children into it.
+			instanceBaseFQN := curFQN
+			for _, templateChild := range templateRoot.Child {
+				cloned := deepClone(templateChild)
+				appendChild(cur, cloned)
+				addClonedToMap(fqnMap, cloned, instanceBaseFQN+"."+cloned.Name)
+			}
+		}
+	}
+}
+
+// collectDimensions reads the dimension1, dimension2, … fields from an
+// _InstanceTag type and returns the ordered list of allowed values for each.
+func collectDimensions(schema *ast.Schema, instType *ast.Definition) [][]dimValue {
+	var dims [][]dimValue
+	for i := 1; ; i++ {
+		fieldName := fmt.Sprintf("dimension%d", i)
+		f := instType.Fields.ForName(fieldName)
+		if f == nil {
+			break
+		}
+		enumType := schema.Types[f.Type.Name()]
+		if enumType == nil || enumType.Kind != ast.Enum {
+			break
+		}
+		var values []dimValue
+		for _, ev := range enumType.EnumValues {
+			origName := originalName(ev)
+			values = append(values, dimValue{origName: origName})
+		}
+		if len(values) > 0 {
+			dims = append(dims, values)
+		}
+	}
+	return dims
+}
+
+// originalName extracts the @vspec(originalName:) from an enum value, falling
+// back to converting the SCREAMING_SNAKE_CASE enum name to PascalCase.
+func originalName(ev *ast.EnumValueDefinition) string {
+	for _, d := range ev.Directives {
+		if d.Name != "vspec" {
+			continue
+		}
+		for _, arg := range d.Arguments {
+			if arg.Name == "originalName" {
+				return strings.Trim(arg.Value.String(), `"`)
+			}
+		}
+	}
+	return screaming2Pascal(ev.Name)
+}
+
+// screaming2Pascal converts SCREAMING_SNAKE_CASE to PascalCase.
+// e.g. "DRIVER_SIDE" → "DriverSide", "ROW1" → "Row1".
+func screaming2Pascal(s string) string {
+	parts := strings.Split(s, "_")
+	var sb strings.Builder
+	for _, p := range parts {
+		if len(p) == 0 {
+			continue
+		}
+		sb.WriteByte(p[0]) // keep first char as-is (already upper from enum)
+		if len(p) > 1 {
+			sb.WriteString(strings.ToLower(p[1:]))
+		}
+	}
+	return sb.String()
+}
+
+// dimensionCombinations returns every ordered combination of one value per
+// dimension.  For [[Row1,Row2],[DriverSide,PassengerSide]] it returns:
+// [[Row1,DriverSide],[Row1,PassengerSide],[Row2,DriverSide],[Row2,PassengerSide]].
+func dimensionCombinations(dims [][]dimValue) [][]dimValue {
+	if len(dims) == 0 {
+		return [][]dimValue{{}}
+	}
+	var result [][]dimValue
+	for _, v := range dims[0] {
+		for _, rest := range dimensionCombinations(dims[1:]) {
+			combo := make([]dimValue, 1+len(rest))
+			combo[0] = v
+			copy(combo[1:], rest)
+			result = append(result, combo)
+		}
+	}
+	return result
+}
+
+// deepClone returns a full copy of the Node_t subtree rooted at n.
+// Parent pointers in the clone are set correctly within the cloned subtree;
+// the clone root's Parent is left nil (caller sets it after attaching).
+func deepClone(n *utils.Node_t) *utils.Node_t {
+	clone := &utils.Node_t{
+		Name:         n.Name,
+		NodeType:     n.NodeType,
+		Uuid:         n.Uuid,
+		Description:  n.Description,
+		Datatype:     n.Datatype,
+		Min:          n.Min,
+		Max:          n.Max,
+		Unit:         n.Unit,
+		Allowed:      n.Allowed,
+		DefaultValue: n.DefaultValue,
+		Validate:     n.Validate,
+	}
+	if len(n.AllowedDef) > 0 {
+		clone.AllowedDef = append([]string{}, n.AllowedDef...)
+	}
+	if len(n.Child) > 0 {
+		clone.Child = make([]*utils.Node_t, len(n.Child))
+		for i, c := range n.Child {
+			clonedChild := deepClone(c)
+			clonedChild.Parent = clone
+			clone.Child[i] = clonedChild
+		}
+		clone.Children = uint8(len(clone.Child))
+	}
+	return clone
+}
+
+// addClonedToMap recursively registers every node in a cloned subtree into
+// fqnMap using rootFQN as the FQN for node, then rootFQN+"."+child.Name etc.
+func addClonedToMap(fqnMap map[string]*utils.Node_t, node *utils.Node_t, rootFQN string) {
+	fqnMap[rootFQN] = node
+	for _, child := range node.Child {
+		addClonedToMap(fqnMap, child, rootFQN+"."+child.Name)
+	}
+}
+
+// ── Unit / default / allowed helpers ────────────────────────────────────────
+
+// unitFromDirectives extracts the unit string from @unit(value:) or
+// @vspec(unit:), normalising SCREAMING_SNAKE_CASE to standard unit strings.
+func unitFromDirectives(dirs ast.DirectiveList) string {
+	for _, d := range dirs {
+		if d.Name == "unit" {
+			for _, arg := range d.Arguments {
+				if arg.Name == "value" {
+					return normalizeUnit(strings.Trim(arg.Value.String(), `"`))
+				}
+			}
+		}
+	}
+	for _, d := range dirs {
+		if d.Name == "vspec" {
+			for _, arg := range d.Arguments {
+				if arg.Name == "unit" {
+					return normalizeUnit(strings.Trim(arg.Value.String(), `"`))
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// normalizeUnit converts well-known SCREAMING_SNAKE_CASE unit enum names to
+// standard unit strings. Values that don't match pass through unchanged so
+// authors can supply arbitrary strings directly (e.g. "km/h").
+func normalizeUnit(s string) string {
+	known := map[string]string{
+		"KM_PER_HOUR":             "km/h",
+		"M_PER_S":                 "m/s",
+		"MPH":                     "mph",
+		"DEGREES_CELSIUS":         "celsius",
+		"CELSIUS":                 "celsius",
+		"DEGREES":                 "degrees",
+		"RADIANS":                 "radians",
+		"PERCENT":                 "percent",
+		"PASCAL":                  "Pa",
+		"KILOGRAM":                "kg",
+		"GRAM":                    "g",
+		"METER":                   "m",
+		"KILOMETER":               "km",
+		"LITER":                   "l",
+		"WATT":                    "W",
+		"KILOWATT":                "kW",
+		"KILOWATT_HOUR":           "kWh",
+		"VOLT":                    "V",
+		"AMPERE":                  "A",
+		"NEWTON_METER":            "Nm",
+		"REVOLUTION_PER_MINUTE":   "rpm",
+		"SECOND":                  "s",
+		"MILLISECOND":             "ms",
+		"MINUTE":                  "min",
+		"HOUR":                    "h",
+		"HERTZ":                   "Hz",
+		"BAR":                     "bar",
+		"MILLIMETER":              "mm",
+	}
+	if v, ok := known[s]; ok {
+		return v
+	}
+	return s
+}
+
+// defaultValueArg extracts the value string from @defaultValue(value:).
+func defaultValueArg(dirs ast.DirectiveList) string {
+	for _, d := range dirs {
+		if d.Name != "defaultValue" {
+			continue
+		}
+		for _, arg := range d.Arguments {
+			if arg.Name == "value" {
+				return strings.Trim(arg.Value.String(), `"`)
+			}
+		}
+	}
+	return ""
+}
+
+// allowedValues returns the set of allowed string values for a signal typed
+// as a user-defined GraphQL enum. Returns nil for scalars, built-in types,
+// and any internal VDM enums (VspecElement, *_InstanceTag_Dimension*).
+func allowedValues(schema *ast.Schema, typeName string) []string {
+	t := schema.Types[typeName]
+	if t == nil || t.Kind != ast.Enum || t.BuiltIn {
+		return nil
+	}
+	if typeName == "VspecElement" || strings.Contains(typeName, "_InstanceTag_Dimension") {
+		return nil
+	}
+	vals := make([]string, 0, len(t.EnumValues))
+	for _, ev := range t.EnumValues {
+		vals = append(vals, originalName(ev))
+	}
+	return vals
+}
+
+// ── SDL directive helpers ────────────────────────────────────────────────────
+
+// vspecDirectiveArgs extracts (fqn, element) from a @vspec directive list.
+func vspecDirectiveArgs(dirs ast.DirectiveList) (fqn, element string) {
+	for _, d := range dirs {
+		if d.Name != "vspec" {
+			continue
+		}
+		for _, arg := range d.Arguments {
+			switch arg.Name {
+			case "fqn":
+				fqn = strings.Trim(arg.Value.String(), `"`)
+			case "element":
+				element = arg.Value.String()
+			}
+		}
+		return
+	}
+	return
+}
+
+// descriptionArg returns the description string from @vspec if present.
+func descriptionArg(dirs ast.DirectiveList) string {
+	for _, d := range dirs {
+		if d.Name != "vspec" {
+			continue
+		}
+		for _, arg := range d.Arguments {
+			if arg.Name == "description" {
+				return strings.Trim(arg.Value.String(), `"`)
+			}
+		}
+	}
+	return ""
+}
+
+// rangeArgs extracts (min, max) strings from a @range directive list.
+func rangeArgs(dirs ast.DirectiveList) (min, max string) {
+	for _, d := range dirs {
+		if d.Name != "range" {
+			continue
+		}
+		for _, arg := range d.Arguments {
+			switch arg.Name {
+			case "min":
+				min = formatFloat(arg.Value.String())
+			case "max":
+				max = formatFloat(arg.Value.String())
+			}
+		}
+		return
+	}
+	return
+}
+
+// hasDirective reports whether the directive list contains a directive by name.
+func hasDirective(dirs ast.DirectiveList, name string) bool {
+	for _, d := range dirs {
+		if d.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ── Type / element helpers ───────────────────────────────────────────────────
+
+// mapDatatype maps GraphQL type names to VSS datatype strings.
+func mapDatatype(gqlType string) string {
+	switch gqlType {
+	case "Int8":
+		return "int8"
+	case "UInt8":
+		return "uint8"
+	case "Int16":
+		return "int16"
+	case "UInt16":
+		return "uint16"
+	case "Int":
+		return "int32"
+	case "UInt32":
+		return "uint32"
+	case "Int64":
+		return "int64"
+	case "UInt64":
+		return "uint64"
+	case "Float":
+		return "float"
+	case "Boolean":
+		return "bool"
+	case "String":
+		return "string"
+	default:
+		return strings.ToLower(gqlType)
+	}
+}
+
+// mapElement converts a VspecElement string to a utils node type constant.
+func mapElement(element string) string {
+	switch element {
+	case "SENSOR":
+		return utils.SENSOR
+	case "ACTUATOR":
+		return utils.ACTUATOR
+	case "ATTRIBUTE":
+		return utils.ATTRIBUTE
+	case "BRANCH":
+		return utils.BRANCH
+	default:
+		return utils.ATTRIBUTE
+	}
+}
+
+// ── FQN helpers ──────────────────────────────────────────────────────────────
+
+// lastSegment returns the portion of an FQN after the final dot.
+func lastSegment(fqn string) string {
+	i := strings.LastIndex(fqn, ".")
+	if i < 0 {
+		return fqn
+	}
+	return fqn[i+1:]
+}
+
+// parentOf returns the FQN with the last segment removed, or "" for roots.
+func parentOf(fqn string) string {
+	i := strings.LastIndex(fqn, ".")
+	if i < 0 {
+		return ""
+	}
+	return fqn[:i]
+}
+
+// appendChild adds child to parent if not already present.
+func appendChild(parent, child *utils.Node_t) {
+	for _, existing := range parent.Child {
+		if existing == child {
+			return
+		}
+	}
+	child.Parent = parent
+	parent.Child = append(parent.Child, child)
+	parent.Children = uint8(len(parent.Child))
+}
+
+// formatFloat trims trailing zeros from a float string for compact storage.
+func formatFloat(s string) string {
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return s
+	}
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}

--- a/server/vissv2server/vdmloader/vdmloader_test.go
+++ b/server/vissv2server/vdmloader/vdmloader_test.go
@@ -1,0 +1,1135 @@
+package vdmloader
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/covesa/vissr/utils"
+)
+
+func init() {
+	utils.InitLog("vdmloader-test.log", os.TempDir(), false, "info")
+}
+
+// findNode does a depth-first search for a node by name in the tree.
+func findNode(root *utils.Node_t, name string) *utils.Node_t {
+	if root == nil {
+		return nil
+	}
+	if root.Name == name {
+		return root
+	}
+	for _, c := range root.Child {
+		if n := findNode(c, name); n != nil {
+			return n
+		}
+	}
+	return nil
+}
+
+// findByFQN walks the tree following dot-separated FQN segments.
+func findByFQN(root *utils.Node_t, fqn string) *utils.Node_t {
+	parts := splitFQN(fqn)
+	cur := root
+	for _, p := range parts {
+		if cur.Name != p {
+			return nil
+		}
+		// Already at the right node; if only one part, we're done
+		if len(parts) == 1 {
+			return cur
+		}
+		break
+	}
+	// Traverse remaining segments into children
+	cur = root
+	for _, p := range parts {
+		if cur.Name == p {
+			continue
+		}
+		var found *utils.Node_t
+		for _, child := range cur.Child {
+			if child.Name == p {
+				found = child
+				break
+			}
+		}
+		if found == nil {
+			return nil
+		}
+		cur = found
+	}
+	return cur
+}
+
+func splitFQN(fqn string) []string {
+	out := []string{}
+	s := fqn
+	for {
+		i := indexOf(s, '.')
+		if i < 0 {
+			out = append(out, s)
+			break
+		}
+		out = append(out, s[:i])
+		s = s[i+1:]
+	}
+	return out
+}
+
+func indexOf(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+// ── ParseSDL tests ──────────────────────────────────────────────────────────
+
+func TestParseSDL_ReturnsRoot(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, metas, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatalf("ParseSDL: unexpected error: %v", err)
+	}
+	if len(roots) != 1 {
+		t.Fatalf("expected 1 root, got %d", len(roots))
+	}
+	if roots[0].Name != "Vehicle" {
+		t.Errorf("root name = %q, want Vehicle", roots[0].Name)
+	}
+	if metas[0].RootName != "Vehicle" {
+		t.Errorf("meta.RootName = %q, want Vehicle", metas[0].RootName)
+	}
+}
+
+func TestParseSDL_RootIsBranch(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, _ := ParseSDL(sdl)
+	if roots[0].NodeType != utils.BRANCH {
+		t.Errorf("root NodeType = %q, want %q", roots[0].NodeType, utils.BRANCH)
+	}
+}
+
+func TestParseSDL_SensorLeaf(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	speed := findNode(roots[0], "Speed")
+	if speed == nil {
+		t.Fatal("Speed node not found")
+	}
+	if speed.NodeType != utils.SENSOR {
+		t.Errorf("Speed.NodeType = %q, want sensor", speed.NodeType)
+	}
+	if speed.Datatype != "float" {
+		t.Errorf("Speed.Datatype = %q, want float", speed.Datatype)
+	}
+	if speed.Min != "0" {
+		t.Errorf("Speed.Min = %q, want 0", speed.Min)
+	}
+	if speed.Max != "250" {
+		t.Errorf("Speed.Max = %q, want 250", speed.Max)
+	}
+}
+
+func TestParseSDL_ActuatorLeaf(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	isEnabled := findNode(roots[0], "IsEnabled")
+	if isEnabled == nil {
+		t.Fatal("IsEnabled node not found")
+	}
+	if isEnabled.NodeType != utils.ACTUATOR {
+		t.Errorf("IsEnabled.NodeType = %q, want actuator", isEnabled.NodeType)
+	}
+	if isEnabled.Datatype != "bool" {
+		t.Errorf("IsEnabled.Datatype = %q, want bool", isEnabled.Datatype)
+	}
+}
+
+func TestParseSDL_AttributeLeaf(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	level := findNode(roots[0], "ActiveAutonomyLevel")
+	if level == nil {
+		t.Fatal("ActiveAutonomyLevel node not found")
+	}
+	if level.NodeType != utils.ATTRIBUTE {
+		t.Errorf("ActiveAutonomyLevel.NodeType = %q, want attribute", level.NodeType)
+	}
+}
+
+func TestParseSDL_NestedBranch(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adas := findNode(roots[0], "ADAS")
+	if adas == nil {
+		t.Fatal("ADAS node not found")
+	}
+	if adas.NodeType != utils.BRANCH {
+		t.Errorf("ADAS.NodeType = %q, want branch", adas.NodeType)
+	}
+	abs := findNode(adas, "ABS")
+	if abs == nil {
+		t.Fatal("ABS node not found under ADAS")
+	}
+	if abs.NodeType != utils.BRANCH {
+		t.Errorf("ABS.NodeType = %q, want branch", abs.NodeType)
+	}
+}
+
+func TestParseSDL_RangeNegative(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lat := findNode(roots[0], "Latitude")
+	if lat == nil {
+		t.Fatal("Latitude node not found")
+	}
+	if lat.Min != "-90" {
+		t.Errorf("Latitude.Min = %q, want -90", lat.Min)
+	}
+	if lat.Max != "90" {
+		t.Errorf("Latitude.Max = %q, want 90", lat.Max)
+	}
+}
+
+func TestParseSDL_ParentChildLinks(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	speed := findNode(roots[0], "Speed")
+	if speed == nil {
+		t.Fatal("Speed not found")
+	}
+	if speed.Parent == nil {
+		t.Fatal("Speed.Parent is nil")
+	}
+	if speed.Parent.Name != "Vehicle" {
+		t.Errorf("Speed.Parent.Name = %q, want Vehicle", speed.Parent.Name)
+	}
+}
+
+func TestParseSDL_ChildrenCount(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := roots[0]
+	if int(root.Children) != len(root.Child) {
+		t.Errorf("Children field %d != len(Child) %d", root.Children, len(root.Child))
+	}
+}
+
+func TestParseSDL_ErrorOnEmpty(t *testing.T) {
+	_, _, err := ParseSDL("")
+	if err == nil {
+		t.Fatal("expected error for empty SDL, got nil")
+	}
+}
+
+func TestParseSDL_ErrorOnNoVspecAnnotations(t *testing.T) {
+	plain := `type Foo { bar: String }`
+	_, _, err := ParseSDL(plain)
+	if err == nil {
+		t.Fatal("expected error for SDL with no @vspec annotations, got nil")
+	}
+}
+
+func TestParseSDL_ErrorOnInvalidSyntax(t *testing.T) {
+	_, _, err := ParseSDL("this is not graphql")
+	if err == nil {
+		t.Fatal("expected error for invalid SDL syntax, got nil")
+	}
+}
+
+// ── ParseFile tests ─────────────────────────────────────────────────────────
+
+func TestParseFile_Roundtrip(t *testing.T) {
+	path := filepath.Join("testdata", "vehicle.graphql")
+	roots, metas, err := ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if len(roots) != 1 || metas[0].RootName != "Vehicle" {
+		t.Errorf("unexpected roots: %v / %v", len(roots), metas)
+	}
+}
+
+func TestParseFile_NonExistentReturnsError(t *testing.T) {
+	_, _, err := ParseFile("/nonexistent/path.graphql")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+// ── LoadDir tests ───────────────────────────────────────────────────────────
+
+func TestLoadDir_RegistersTree(t *testing.T) {
+	n, err := LoadDir("testdata")
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if n < 1 {
+		t.Errorf("expected at least 1 tree registered, got %d", n)
+	}
+}
+
+func TestLoadDir_NonExistentReturnsError(t *testing.T) {
+	_, err := LoadDir("/nonexistent/dir")
+	if err == nil {
+		t.Fatal("expected error for nonexistent directory")
+	}
+}
+
+func TestLoadDir_EmptyDirReturnsZero(t *testing.T) {
+	dir := t.TempDir()
+	n, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir on empty dir: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 trees from empty dir, got %d", n)
+	}
+}
+
+// ── Datatype mapping tests ──────────────────────────────────────────────────
+
+func TestMapDatatype(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Int8", "int8"},
+		{"UInt8", "uint8"},
+		{"Int16", "int16"},
+		{"UInt16", "uint16"},
+		{"Int", "int32"},
+		{"UInt32", "uint32"},
+		{"Int64", "int64"},
+		{"UInt64", "uint64"},
+		{"Float", "float"},
+		{"Boolean", "bool"},
+		{"String", "string"},
+		{"Unknown", "unknown"},
+	}
+	for _, tc := range cases {
+		got := mapDatatype(tc.in)
+		if got != tc.want {
+			t.Errorf("mapDatatype(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ── Helper tests ────────────────────────────────────────────────────────────
+
+func TestLastSegment(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Vehicle", "Vehicle"},
+		{"Vehicle.Speed", "Speed"},
+		{"Vehicle.ADAS.ABS", "ABS"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := lastSegment(tc.in); got != tc.want {
+			t.Errorf("lastSegment(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParentOf(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Vehicle", ""},
+		{"Vehicle.Speed", "Vehicle"},
+		{"Vehicle.ADAS.ABS", "Vehicle.ADAS"},
+	}
+	for _, tc := range cases {
+		if got := parentOf(tc.in); got != tc.want {
+			t.Errorf("parentOf(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFormatFloat(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"0", "0"},
+		{"250", "250"},
+		{"-90", "-90"},
+		{"3.14", "3.14"},
+		{"notanumber", "notanumber"},
+	}
+	for _, tc := range cases {
+		if got := formatFloat(tc.in); got != tc.want {
+			t.Errorf("formatFloat(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestAppendChild_NoDuplicate(t *testing.T) {
+	parent := utils.NewBranchNode("Parent")
+	child := utils.NewBranchNode("Child")
+	appendChild(parent, child)
+	appendChild(parent, child) // second call must be idempotent
+	if int(parent.Children) != 1 {
+		t.Errorf("expected 1 child, got %d", parent.Children)
+	}
+}
+
+// ── viss_service extension test ─────────────────────────────────────────────
+
+func TestParseSDL_VissServiceCreatesProc(t *testing.T) {
+	sdl := `
+type Svc @vspec(element: BRANCH, fqn: "Svc", description: "service root") {
+  DoThing: Boolean @vspec(element: SENSOR, fqn: "Svc.DoThing") @viss_service
+}
+`
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatalf("ParseSDL: %v", err)
+	}
+	doThing := findNode(roots[0], "DoThing")
+	if doThing == nil {
+		t.Fatal("DoThing not found")
+	}
+	if doThing.NodeType != utils.PROCEDURE {
+		t.Errorf("DoThing.NodeType = %q, want procedure", doThing.NodeType)
+	}
+}
+
+// ── Unit mapping tests ──────────────────────────────────────────────────────
+
+func TestParseSDL_UnitPopulated(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	speed := findNode(roots[0], "Speed")
+	if speed == nil {
+		t.Fatal("Speed not found")
+	}
+	if speed.Unit != "km/h" {
+		t.Errorf("Speed.Unit = %q, want km/h", speed.Unit)
+	}
+}
+
+func TestParseSDL_UnitNormalised(t *testing.T) {
+	sdl := `
+type T @vspec(element: BRANCH, fqn: "T") {
+  Temp: Float @vspec(element: SENSOR, fqn: "T.Temp") @unit(value: "DEGREES_CELSIUS")
+}
+`
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	temp := findNode(roots[0], "Temp")
+	if temp == nil {
+		t.Fatal("Temp not found")
+	}
+	if temp.Unit != "celsius" {
+		t.Errorf("Temp.Unit = %q, want celsius", temp.Unit)
+	}
+}
+
+func TestNormalizeUnit(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"KM_PER_HOUR", "km/h"},
+		{"M_PER_S", "m/s"},
+		{"DEGREES_CELSIUS", "celsius"},
+		{"PERCENT", "percent"},
+		{"km/h", "km/h"},   // already a standard string — pass through
+		{"unknown", "unknown"},
+	}
+	for _, tc := range cases {
+		if got := normalizeUnit(tc.in); got != tc.want {
+			t.Errorf("normalizeUnit(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ── Default value tests ─────────────────────────────────────────────────────
+
+func TestParseSDL_DefaultValuePopulated(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mileage := findNode(roots[0], "TripMileage")
+	if mileage == nil {
+		t.Fatal("TripMileage not found")
+	}
+	if mileage.DefaultValue != "0" {
+		t.Errorf("TripMileage.DefaultValue = %q, want 0", mileage.DefaultValue)
+	}
+}
+
+func TestParseSDL_DefaultValueString(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	isEnabled := findNode(roots[0], "IsEnabled")
+	if isEnabled == nil {
+		t.Fatal("IsEnabled not found")
+	}
+	if isEnabled.DefaultValue != "false" {
+		t.Errorf("IsEnabled.DefaultValue = %q, want false", isEnabled.DefaultValue)
+	}
+}
+
+func TestParseSDL_NoDefaultValue(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	speed := findNode(roots[0], "Speed")
+	if speed == nil {
+		t.Fatal("Speed not found")
+	}
+	if speed.DefaultValue != "" {
+		t.Errorf("Speed.DefaultValue = %q, want empty", speed.DefaultValue)
+	}
+}
+
+// ── Allowed values tests ─────────────────────────────────────────────────────
+
+func TestParseSDL_AllowedValuesFromEnum(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gear := findNode(roots[0], "CurrentGear")
+	if gear == nil {
+		t.Fatal("CurrentGear not found")
+	}
+	if int(gear.Allowed) != 4 {
+		t.Errorf("CurrentGear.Allowed = %d, want 4", gear.Allowed)
+	}
+	want := map[string]bool{"Park": true, "Reverse": true, "Neutral": true, "Drive": true}
+	for _, v := range gear.AllowedDef {
+		if !want[v] {
+			t.Errorf("unexpected allowed value %q", v)
+		}
+	}
+	if len(gear.AllowedDef) != 4 {
+		t.Errorf("len(AllowedDef) = %d, want 4", len(gear.AllowedDef))
+	}
+}
+
+func TestParseSDL_AllowedOriginalNames(t *testing.T) {
+	sdl := `
+enum Dir { NORTH @vspec(originalName: "North") SOUTH @vspec(originalName: "South") }
+type Nav @vspec(element: BRANCH, fqn: "Nav") {
+  Heading: Dir @vspec(element: SENSOR, fqn: "Nav.Heading")
+}
+`
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	heading := findNode(roots[0], "Heading")
+	if heading == nil {
+		t.Fatal("Heading not found")
+	}
+	if len(heading.AllowedDef) != 2 {
+		t.Fatalf("AllowedDef len = %d, want 2", len(heading.AllowedDef))
+	}
+	if heading.AllowedDef[0] != "North" || heading.AllowedDef[1] != "South" {
+		t.Errorf("AllowedDef = %v, want [North South]", heading.AllowedDef)
+	}
+}
+
+func TestParseSDL_ScalarHasNoAllowed(t *testing.T) {
+	sdl := readFixture(t, "vehicle.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	speed := findNode(roots[0], "Speed")
+	if speed == nil {
+		t.Fatal("Speed not found")
+	}
+	if len(speed.AllowedDef) != 0 {
+		t.Errorf("Speed.AllowedDef = %v, want empty", speed.AllowedDef)
+	}
+}
+
+// ── Instance tag expansion tests ─────────────────────────────────────────────
+
+func TestInstanceTag_2D_ExpandsCorrectInstances(t *testing.T) {
+	sdl := readFixture(t, "cabin.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatalf("ParseSDL cabin.graphql: %v", err)
+	}
+	seat := findNode(roots[0], "Seat")
+	if seat == nil {
+		t.Fatal("Seat node not found")
+	}
+	// Seat must have Row1 and Row2 as children (not IsOccupied/IsBelted/Position directly)
+	if int(seat.Children) != 2 {
+		t.Errorf("Seat.Children = %d, want 2 (Row1, Row2)", seat.Children)
+	}
+	row1 := findNode(seat, "Row1")
+	if row1 == nil {
+		t.Fatal("Seat.Row1 not found")
+	}
+	if row1.NodeType != utils.BRANCH {
+		t.Errorf("Row1.NodeType = %q, want branch", row1.NodeType)
+	}
+	// Row1 must have DriverSide and PassengerSide
+	if int(row1.Children) != 2 {
+		t.Errorf("Row1.Children = %d, want 2 (DriverSide, PassengerSide)", row1.Children)
+	}
+}
+
+func TestInstanceTag_2D_ChildrenClonedPerInstance(t *testing.T) {
+	sdl := readFixture(t, "cabin.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Every leaf instance should have IsOccupied, IsBelted, Position
+	for _, rowName := range []string{"Row1", "Row2"} {
+		for _, sideName := range []string{"DriverSide", "PassengerSide"} {
+			seat := findNode(roots[0], "Seat")
+			row := findNode(seat, rowName)
+			if row == nil {
+				t.Fatalf("%s not found under Seat", rowName)
+			}
+			side := findNode(row, sideName)
+			if side == nil {
+				t.Fatalf("%s not found under %s", sideName, rowName)
+			}
+			for _, childName := range []string{"IsOccupied", "IsBelted", "Position"} {
+				if findNode(side, childName) == nil {
+					t.Errorf("Seat.%s.%s.%s not found", rowName, sideName, childName)
+				}
+			}
+		}
+	}
+}
+
+func TestInstanceTag_2D_SignalPropertiesPreserved(t *testing.T) {
+	sdl := readFixture(t, "cabin.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seat := findNode(roots[0], "Seat")
+	row1 := findNode(seat, "Row1")
+	driver := findNode(row1, "DriverSide")
+	pos := findNode(driver, "Position")
+	if pos == nil {
+		t.Fatal("Position not found under Row1.DriverSide")
+	}
+	if pos.NodeType != utils.ACTUATOR {
+		t.Errorf("Position.NodeType = %q, want actuator", pos.NodeType)
+	}
+	if pos.Min != "0" || pos.Max != "100" {
+		t.Errorf("Position range = [%q, %q], want [0, 100]", pos.Min, pos.Max)
+	}
+}
+
+func TestInstanceTag_2D_ClonesAreIndependent(t *testing.T) {
+	sdl := readFixture(t, "cabin.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seat := findNode(roots[0], "Seat")
+	row1 := findNode(seat, "Row1")
+	row2 := findNode(seat, "Row2")
+	driver1 := findNode(row1, "DriverSide")
+	driver2 := findNode(row2, "DriverSide")
+	pos1 := findNode(driver1, "Position")
+	pos2 := findNode(driver2, "Position")
+	if pos1 == nil || pos2 == nil {
+		t.Fatal("Position not found in one or both instances")
+	}
+	if pos1 == pos2 {
+		t.Error("Row1 and Row2 share the same Position pointer — deep clone failed")
+	}
+}
+
+func TestInstanceTag_2D_ParentLinksCorrect(t *testing.T) {
+	sdl := readFixture(t, "cabin.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seat := findNode(roots[0], "Seat")
+	row1 := findNode(seat, "Row1")
+	driver := findNode(row1, "DriverSide")
+	if driver.Parent == nil || driver.Parent.Name != "Row1" {
+		t.Errorf("DriverSide.Parent = %v, want Row1", driver.Parent)
+	}
+	pos := findNode(driver, "Position")
+	if pos.Parent == nil || pos.Parent.Name != "DriverSide" {
+		t.Errorf("Position.Parent = %v, want DriverSide", pos.Parent)
+	}
+}
+
+func TestInstanceTag_1D_ExpandsCorrectInstances(t *testing.T) {
+	sdl := readFixture(t, "cabin.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	door := findNode(roots[0], "Door")
+	if door == nil {
+		t.Fatal("Door node not found")
+	}
+	// Door must have Row1, Row2, Row3
+	if int(door.Children) != 3 {
+		t.Errorf("Door.Children = %d, want 3 (Row1, Row2, Row3)", door.Children)
+	}
+	for _, row := range []string{"Row1", "Row2", "Row3"} {
+		n := findNode(door, row)
+		if n == nil {
+			t.Errorf("Door.%s not found", row)
+		}
+	}
+}
+
+func TestInstanceTag_1D_ChildrenCloned(t *testing.T) {
+	sdl := readFixture(t, "cabin.graphql")
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	door := findNode(roots[0], "Door")
+	for _, row := range []string{"Row1", "Row2", "Row3"} {
+		rowNode := findNode(door, row)
+		if rowNode == nil {
+			t.Fatalf("Door.%s not found", row)
+		}
+		for _, childName := range []string{"IsOpen", "IsLocked"} {
+			if findNode(rowNode, childName) == nil {
+				t.Errorf("Door.%s.%s not found", row, childName)
+			}
+		}
+	}
+}
+
+// ── screaming2Pascal and dimensionCombinations helpers ───────────────────────
+
+func TestScreaming2Pascal(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"ROW1", "Row1"},
+		{"DRIVER_SIDE", "DriverSide"},
+		{"PASSENGER_SIDE", "PassengerSide"},
+		{"LEFT", "Left"},
+		{"RIGHT", "Right"},
+		{"MIDDLE", "Middle"},
+	}
+	for _, tc := range cases {
+		if got := screaming2Pascal(tc.in); got != tc.want {
+			t.Errorf("screaming2Pascal(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDimensionCombinations_2D(t *testing.T) {
+	dims := [][]dimValue{
+		{{origName: "Row1"}, {origName: "Row2"}},
+		{{origName: "DriverSide"}, {origName: "PassengerSide"}},
+	}
+	combos := dimensionCombinations(dims)
+	if len(combos) != 4 {
+		t.Fatalf("expected 4 combinations, got %d", len(combos))
+	}
+	want := [][2]string{{"Row1", "DriverSide"}, {"Row1", "PassengerSide"}, {"Row2", "DriverSide"}, {"Row2", "PassengerSide"}}
+	for i, combo := range combos {
+		if combo[0].origName != want[i][0] || combo[1].origName != want[i][1] {
+			t.Errorf("combo[%d] = [%s,%s], want [%s,%s]", i, combo[0].origName, combo[1].origName, want[i][0], want[i][1])
+		}
+	}
+}
+
+func TestDimensionCombinations_1D(t *testing.T) {
+	dims := [][]dimValue{
+		{{origName: "Row1"}, {origName: "Row2"}, {origName: "Row3"}},
+	}
+	combos := dimensionCombinations(dims)
+	if len(combos) != 3 {
+		t.Fatalf("expected 3 combinations, got %d", len(combos))
+	}
+}
+
+func TestDeepClone_IsIndependent(t *testing.T) {
+	orig := utils.NewBranchNode("Parent")
+	child := utils.NewSignalNode("Speed", utils.SENSOR, "float", "speed", "0", "250", "km/h")
+	appendChild(orig, child)
+
+	clone := deepClone(orig)
+	if clone == orig {
+		t.Fatal("clone is same pointer as orig")
+	}
+	if clone.Child[0] == orig.Child[0] {
+		t.Error("clone child is same pointer as orig child")
+	}
+	if clone.Child[0].Name != "Speed" {
+		t.Errorf("clone child name = %q, want Speed", clone.Child[0].Name)
+	}
+	if clone.Child[0].Max != "250" {
+		t.Errorf("clone child Max = %q, want 250", clone.Child[0].Max)
+	}
+	if clone.Child[0].Parent != clone {
+		t.Error("clone child Parent does not point to clone")
+	}
+}
+
+// ── Coverage gap tests ────────────────────────────────────────────────────────
+
+func TestScreaming2Pascal_EmptySegment(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"DOUBLE__UNDER", "DoubleUnder"},
+		{"TRAILING_", "Trailing"},
+		{"_LEADING", "Leading"},
+	}
+	for _, tc := range cases {
+		if got := screaming2Pascal(tc.in); got != tc.want {
+			t.Errorf("screaming2Pascal(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMapElement_AllCases(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"SENSOR", utils.SENSOR},
+		{"ACTUATOR", utils.ACTUATOR},
+		{"ATTRIBUTE", utils.ATTRIBUTE},
+		{"BRANCH", utils.BRANCH},
+		{"BOGUS", utils.ATTRIBUTE},
+		{"", utils.ATTRIBUTE},
+	}
+	for _, tc := range cases {
+		if got := mapElement(tc.in); got != tc.want {
+			t.Errorf("mapElement(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestAddClonedToMap_Recursive(t *testing.T) {
+	parent := utils.NewBranchNode("Parent")
+	child := utils.NewBranchNode("Child")
+	grandchild := utils.NewSignalNode("Signal", utils.SENSOR, "float", "", "", "", "")
+	appendChild(child, grandchild)
+	appendChild(parent, child)
+
+	fqnMap := make(map[string]*utils.Node_t)
+	addClonedToMap(fqnMap, parent, "Root.Parent")
+
+	for _, want := range []string{"Root.Parent", "Root.Parent.Child", "Root.Parent.Child.Signal"} {
+		if _, ok := fqnMap[want]; !ok {
+			t.Errorf("fqnMap missing %q", want)
+		}
+	}
+}
+
+func TestDeepClone_Grandchildren(t *testing.T) {
+	root := utils.NewBranchNode("Root")
+	mid := utils.NewBranchNode("Mid")
+	leaf := utils.NewSignalNode("Leaf", utils.SENSOR, "float", "desc", "0", "100", "km/h")
+	appendChild(mid, leaf)
+	appendChild(root, mid)
+
+	clone := deepClone(root)
+
+	if len(clone.Child) != 1 {
+		t.Fatalf("clone.Child length = %d, want 1", len(clone.Child))
+	}
+	midClone := clone.Child[0]
+	if midClone == mid {
+		t.Error("mid clone is same pointer as original")
+	}
+	if midClone.Parent != clone {
+		t.Error("midClone.Parent != clone root")
+	}
+	if len(midClone.Child) != 1 {
+		t.Fatalf("midClone.Child length = %d, want 1", len(midClone.Child))
+	}
+	leafClone := midClone.Child[0]
+	if leafClone == leaf {
+		t.Error("leaf clone is same pointer as original")
+	}
+	if leafClone.Parent != midClone {
+		t.Error("leafClone.Parent != midClone")
+	}
+}
+
+func TestDeepClone_AllowedDef(t *testing.T) {
+	gear := utils.NewSignalNode("Gear", utils.SENSOR, "string", "", "", "", "")
+	gear.AllowedDef = []string{"Park", "Reverse", "Neutral"}
+	clone := deepClone(gear)
+
+	if len(clone.AllowedDef) != 3 {
+		t.Fatalf("clone.AllowedDef length = %d, want 3", len(clone.AllowedDef))
+	}
+	clone.AllowedDef[0] = "MODIFIED"
+	if gear.AllowedDef[0] != "Park" {
+		t.Error("original AllowedDef was mutated through clone slice")
+	}
+}
+
+func TestLoadDir_SkipsNonGraphQL(t *testing.T) {
+	// ReadDir returns entries in alpha order. Name non-.graphql files before any .graphql
+	// so the skip-continue branch fires before ParseSDL is reached.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "00_readme.txt"), []byte("ignore me"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "01_subdir"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	minimalSDL := `
+type VehicleNGQ @vspec(element: BRANCH, fqn: "VehicleNGQ") {
+  speed: Float @vspec(element: SENSOR, fqn: "VehicleNGQ.Speed")
+}`
+	if err := os.WriteFile(filepath.Join(dir, "vehicle.graphql"), []byte(minimalSDL), 0644); err != nil {
+		t.Fatal(err)
+	}
+	n, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if n == 0 {
+		t.Error("expected at least one tree registered")
+	}
+}
+
+func TestLoadDir_InvalidSDLReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "bad.graphql"), []byte("not valid SDL !!!"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadDir(dir)
+	if err == nil {
+		t.Error("expected error for invalid SDL file, got nil")
+	}
+}
+
+func TestLoadDir_DuplicateSkipped(t *testing.T) {
+	dir := t.TempDir()
+	minimalSDL := `
+type VehicleDD @vspec(element: BRANCH, fqn: "VehicleDD") {
+  speed: Float @vspec(element: SENSOR, fqn: "VehicleDD.Speed")
+}`
+	if err := os.WriteFile(filepath.Join(dir, "dd.graphql"), []byte(minimalSDL), 0644); err != nil {
+		t.Fatal(err)
+	}
+	n1, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("first LoadDir: %v", err)
+	}
+	if n1 == 0 {
+		t.Fatal("expected at least one tree registered on first LoadDir")
+	}
+	n2, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("second LoadDir: %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("second LoadDir registered %d trees, want 0 (already registered)", n2)
+	}
+}
+
+func TestOriginalName_VspecWithoutOriginalNameArg(t *testing.T) {
+	// Enum value has @vspec but no originalName arg — inner loop exhausts, falls back to screaming2Pascal.
+	sdl := `
+type VehicleON @vspec(element: BRANCH, fqn: "VehicleON") {
+  gear: GearPosON @vspec(element: SENSOR, fqn: "VehicleON.Gear")
+}
+enum GearPosON {
+  PARK @vspec(fqn: "GearPosON.PARK")
+  REVERSE
+}`
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatalf("ParseSDL: %v", err)
+	}
+	gear := findNode(roots[0], "Gear")
+	if gear == nil {
+		t.Fatal("Gear not found")
+	}
+	found := false
+	for _, v := range gear.AllowedDef {
+		if v == "Park" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("AllowedDef = %v, expected 'Park' (screaming2Pascal fallback for @vspec without originalName)", gear.AllowedDef)
+	}
+}
+
+func TestOriginalName_NonVspecDirectiveSkipped(t *testing.T) {
+	// Enum value has @deprecated (non-vspec directive) — outer loop hits continue, then falls back.
+	sdl := `
+type VehicleND @vspec(element: BRANCH, fqn: "VehicleND") {
+  gear: GearPosND @vspec(element: SENSOR, fqn: "VehicleND.Gear")
+}
+enum GearPosND {
+  PARK
+  REVERSE @deprecated
+}`
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatalf("ParseSDL: %v", err)
+	}
+	gear := findNode(roots[0], "Gear")
+	if gear == nil {
+		t.Fatal("Gear not found")
+	}
+	found := false
+	for _, v := range gear.AllowedDef {
+		if v == "Reverse" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("AllowedDef = %v, expected 'Reverse' (non-vspec directive skipped, screaming2Pascal fallback)", gear.AllowedDef)
+	}
+}
+
+func TestExpandInstanceTags_AutoCreateMissingBase(t *testing.T) {
+	// InstanceTag's baseFQN is not declared as a BRANCH type — expandInstanceTags must auto-create it.
+	sdl := `
+type VehicleAC @vspec(element: BRANCH, fqn: "VehicleAC") {
+  cabin: VehicleACCabin @vspec(element: BRANCH, fqn: "VehicleAC.Cabin")
+}
+type VehicleACCabin @vspec(element: BRANCH, fqn: "VehicleAC.Cabin") {
+  dummy: Boolean @vspec(element: ATTRIBUTE, fqn: "VehicleAC.Cabin.Dummy")
+}
+
+type VehicleACCabinSeat_InstanceTag @vspec(fqn: "VehicleAC.Cabin.Seat") @instanceTag {
+  dimension1: SeatRowAutoEnum
+}
+enum SeatRowAutoEnum { ROW1 ROW2 }
+`
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatalf("ParseSDL: %v", err)
+	}
+	seat := findNode(roots[0], "Seat")
+	if seat == nil {
+		t.Fatal("Seat not found — auto-create base branch failed")
+	}
+	if seat.NodeType != utils.BRANCH {
+		t.Errorf("Seat.NodeType = %q, want branch", seat.NodeType)
+	}
+	if int(seat.Children) != 2 {
+		t.Errorf("Seat.Children = %d, want 2 (Row1, Row2)", seat.Children)
+	}
+}
+
+func TestUnitFromDirectives_NoUnit(t *testing.T) {
+	// Field with no unit directive at all — covers the empty-string return path.
+	sdl := `
+type VehicleNU @vspec(element: BRANCH, fqn: "VehicleNU") {
+  flag: Boolean @vspec(element: SENSOR, fqn: "VehicleNU.Flag")
+}`
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatalf("ParseSDL: %v", err)
+	}
+	flag := findNode(roots[0], "Flag")
+	if flag == nil {
+		t.Fatal("Flag not found")
+	}
+	if flag.Unit != "" {
+		t.Errorf("Unit = %q, want empty for field with no unit directive", flag.Unit)
+	}
+}
+
+func TestUnitFromDirectives_AtUnitForm(t *testing.T) {
+	// @unit(value: "KM_PER_HOUR") form — covers the first loop in unitFromDirectives.
+	sdl := `
+type VehicleU @vspec(element: BRANCH, fqn: "VehicleU") {
+  speed: Float @vspec(element: SENSOR, fqn: "VehicleU.Speed") @unit(value: "KM_PER_HOUR")
+}`
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatalf("ParseSDL: %v", err)
+	}
+	speed := findNode(roots[0], "Speed")
+	if speed == nil {
+		t.Fatal("Speed not found")
+	}
+	if speed.Unit != "km/h" {
+		t.Errorf("Speed.Unit = %q, want km/h (via @unit directive)", speed.Unit)
+	}
+}
+
+func TestCollectDimensions_NonEnumBreaks(t *testing.T) {
+	// dimension1 typed as scalar (String) → collectDimensions breaks, no expansion.
+	sdl := `
+type VehicleCNE @vspec(element: BRANCH, fqn: "VehicleCNE") {
+  dummy: Boolean @vspec(element: ATTRIBUTE, fqn: "VehicleCNE.Dummy")
+}
+
+type VehicleCNE_InstanceTag @vspec(fqn: "VehicleCNE") @instanceTag {
+  dimension1: String
+}
+`
+	roots, _, err := ParseSDL(sdl)
+	if err != nil {
+		t.Fatalf("ParseSDL: %v", err)
+	}
+	if len(roots) == 0 {
+		t.Fatal("expected at least one root")
+	}
+	var cne *utils.Node_t
+	for _, r := range roots {
+		if r.Name == "VehicleCNE" {
+			cne = r
+			break
+		}
+	}
+	if cne == nil {
+		t.Fatal("VehicleCNE root not found")
+	}
+	// No instance branches (Row1/Row2) should have been added — only the Dummy attribute.
+	for _, child := range cne.Child {
+		if strings.HasPrefix(child.Name, "Row") || child.Name == "ROW1" || child.Name == "ROW2" {
+			t.Errorf("unexpected instance branch %q — collectDimensions should have broken on non-enum type", child.Name)
+		}
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func readFixture(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("readFixture(%q): %v", name, err)
+	}
+	return string(data)
+}

--- a/server/vissv2server/vdmloader/watcher.go
+++ b/server/vissv2server/vdmloader/watcher.go
@@ -1,0 +1,157 @@
+package vdmloader
+
+// watcher.go — fsnotify-based live-reload for VDM directories.
+// When any *.graphql file in a watched directory changes, the watcher
+// deregisters all trees previously loaded from that directory and calls
+// LoadDir again.
+
+import (
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/covesa/vissr/utils"
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watcher watches a directory of *.graphql files and reloads the VDM trees
+// whenever a file changes.  Create with NewWatcher and stop with Stop.
+type Watcher struct {
+	dir     string
+	w       *fsnotify.Watcher
+	mu      sync.Mutex
+	loaded  []string // rootNames last loaded from this dir
+	stopCh  chan struct{}
+	stopped chan struct{}
+}
+
+// NewWatcher creates a Watcher for dir and starts the background goroutine.
+// The caller should call Stop() when done.
+func NewWatcher(dir string) (*Watcher, error) {
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	if err := fw.Add(dir); err != nil {
+		fw.Close()
+		return nil, err
+	}
+
+	wt := &Watcher{
+		dir:     dir,
+		w:       fw,
+		stopCh:  make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+	// Record the names of trees already loaded by an initial LoadDir call.
+	wt.loaded = currentRootNames(dir)
+
+	go wt.loop()
+	return wt, nil
+}
+
+// Stop shuts down the watcher and waits for the background goroutine to exit.
+func (wt *Watcher) Stop() {
+	close(wt.stopCh)
+	<-wt.stopped
+	wt.w.Close()
+}
+
+// loop is the background event handler.
+func (wt *Watcher) loop() {
+	defer close(wt.stopped)
+
+	// Debounce: coalesce rapid writes (editors often do multiple writes per save).
+	var debounce <-chan time.Time
+
+	for {
+		select {
+		case <-wt.stopCh:
+			return
+
+		case event, ok := <-wt.w.Events:
+			if !ok {
+				return
+			}
+			if !isGraphQL(event.Name) {
+				continue
+			}
+			if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) ||
+				event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+				debounce = time.After(200 * time.Millisecond)
+			}
+
+		case err, ok := <-wt.w.Errors:
+			if !ok {
+				return
+			}
+			utils.Error.Printf("vdmloader watcher: %v", err)
+
+		case <-debounce:
+			debounce = nil
+			wt.reload()
+		}
+	}
+}
+
+// reload deregisters the previously loaded trees and reloads from the directory.
+func (wt *Watcher) reload() {
+	wt.mu.Lock()
+	prev := wt.loaded
+	wt.mu.Unlock()
+
+	for _, name := range prev {
+		utils.DeregisterServiceTree(name)
+	}
+
+	n, err := LoadDir(wt.dir)
+	if err != nil {
+		utils.Error.Printf("vdmloader watcher: reload %s: %v", wt.dir, err)
+		// Keep prev loaded list so we try to deregister them next time.
+		return
+	}
+
+	next := currentRootNames(wt.dir)
+	wt.mu.Lock()
+	wt.loaded = next
+	wt.mu.Unlock()
+
+	utils.Info.Printf("vdmloader watcher: reloaded %s (%d tree(s))", wt.dir, n)
+}
+
+// currentRootNames parses all *.graphql files in dir and returns the unique
+// root names — without registering anything in the forest.
+func currentRootNames(dir string) []string {
+	entries, err := graphqlFiles(dir)
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var names []string
+	for _, path := range entries {
+		_, metas, err := ParseFile(path)
+		if err != nil || len(metas) == 0 {
+			continue
+		}
+		for _, m := range metas {
+			if !seen[m.RootName] {
+				seen[m.RootName] = true
+				names = append(names, m.RootName)
+			}
+		}
+	}
+	return names
+}
+
+// graphqlFiles returns the absolute paths of *.graphql files in dir.
+func graphqlFiles(dir string) ([]string, error) {
+	entries, err := filepath.Glob(filepath.Join(dir, "*.graphql"))
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func isGraphQL(name string) bool {
+	return filepath.Ext(name) == ".graphql"
+}

--- a/server/vissv2server/vdmloader/watcher_test.go
+++ b/server/vissv2server/vdmloader/watcher_test.go
@@ -1,0 +1,276 @@
+package vdmloader
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/covesa/vissr/utils"
+)
+
+func init() {
+	utils.InitLog("watcher-log.txt", os.TempDir(), false, "info")
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func writeGraphQL(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+const minimalSDL = `
+type Vehicle @vspec(element: BRANCH, fqn: "Vehicle") {
+  Speed: Float @vspec(element: SENSOR, fqn: "Vehicle.Speed")
+}
+`
+
+const updatedSDL = `
+type Vehicle @vspec(element: BRANCH, fqn: "Vehicle") {
+  Speed: Float @vspec(element: SENSOR, fqn: "Vehicle.Speed")
+  Gear:  String @vspec(element: SENSOR, fqn: "Vehicle.Gear")
+}
+`
+
+const secondTreeSDL = `
+type Trailer @vspec(element: BRANCH, fqn: "Trailer") {
+  Weight: Float @vspec(element: SENSOR, fqn: "Trailer.Weight")
+}
+`
+
+// ── isGraphQL ─────────────────────────────────────────────────────────────────
+
+func TestIsGraphQL_True(t *testing.T) {
+	for _, name := range []string{"vehicle.graphql", "/tmp/x/foo.graphql"} {
+		if !isGraphQL(name) {
+			t.Errorf("isGraphQL(%q) = false, want true", name)
+		}
+	}
+}
+
+func TestIsGraphQL_False(t *testing.T) {
+	for _, name := range []string{"vehicle.go", "foo.graphql.bak", "README.md", ""} {
+		if isGraphQL(name) {
+			t.Errorf("isGraphQL(%q) = true, want false", name)
+		}
+	}
+}
+
+// ── graphqlFiles ──────────────────────────────────────────────────────────────
+
+func TestGraphqlFiles_Empty(t *testing.T) {
+	dir := t.TempDir()
+	files, err := graphqlFiles(dir)
+	if err != nil {
+		t.Fatalf("graphqlFiles: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("expected 0 files, got %d", len(files))
+	}
+}
+
+func TestGraphqlFiles_OnlyGraphQL(t *testing.T) {
+	dir := t.TempDir()
+	writeGraphQL(t, dir, "a.graphql", minimalSDL)
+	writeGraphQL(t, dir, "b.graphql", secondTreeSDL)
+	// should not be returned
+	os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("hi"), 0644)
+
+	files, err := graphqlFiles(dir)
+	if err != nil {
+		t.Fatalf("graphqlFiles: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("expected 2 .graphql files, got %d", len(files))
+	}
+}
+
+// ── currentRootNames ──────────────────────────────────────────────────────────
+
+func TestCurrentRootNames_Empty(t *testing.T) {
+	dir := t.TempDir()
+	names := currentRootNames(dir)
+	if len(names) != 0 {
+		t.Errorf("expected 0 names, got %v", names)
+	}
+}
+
+func TestCurrentRootNames_Single(t *testing.T) {
+	dir := t.TempDir()
+	writeGraphQL(t, dir, "v.graphql", minimalSDL)
+	names := currentRootNames(dir)
+	if len(names) != 1 || names[0] != "Vehicle" {
+		t.Errorf("expected [Vehicle], got %v", names)
+	}
+}
+
+func TestCurrentRootNames_Multiple(t *testing.T) {
+	dir := t.TempDir()
+	writeGraphQL(t, dir, "v.graphql", minimalSDL)
+	writeGraphQL(t, dir, "t.graphql", secondTreeSDL)
+	names := currentRootNames(dir)
+	if len(names) != 2 {
+		t.Errorf("expected 2 names, got %v", names)
+	}
+}
+
+func TestCurrentRootNames_InvalidFile(t *testing.T) {
+	dir := t.TempDir()
+	writeGraphQL(t, dir, "bad.graphql", "this is not valid SDL {{{{")
+	// Should not panic; returns empty list.
+	names := currentRootNames(dir)
+	if len(names) != 0 {
+		t.Errorf("expected 0 names for invalid SDL, got %v", names)
+	}
+}
+
+// ── NewWatcher / Stop ─────────────────────────────────────────────────────────
+
+func TestNewWatcher_NonExistentDir(t *testing.T) {
+	_, err := NewWatcher("/nonexistent-vissr-test-dir-xyz/")
+	if err == nil {
+		t.Error("expected error for non-existent directory")
+	}
+}
+
+func TestNewWatcher_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	wt, err := NewWatcher(dir)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	wt.Stop()
+}
+
+func TestWatcher_StopIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	wt, err := NewWatcher(dir)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	wt.Stop()
+	// Second Stop would panic if stopCh was closed twice — but since loop
+	// exits on the first close, the channel receive in Stop just returns.
+	// Verify the stopped channel is already closed (non-blocking receive).
+	select {
+	case <-wt.stopped:
+		// expected
+	default:
+		t.Error("stopped channel not closed after Stop()")
+	}
+}
+
+// ── live-reload ───────────────────────────────────────────────────────────────
+
+// waitForTree polls the forest for rootName up to deadline.
+func waitForTree(rootName string, present bool, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		root := utils.GetForestRoot(rootName)
+		if present && root != nil {
+			return true
+		}
+		if !present && root == nil {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}
+
+func TestWatcher_ReloadOnWrite(t *testing.T) {
+	dir := t.TempDir()
+	writeGraphQL(t, dir, "v.graphql", minimalSDL)
+
+	// Ensure clean state.
+	utils.DeregisterServiceTree("Vehicle")
+
+	// Initial load.
+	n, err := LoadDir(dir)
+	if err != nil || n == 0 {
+		t.Fatalf("LoadDir: n=%d err=%v", n, err)
+	}
+	t.Cleanup(func() { utils.DeregisterServiceTree("Vehicle") })
+
+	wt, err := NewWatcher(dir)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	t.Cleanup(wt.Stop)
+
+	// Overwrite — watcher should deregister + reload.
+	writeGraphQL(t, dir, "v.graphql", updatedSDL)
+
+	// Wait for reload (watcher debounces 200ms + processing time).
+	if !waitForTree("Vehicle", true, 2*time.Second) {
+		t.Error("Vehicle tree was not reloaded after write")
+	}
+}
+
+func TestWatcher_ReloadOnCreate(t *testing.T) {
+	dir := t.TempDir()
+	utils.DeregisterServiceTree("Trailer")
+
+	wt, err := NewWatcher(dir)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	t.Cleanup(func() {
+		wt.Stop()
+		utils.DeregisterServiceTree("Trailer")
+	})
+
+	// Create a new file — watcher should pick it up.
+	writeGraphQL(t, dir, "trailer.graphql", secondTreeSDL)
+
+	if !waitForTree("Trailer", true, 2*time.Second) {
+		t.Error("Trailer tree was not loaded after file creation")
+	}
+}
+
+func TestWatcher_ReloadOnDelete(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGraphQL(t, dir, "v.graphql", minimalSDL)
+
+	utils.DeregisterServiceTree("Vehicle")
+
+	n, err := LoadDir(dir)
+	if err != nil || n == 0 {
+		t.Fatalf("LoadDir: n=%d err=%v", n, err)
+	}
+	t.Cleanup(func() { utils.DeregisterServiceTree("Vehicle") })
+
+	wt, err := NewWatcher(dir)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	t.Cleanup(wt.Stop)
+
+	// Delete the file — watcher should deregister the tree.
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	if !waitForTree("Vehicle", false, 2*time.Second) {
+		t.Error("Vehicle tree still in forest after file deletion")
+	}
+}
+
+// ── FuzzIsGraphQL ─────────────────────────────────────────────────────────────
+
+func FuzzIsGraphQL(f *testing.F) {
+	f.Add("vehicle.graphql")
+	f.Add("vehicle.go")
+	f.Add("")
+	f.Add(".graphql")
+	f.Add("a/b/c.graphql")
+	f.Fuzz(func(t *testing.T, name string) {
+		// Must not panic on any input.
+		_ = isGraphQL(name)
+	})
+}

--- a/server/vissv2server/vissv2server.go
+++ b/server/vissv2server/vissv2server.go
@@ -33,6 +33,8 @@ import (
 	"github.com/covesa/vissr/server/vissv2server/httpMgr"
 	"github.com/covesa/vissr/server/vissv2server/mqttMgr"
 	"github.com/covesa/vissr/server/vissv2server/serviceMgr"
+	"github.com/covesa/vissr/server/vissv2server/vdmloader"
+	"github.com/covesa/vissr/server/vissv2server/webdash"
 	"github.com/covesa/vissr/server/vissv2server/vissServiceMgr"
 	"github.com/covesa/vissr/server/vissv2server/wsMgr"
 	"github.com/covesa/vissr/server/vissv2server/wsMgrFT"
@@ -1071,6 +1073,8 @@ func main() {
 		Default:  "serviceMgr/statestorage.db"})
 	consentSupport := parser.Flag("c", "consentsupport", &argparse.Options{Required: false, Help: "try to connect to ECF", Default: false})
 	mqttEnable := parser.Flag("m", "mqttenable", &argparse.Options{Required: false, Help: "enable MQTT usage", Default: false})
+	vdmDir := parser.String("", "vdm", &argparse.Options{Required: false, Help: "directory of VDM .graphql SDL files to load (mutually exclusive with viss.him)", Default: ""})
+	webAddr := parser.String("", "web-addr", &argparse.Options{Required: false, Help: "address for optional VDM web dashboard (e.g. :8090); disabled when empty", Default: ""})
 
 	// Parse input
 	err := parser.Parse(os.Args)
@@ -1081,9 +1085,24 @@ func main() {
 
 	utils.InitLog("servercore-log.txt", "./logs", *logFile, *logLevel)
 
-	if !utils.InitForest("viss.him") {
-		utils.Error.Printf("Failed to initialize viss.him")
-		return
+	if *vdmDir != "" {
+		n, err := vdmloader.LoadDir(*vdmDir)
+		if err != nil {
+			utils.Error.Printf("Failed to load VDM from %s: %v", *vdmDir, err)
+			return
+		}
+		utils.Info.Printf("VDM loader: registered %d tree(s) from %s", n, *vdmDir)
+	} else {
+		if !utils.InitForest("viss.him") {
+			utils.Error.Printf("Failed to initialize viss.him")
+			return
+		}
+	}
+
+	if *webAddr != "" {
+		if err := webdash.Start(*webAddr); err != nil {
+			utils.Error.Printf("webdash: failed to start on %s: %v", *webAddr, err)
+		}
 	}
 
 	if *dPop {

--- a/server/vissv2server/vissv2server.go
+++ b/server/vissv2server/vissv2server.go
@@ -1074,6 +1074,7 @@ func main() {
 	consentSupport := parser.Flag("c", "consentsupport", &argparse.Options{Required: false, Help: "try to connect to ECF", Default: false})
 	mqttEnable := parser.Flag("m", "mqttenable", &argparse.Options{Required: false, Help: "enable MQTT usage", Default: false})
 	vdmDir := parser.String("", "vdm", &argparse.Options{Required: false, Help: "directory of VDM .graphql SDL files to load (mutually exclusive with viss.him)", Default: ""})
+	vdmWatch := parser.Flag("", "vdm-watch", &argparse.Options{Required: false, Help: "watch --vdm directory for changes and reload trees automatically", Default: false})
 	webAddr := parser.String("", "web-addr", &argparse.Options{Required: false, Help: "address for optional VDM web dashboard (e.g. :8090); disabled when empty", Default: ""})
 
 	// Parse input
@@ -1092,6 +1093,15 @@ func main() {
 			return
 		}
 		utils.Info.Printf("VDM loader: registered %d tree(s) from %s", n, *vdmDir)
+		if *vdmWatch {
+			watcher, werr := vdmloader.NewWatcher(*vdmDir)
+			if werr != nil {
+				utils.Error.Printf("VDM watcher: failed to start for %s: %v", *vdmDir, werr)
+			} else {
+				utils.Info.Printf("VDM watcher: watching %s for changes", *vdmDir)
+				defer watcher.Stop()
+			}
+		}
 	} else {
 		if !utils.InitForest("viss.him") {
 			utils.Error.Printf("Failed to initialize viss.him")

--- a/server/vissv2server/vissv2server_helpers_test.go
+++ b/server/vissv2server/vissv2server_helpers_test.go
@@ -23,11 +23,15 @@ package main
 
 import (
 	"crypto/sha1"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/covesa/vissr/utils"
 )
 
 // TestExtractMgrId checks the "mgrId?clientId" parser used by the
@@ -89,7 +93,7 @@ func TestCountPathSegments(t *testing.T) {
 // TestGetTokenErrorMessage covers every documented error-code index
 // plus an unknown-index baseline.
 func TestGetTokenErrorMessage(t *testing.T) {
-	knownIndices := []int{1, 2, 5, 6, 10, 11, 15, 16, 20, 21, 30, 40, 41, 42, 60}
+	knownIndices := []int{1, 2, 5, 6, 10, 11, 15, 16, 20, 21, 22, 30, 40, 41, 42, 60, 61}
 	for _, idx := range knownIndices {
 		t.Run("known", func(t *testing.T) {
 			got := getTokenErrorMessage(idx)
@@ -312,6 +316,14 @@ func TestGetRangeBoundary(t *testing.T) {
 	}
 }
 
+func TestGetRangeBoundary_NonStringValueIgnored(t *testing.T) {
+	// numeric value hits the default branch and is logged, boundary stays ""
+	got := getRangeBoundary(map[string]interface{}{"boundary": 42})
+	if got != "" {
+		t.Errorf("getRangeBoundary with non-string boundary = %q; want \"\"", got)
+	}
+}
+
 // TestGetRangeBoundaries handles both shapes the filter parser
 // produces: a single object (one boundary) and an array of objects
 // (two boundaries).
@@ -397,4 +409,232 @@ func FuzzGetRangeBoundaries(f *testing.F) {
 		}()
 		_, _ = getRangeBoundaries(in)
 	})
+}
+
+// ── isServiceAction ──────────────────────────────────────────────────────────
+
+func TestIsServiceAction_TrueCases(t *testing.T) {
+	for _, action := range []string{"invoke", "monitor", "cancel", "discover"} {
+		if !isServiceAction(action) {
+			t.Errorf("isServiceAction(%q) = false; want true", action)
+		}
+	}
+}
+
+func TestIsServiceAction_FalseCases(t *testing.T) {
+	for _, action := range []string{"get", "set", "subscribe", "unsubscribe", "internal-killsubscriptions", ""} {
+		if isServiceAction(action) {
+			t.Errorf("isServiceAction(%q) = true; want false", action)
+		}
+	}
+}
+
+// ── getTokenContext ──────────────────────────────────────────────────────────
+
+// jwtWith builds a minimal unsigned JWT whose payload contains the given claims.
+func jwtWith(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	hdr, _ := json.Marshal(map[string]string{"alg": "none"})
+	pay, _ := json.Marshal(claims)
+	return base64.RawURLEncoding.EncodeToString(hdr) + "." +
+		base64.RawURLEncoding.EncodeToString(pay) + ".sig"
+}
+
+func TestGetTokenContext_WithStringAuthorization(t *testing.T) {
+	jwt := jwtWith(t, map[string]interface{}{"clx": "Owner+OEM+Vehicle"})
+	got := getTokenContext(map[string]interface{}{"authorization": jwt})
+	if got != "Owner+OEM+Vehicle" {
+		t.Errorf("getTokenContext with clx claim = %q; want %q", got, "Owner+OEM+Vehicle")
+	}
+}
+
+func TestGetTokenContext_JWTWithoutClxReturnsEmpty(t *testing.T) {
+	jwt := jwtWith(t, map[string]interface{}{"sub": "user1"})
+	got := getTokenContext(map[string]interface{}{"authorization": jwt})
+	if got != "" {
+		t.Errorf("getTokenContext without clx = %q; want \"\"", got)
+	}
+}
+
+// ── jsonifyTreeNode ──────────────────────────────────────────────────────────
+
+func TestJsonifyTreeNode_DepthLimitReturnsInputBuffer(t *testing.T) {
+	node := utils.NewSignalNode("Speed", utils.SENSOR, "float32", "Vehicle speed", "", "", "km/h")
+	got := jsonifyTreeNode(node, "prefix", 3, 3) // depth >= maxDepth → early return
+	if got != "prefix" {
+		t.Errorf("jsonifyTreeNode at depth limit = %q; want %q", got, "prefix")
+	}
+}
+
+func TestJsonifyTreeNode_SignalNode(t *testing.T) {
+	node := utils.NewSignalNode("Speed", utils.SENSOR, "float32", "Vehicle speed", "", "", "km/h")
+	got := jsonifyTreeNode(node, "", 0, 2)
+	if !strings.Contains(got, `"Speed":{`) {
+		t.Errorf("missing node name in output: %s", got)
+	}
+	if !strings.Contains(got, `"type":"sensor"`) {
+		t.Errorf("missing type in output: %s", got)
+	}
+	if !strings.Contains(got, `"datatype":"float32"`) {
+		t.Errorf("missing datatype in output: %s", got)
+	}
+	if !strings.Contains(got, `"description":"Vehicle speed"`) {
+		t.Errorf("missing description in output: %s", got)
+	}
+}
+
+func TestJsonifyTreeNode_BranchWithChild(t *testing.T) {
+	child := utils.NewSignalNode("Speed", utils.SENSOR, "float32", "Vehicle speed", "", "", "km/h")
+	branch := utils.NewBranchNode("Vehicle", child)
+	got := jsonifyTreeNode(branch, "", 0, 3)
+	if !strings.Contains(got, `"Vehicle":{`) {
+		t.Errorf("missing branch node in output: %s", got)
+	}
+	if !strings.Contains(got, `"children":{`) {
+		t.Errorf("missing children block in output: %s", got)
+	}
+	if !strings.Contains(got, `"Speed":{`) {
+		t.Errorf("missing child node in output: %s", got)
+	}
+}
+
+func TestJsonifyTreeNode_WithDefaultValue(t *testing.T) {
+	node := &utils.Node_t{
+		Name:         "Gear",
+		NodeType:     utils.ACTUATOR,
+		DefaultValue: "1",
+		Description:  "Current gear",
+		Datatype:     "uint8",
+	}
+	got := jsonifyTreeNode(node, "", 0, 2)
+	if !strings.Contains(got, `"default":"1"`) {
+		t.Errorf("missing default field in output: %s", got)
+	}
+}
+
+func TestJsonifyTreeNode_WithObjectDefault(t *testing.T) {
+	// When DefaultValue starts with '{' or '[' it is embedded without extra quotes.
+	node := &utils.Node_t{
+		Name:         "Config",
+		NodeType:     utils.SENSOR,
+		DefaultValue: `{'key':'val'}`,
+		Description:  "Config obj",
+	}
+	got := jsonifyTreeNode(node, "", 0, 2)
+	if !strings.Contains(got, `"default":`) {
+		t.Errorf("missing default field in output: %s", got)
+	}
+	// singleToDoubleQuote should have converted the single quotes
+	if !strings.Contains(got, `"key"`) {
+		t.Errorf("singleToDoubleQuote not applied to default value: %s", got)
+	}
+}
+
+// ── himJsonify ───────────────────────────────────────────────────────────────
+
+// chdirTest changes to dir for the duration of t and restores cwd in cleanup.
+// Uses os.Chdir because t.Chdir requires Go 1.24 and our module is pinned to 1.22.
+func chdirTest(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
+// TestHimJsonify_MissingFileReturnsEmpty covers the os.ReadFile error path.
+func TestHimJsonify_MissingFileReturnsEmpty(t *testing.T) {
+	chdirTest(t, t.TempDir())
+	got := himJsonify()
+	if got != "" {
+		t.Errorf("himJsonify with no viss.him = %q; want \"\"", got)
+	}
+}
+
+// TestHimJsonify_InvalidYAMLReturnsEmpty covers the yaml.Unmarshal error path.
+func TestHimJsonify_InvalidYAMLReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "viss.him"), []byte(":\tbad yaml\x00"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	chdirTest(t, dir)
+	got := himJsonify()
+	if got != "" {
+		t.Errorf("himJsonify with bad YAML = %q; want \"\"", got)
+	}
+}
+
+// TestHimJsonify_ValidYAMLReturnsJSON covers the success path.
+func TestHimJsonify_ValidYAMLReturnsJSON(t *testing.T) {
+	dir := t.TempDir()
+	yml := "section:\n  key: value\n  other: 42\n"
+	if err := os.WriteFile(filepath.Join(dir, "viss.him"), []byte(yml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	chdirTest(t, dir)
+	got := himJsonify()
+	if got == "" {
+		t.Fatal("himJsonify returned empty string for valid YAML")
+	}
+	if got[0] != '{' {
+		t.Errorf("himJsonify result is not JSON: %q", got)
+	}
+}
+
+func TestJsonifyTreeNode_AppendsToExistingBuffer(t *testing.T) {
+	node := utils.NewSignalNode("RPM", utils.SENSOR, "uint16", "Engine RPM", "", "", "rpm")
+	got := jsonifyTreeNode(node, `"existing":true,`, 0, 2)
+	if !strings.HasPrefix(got, `"existing":true,`) {
+		t.Errorf("existing buffer not preserved; got: %s", got)
+	}
+	if !strings.Contains(got, `"RPM":{`) {
+		t.Errorf("new node not appended; got: %s", got)
+	}
+}
+
+// ── isServiceTree ────────────────────────────────────────────────────────────
+
+// registerTestServiceTree registers a synthetic service tree and returns a
+// cleanup function that deregisters it. Callers must defer the cleanup.
+func registerTestServiceTree(t *testing.T, rootName, domain string) func() {
+	t.Helper()
+	root := utils.NewBranchNode(rootName)
+	utils.RegisterServiceTree(rootName, domain, "1.0", root)
+	return func() { utils.DeregisterServiceTree(rootName) }
+}
+
+func TestIsServiceTree_NoPathKeyReturnsFalse(t *testing.T) {
+	if isServiceTree(map[string]interface{}{}) {
+		t.Error("isServiceTree with no path key should return false")
+	}
+}
+
+func TestIsServiceTree_NonStringPathReturnsFalse(t *testing.T) {
+	if isServiceTree(map[string]interface{}{"path": 42}) {
+		t.Error("isServiceTree with non-string path should return false")
+	}
+}
+
+func TestIsServiceTree_UnknownRootReturnsFalse(t *testing.T) {
+	if isServiceTree(map[string]interface{}{"path": "UnknownRoot.Invoke"}) {
+		t.Error("isServiceTree with unregistered root should return false")
+	}
+}
+
+func TestIsServiceTree_NonServiceDomainReturnsFalse(t *testing.T) {
+	defer registerTestServiceTree(t, "TestData", "Vehicle.Car.Data")()
+	if isServiceTree(map[string]interface{}{"path": "TestData.SomeLeaf"}) {
+		t.Error("isServiceTree with non-service domain should return false")
+	}
+}
+
+func TestIsServiceTree_ServiceDomainReturnsTrue(t *testing.T) {
+	defer registerTestServiceTree(t, "TestSvc", "Vehicle.Car.Service")()
+	if !isServiceTree(map[string]interface{}{"path": "TestSvc.Invoke"}) {
+		t.Error("isServiceTree with .Service domain should return true")
+	}
 }

--- a/server/vissv2server/webdash/embed.go
+++ b/server/vissv2server/webdash/embed.go
@@ -1,0 +1,6 @@
+package webdash
+
+import "embed"
+
+//go:embed static
+var embeddedStatic embed.FS

--- a/server/vissv2server/webdash/static/index.html
+++ b/server/vissv2server/webdash/static/index.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>vissr — VDM Signal Tree</title>
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+:root {
+  --bg: #1a1d23; --surface: #23272e; --border: #363b45;
+  --text: #d4d8e0; --muted: #7c8391; --accent: #4c9be8;
+  --green: #56d364; --orange: #e8963c; --purple: #bc8cff; --red: #f47067; --yellow: #d29922;
+  --sensor: var(--green); --actuator: var(--orange);
+  --attribute: var(--purple); --branch: var(--muted);
+  --procedure: var(--red);
+}
+body { background: var(--bg); color: var(--text); font-family: "Segoe UI", system-ui, sans-serif; font-size: 14px; display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
+
+/* ── header ── */
+header { background: var(--surface); border-bottom: 1px solid var(--border); padding: .5rem 1rem; display: flex; align-items: center; gap: .75rem; flex-shrink: 0; flex-wrap: wrap; }
+header h1 { font-size: .95rem; font-weight: 600; color: var(--accent); letter-spacing: .04em; white-space: nowrap; }
+header select { background: var(--bg); border: 1px solid var(--border); color: var(--text); padding: .3rem .6rem; border-radius: 4px; font-size: 13px; cursor: pointer; }
+header select:focus { outline: none; border-color: var(--accent); }
+.hdr-btn { background: rgba(255,255,255,.07); border: 1px solid var(--border); color: var(--text); padding: .28rem .7rem; border-radius: 4px; font-size: 12px; cursor: pointer; white-space: nowrap; }
+.hdr-btn:hover { background: rgba(255,255,255,.12); }
+.hdr-btn.active { border-color: var(--accent); color: var(--accent); }
+#health-bar { margin-left: auto; display: flex; align-items: center; gap: .5rem; font-size: 11px; color: var(--muted); white-space: nowrap; }
+.health-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--muted); flex-shrink: 0; }
+.health-dot.live { background: var(--green); }
+
+/* ── layout ── */
+main { display: flex; flex: 1; overflow: hidden; }
+
+/* ── tree panel ── */
+#tree-panel { width: 42%; min-width: 260px; background: var(--surface); border-right: 1px solid var(--border); display: flex; flex-direction: column; }
+#search { display: block; width: calc(100% - 1rem); margin: .5rem; padding: .4rem .7rem; background: var(--bg); border: 1px solid var(--border); border-radius: 4px; color: var(--text); font-size: 13px; flex-shrink: 0; }
+#search:focus { outline: none; border-color: var(--accent); }
+#search::placeholder { color: var(--muted); }
+#tree-root { flex: 1; overflow-y: auto; padding: 0 0 1rem 0; }
+
+/* ── search results pane ── */
+#search-results { display: none; flex: 1; overflow-y: auto; padding: .5rem; }
+#search-results.visible { display: block; }
+.search-hit { padding: .3rem .5rem; border-radius: 3px; cursor: pointer; font-size: 12px; font-family: monospace; color: var(--accent); }
+.search-hit:hover { background: rgba(255,255,255,.05); }
+.search-hit-meta { color: var(--muted); margin-left: .5rem; font-family: sans-serif; }
+
+/* ── tree items ── */
+.tree-item { display: flex; align-items: center; gap: .4rem; padding: .22rem .5rem .22rem 0; cursor: pointer; white-space: nowrap; border-radius: 3px; margin: 0 .25rem; }
+.tree-item:hover { background: rgba(255,255,255,.05); }
+.tree-item.selected { background: rgba(76,155,232,.18); }
+.tree-indent { display: inline-block; width: 16px; flex-shrink: 0; }
+.toggle { width: 16px; text-align: center; flex-shrink: 0; color: var(--muted); font-size: 10px; user-select: none; }
+.node-name { flex: 1; overflow: hidden; text-overflow: ellipsis; font-size: 13px; }
+.node-badge { font-size: 10px; padding: .1em .45em; border-radius: 3px; font-weight: 600; flex-shrink: 0; text-transform: uppercase; letter-spacing: .04em; }
+.badge-branch    { background: rgba(124,131,145,.2); color: var(--muted); }
+.badge-sensor    { background: rgba(86,211,100,.15); color: var(--sensor); }
+.badge-actuator  { background: rgba(232,150,60,.15);  color: var(--actuator); }
+.badge-attribute { background: rgba(188,140,255,.15); color: var(--attribute); }
+.badge-procedure { background: rgba(244,112,103,.15); color: var(--procedure); }
+.tree-children { }
+
+/* ── detail panel ── */
+#detail-panel { flex: 1; overflow-y: auto; padding: 1.5rem; }
+#detail-panel h2 { font-size: 1.05rem; margin-bottom: 1rem; color: var(--text); display: flex; align-items: center; gap: .6rem; }
+#detail-panel .empty { color: var(--muted); font-size: 13px; margin-top: 2rem; text-align: center; }
+.detail-grid { display: grid; grid-template-columns: 140px 1fr; gap: .4rem 1rem; }
+.detail-label { color: var(--muted); font-size: 12px; padding-top: .1rem; }
+.detail-value { color: var(--text); font-size: 13px; word-break: break-all; }
+.detail-value.path { font-family: monospace; font-size: 12px; color: var(--accent); display: flex; align-items: center; gap: .4rem; }
+.copy-btn { background: none; border: 1px solid var(--border); color: var(--muted); font-size: 11px; padding: .1em .4em; border-radius: 3px; cursor: pointer; flex-shrink: 0; }
+.copy-btn:hover { color: var(--text); border-color: var(--text); }
+.copy-btn.copied { color: var(--green); border-color: var(--green); }
+.allowed-chips { display: flex; flex-wrap: wrap; gap: .3rem; }
+.allowed-chip { background: rgba(188,140,255,.15); color: var(--attribute); padding: .15em .5em; border-radius: 3px; font-size: 12px; }
+hr.divider { border: none; border-top: 1px solid var(--border); margin: 1rem 0; }
+
+/* ── validate panel ── */
+#validate-panel { display: none; }
+#validate-panel.visible { display: block; }
+.validate-header { font-size: 13px; font-weight: 600; margin-bottom: .6rem; color: var(--text); }
+.issue-item { display: flex; gap: .5rem; align-items: baseline; padding: .3rem 0; border-bottom: 1px solid var(--border); font-size: 12px; }
+.issue-item:last-child { border-bottom: none; }
+.issue-sev { font-size: 10px; font-weight: 700; padding: .1em .4em; border-radius: 3px; text-transform: uppercase; flex-shrink: 0; }
+.issue-sev.error   { background: rgba(244,112,103,.2); color: var(--red); }
+.issue-sev.warning { background: rgba(210,153,34,.2);  color: var(--yellow); }
+.issue-path { font-family: monospace; color: var(--accent); }
+.issue-msg  { color: var(--muted); }
+.issue-none { color: var(--green); font-size: 13px; padding: .5rem 0; }
+
+/* ── scrollbar ── */
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>vissr VDM</h1>
+  <select id="forest-select"><option value="">Loading…</option></select>
+  <button class="hdr-btn" id="validate-btn" title="Validate current tree">Validate</button>
+  <div id="health-bar">
+    <span class="health-dot" id="health-dot"></span>
+    <span id="health-text">—</span>
+  </div>
+</header>
+
+<main>
+  <div id="tree-panel">
+    <input id="search" type="search" placeholder="Filter or search all trees (Enter)…">
+    <div id="tree-root"></div>
+    <div id="search-results"></div>
+  </div>
+  <div id="detail-panel">
+    <p class="empty">Select a signal node to see its properties.</p>
+  </div>
+</main>
+
+<script>
+// ── state ───────────────────────────────────────────────────────────────────
+let treeData = null;
+let selected = null;
+let currentRoot = null;
+
+// ── bootstrap ────────────────────────────────────────────────────────────────
+async function init() {
+  connectSSE();
+  const forestRes = await fetch('/api/forest').catch(() => null);
+  if (!forestRes || !forestRes.ok) {
+    document.getElementById('health-text').textContent = 'Error: /api/forest unreachable';
+    return;
+  }
+  const forest = await forestRes.json();
+  const sel = document.getElementById('forest-select');
+  sel.innerHTML = '';
+  if (!forest || forest.length === 0) {
+    sel.innerHTML = '<option>No trees loaded</option>';
+    return;
+  }
+  forest.forEach(f => {
+    const opt = document.createElement('option');
+    opt.value = f.rootName;
+    opt.textContent = `${f.rootName}  (${f.domain} v${f.version})`;
+    sel.appendChild(opt);
+  });
+  sel.addEventListener('change', () => loadTree(sel.value));
+  loadTree(sel.value);
+}
+
+async function loadTree(rootName) {
+  if (!rootName) return;
+  currentRoot = rootName;
+  document.getElementById('tree-root').innerHTML = '';
+  clearDetail();
+  hideSearchResults();
+  const res = await fetch(`/api/tree/${rootName}`).catch(() => null);
+  if (!res || !res.ok) {
+    document.getElementById('health-text').textContent = `Error loading ${rootName}`;
+    return;
+  }
+  treeData = await res.json();
+  renderTree(treeData, document.getElementById('tree-root'), '');
+}
+
+// ── SSE health ────────────────────────────────────────────────────────────────
+function connectSSE() {
+  const es = new EventSource('/api/events');
+  es.addEventListener('health', e => {
+    try {
+      const h = JSON.parse(e.data);
+      const mb = h.heapMB.toFixed(1);
+      const upMin = Math.floor(h.uptimeS / 60);
+      const upSec = h.uptimeS % 60;
+      const up = upMin > 0 ? `${upMin}m${upSec}s` : `${upSec}s`;
+      document.getElementById('health-text').textContent =
+        `${h.goroutines} goroutines · ${mb} MB heap · up ${up} · ${h.trees} tree${h.trees !== 1 ? 's' : ''}`;
+      document.getElementById('health-dot').className = 'health-dot live';
+    } catch (_) {}
+  });
+  es.onerror = () => {
+    document.getElementById('health-dot').className = 'health-dot';
+  };
+}
+
+// ── tree rendering ───────────────────────────────────────────────────────────
+function renderTree(node, container, parentPath, depth = 0) {
+  const path = parentPath ? `${parentPath}.${node.name}` : node.name;
+  const hasCh = node.children && node.children.length > 0;
+
+  const item = document.createElement('div');
+  item.className = 'tree-item';
+  item.dataset.path = path;
+  item.dataset.node = JSON.stringify(node);
+
+  for (let i = 0; i < depth; i++) {
+    const ind = document.createElement('span');
+    ind.className = 'tree-indent';
+    item.appendChild(ind);
+  }
+
+  const toggle = document.createElement('span');
+  toggle.className = 'toggle';
+  toggle.textContent = hasCh ? '▶' : '';
+  item.appendChild(toggle);
+
+  const nameEl = document.createElement('span');
+  nameEl.className = 'node-name';
+  nameEl.textContent = node.name;
+  item.appendChild(nameEl);
+
+  const badge = document.createElement('span');
+  badge.className = `node-badge badge-${node.nodeType || 'branch'}`;
+  badge.textContent = node.nodeType || 'branch';
+  item.appendChild(badge);
+
+  container.appendChild(item);
+
+  let childContainer = null;
+  let expanded = depth < 1;
+
+  if (hasCh) {
+    childContainer = document.createElement('div');
+    childContainer.className = 'tree-children';
+    childContainer.style.display = expanded ? '' : 'none';
+    toggle.textContent = expanded ? '▼' : '▶';
+    node.children.forEach(ch => renderTree(ch, childContainer, path, depth + 1));
+    container.appendChild(childContainer);
+
+    toggle.addEventListener('click', e => {
+      e.stopPropagation();
+      expanded = !expanded;
+      childContainer.style.display = expanded ? '' : 'none';
+      toggle.textContent = expanded ? '▼' : '▶';
+    });
+  }
+
+  item.addEventListener('click', () => {
+    if (selected) selected.classList.remove('selected');
+    item.classList.add('selected');
+    selected = item;
+    hideValidate();
+    showDetail(JSON.parse(item.dataset.node), item.dataset.path);
+  });
+}
+
+// ── detail panel ─────────────────────────────────────────────────────────────
+function clearDetail() {
+  document.getElementById('detail-panel').innerHTML = '<p class="empty">Select a signal node to see its properties.</p>';
+}
+
+function showDetail(node, path) {
+  const panel = document.getElementById('detail-panel');
+  const rows = [];
+
+  const row = (label, value, cls = '') =>
+    `<div class="detail-label">${label}</div><div class="detail-value ${cls}">${value}</div>`;
+
+  const pathHtml = `<span style="font-family:monospace;font-size:12px;color:var(--accent)">${escHtml(path)}</span>
+    <button class="copy-btn" onclick="copyFQN(this,'${escAttr(path)}')" title="Copy FQN">copy</button>`;
+  rows.push(`<div class="detail-label">Path</div><div class="detail-value path">${pathHtml}</div>`);
+  rows.push(row('Node type', badgeHtml(node.nodeType)));
+  if (node.datatype)    rows.push(row('Datatype',    escHtml(node.datatype)));
+  if (node.unit)        rows.push(row('Unit',        escHtml(node.unit)));
+  if (node.min || node.max) rows.push(row('Range', `${node.min || '—'} … ${node.max || '—'}`));
+  if (node.default)     rows.push(row('Default',     escHtml(node.default)));
+  if (node.description) rows.push(row('Description', escHtml(node.description)));
+
+  let allowedHtml = '';
+  if (node.allowed && node.allowed.length > 0) {
+    const chips = node.allowed.map(v => `<span class="allowed-chip">${escHtml(v)}</span>`).join('');
+    allowedHtml = `<hr class="divider"><div class="detail-grid">
+      <div class="detail-label">Allowed values</div>
+      <div class="detail-value"><div class="allowed-chips">${chips}</div></div>
+    </div>`;
+  }
+
+  let childCount = '';
+  if (node.children && node.children.length > 0) {
+    childCount = `<hr class="divider"><div class="detail-grid">${row('Children', node.children.length)}</div>`;
+  }
+
+  panel.innerHTML = `
+    <h2>${escHtml(node.name)} ${badgeHtml(node.nodeType)}</h2>
+    <div class="detail-grid">${rows.join('')}</div>
+    ${allowedHtml}
+    ${childCount}
+    <div id="validate-panel"></div>
+  `;
+}
+
+function copyFQN(btn, path) {
+  navigator.clipboard.writeText(path).then(() => {
+    btn.textContent = 'copied!';
+    btn.className = 'copy-btn copied';
+    setTimeout(() => { btn.textContent = 'copy'; btn.className = 'copy-btn'; }, 1500);
+  }).catch(() => {
+    btn.textContent = 'err';
+    setTimeout(() => { btn.textContent = 'copy'; }, 1500);
+  });
+}
+
+function badgeHtml(type) {
+  return `<span class="node-badge badge-${type || 'branch'}">${type || 'branch'}</span>`;
+}
+
+// ── validate ──────────────────────────────────────────────────────────────────
+document.getElementById('validate-btn').addEventListener('click', async () => {
+  if (!currentRoot) return;
+  const btn = document.getElementById('validate-btn');
+  btn.textContent = 'Validating…';
+  btn.disabled = true;
+
+  const res = await fetch(`/api/validate/${currentRoot}`).catch(() => null);
+  btn.textContent = 'Validate';
+  btn.disabled = false;
+
+  if (!res || !res.ok) {
+    alert('Validate failed — is the tree loaded?');
+    return;
+  }
+  const issues = await res.json();
+
+  // Show validate panel in detail area, replacing whatever was there.
+  const panel = document.getElementById('detail-panel');
+  if (issues.length === 0) {
+    panel.innerHTML = `
+      <h2>Validate: ${escHtml(currentRoot)}</h2>
+      <div id="validate-panel" class="visible">
+        <p class="issue-none">✓ No issues found in ${escHtml(currentRoot)}</p>
+      </div>`;
+    return;
+  }
+
+  const errCount   = issues.filter(i => i.severity === 'error').length;
+  const warnCount  = issues.filter(i => i.severity === 'warning').length;
+  const itemsHtml  = issues.map(i => `
+    <div class="issue-item">
+      <span class="issue-sev ${i.severity}">${i.severity}</span>
+      <span class="issue-path">${escHtml(i.path)}</span>
+      <span class="issue-msg">— ${escHtml(i.message)}</span>
+    </div>`).join('');
+
+  panel.innerHTML = `
+    <h2>Validate: ${escHtml(currentRoot)}</h2>
+    <div id="validate-panel" class="visible">
+      <p class="validate-header">${errCount} error${errCount !== 1 ? 's' : ''}, ${warnCount} warning${warnCount !== 1 ? 's' : ''}</p>
+      ${itemsHtml}
+    </div>`;
+});
+
+function hideValidate() {
+  const vp = document.getElementById('validate-panel');
+  if (vp) vp.classList.remove('visible');
+}
+
+// ── search / filter ───────────────────────────────────────────────────────────
+const searchEl = document.getElementById('search');
+let searchTimer = null;
+
+searchEl.addEventListener('input', function() {
+  clearTimeout(searchTimer);
+  const q = this.value.trim();
+  if (!q) {
+    hideSearchResults();
+    filterTree('');
+    return;
+  }
+  filterTree(q.toLowerCase());
+  // Server-side cross-tree search on Enter or after 400 ms pause
+  searchTimer = setTimeout(() => runServerSearch(q), 400);
+});
+
+searchEl.addEventListener('keydown', function(e) {
+  if (e.key === 'Enter') {
+    clearTimeout(searchTimer);
+    runServerSearch(this.value.trim());
+  }
+});
+
+function filterTree(q) {
+  document.querySelectorAll('.tree-item').forEach(item => {
+    const path = (item.dataset.path || '').toLowerCase();
+    item.style.display = (!q || path.includes(q)) ? '' : 'none';
+  });
+  document.querySelectorAll('.tree-children').forEach(c => {
+    if (q) c.style.display = '';
+  });
+}
+
+async function runServerSearch(q) {
+  if (!q) { hideSearchResults(); return; }
+  const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`).catch(() => null);
+  if (!res || !res.ok) return;
+  const results = await res.json();
+  showSearchResults(results, q);
+}
+
+function showSearchResults(results, q) {
+  const container = document.getElementById('search-results');
+  const treeRoot  = document.getElementById('tree-root');
+  if (results.length === 0) {
+    container.innerHTML = `<p style="color:var(--muted);font-size:12px;padding:.5rem">No results for "${escHtml(q)}"</p>`;
+  } else {
+    container.innerHTML = results.map(r =>
+      `<div class="search-hit" onclick="jumpToPath('${escAttr(r.path)}')">
+        ${escHtml(r.path)}<span class="search-hit-meta">${escHtml(r.treeName)}</span>
+      </div>`
+    ).join('');
+  }
+  container.classList.add('visible');
+  treeRoot.style.display = 'none';
+}
+
+function hideSearchResults() {
+  document.getElementById('search-results').classList.remove('visible');
+  document.getElementById('tree-root').style.display = '';
+}
+
+function jumpToPath(path) {
+  hideSearchResults();
+  searchEl.value = '';
+  filterTree('');
+  // Expand and highlight the item in the tree.
+  const item = document.querySelector(`.tree-item[data-path="${CSS.escape(path)}"]`);
+  if (!item) return;
+  // Ensure all ancestors are expanded.
+  let el = item.parentElement;
+  while (el && el.id !== 'tree-root') {
+    if (el.classList.contains('tree-children')) el.style.display = '';
+    el = el.parentElement;
+  }
+  if (selected) selected.classList.remove('selected');
+  item.classList.add('selected');
+  selected = item;
+  item.scrollIntoView({ block: 'nearest' });
+  showDetail(JSON.parse(item.dataset.node), item.dataset.path);
+}
+
+// ── utils ─────────────────────────────────────────────────────────────────────
+function escHtml(s) {
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+function escAttr(s) {
+  return String(s).replace(/'/g,"\\'").replace(/"/g,'&quot;');
+}
+
+// ── start ─────────────────────────────────────────────────────────────────────
+init();
+</script>
+</body>
+</html>

--- a/server/vissv2server/webdash/webdash.go
+++ b/server/vissv2server/webdash/webdash.go
@@ -1,0 +1,322 @@
+// Package webdash serves an optional embedded web dashboard that visualises
+// the vissr HIM forest. Start it with Start(addr); it runs in the background.
+// Disabled by default — only started when --web-addr is set on vissv2server.
+package webdash
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/covesa/vissr/utils"
+)
+
+// nodeJSON is a JSON-serialisable snapshot of a Node_t subtree.
+// Parent pointers are omitted to avoid circular-reference problems.
+type nodeJSON struct {
+	Name        string     `json:"name"`
+	NodeType    string     `json:"nodeType"`
+	Description string     `json:"description,omitempty"`
+	Datatype    string     `json:"datatype,omitempty"`
+	Min         string     `json:"min,omitempty"`
+	Max         string     `json:"max,omitempty"`
+	Unit        string     `json:"unit,omitempty"`
+	Default     string     `json:"default,omitempty"`
+	Allowed     []string   `json:"allowed,omitempty"`
+	Children    []nodeJSON `json:"children,omitempty"`
+}
+
+func toNodeJSON(n *utils.Node_t) nodeJSON {
+	j := nodeJSON{
+		Name:        n.Name,
+		NodeType:    n.NodeType,
+		Description: n.Description,
+		Datatype:    n.Datatype,
+		Min:         n.Min,
+		Max:         n.Max,
+		Unit:        n.Unit,
+		Default:     n.DefaultValue,
+	}
+	if len(n.AllowedDef) > 0 {
+		j.Allowed = n.AllowedDef
+	}
+	for _, child := range n.Child {
+		j.Children = append(j.Children, toNodeJSON(child))
+	}
+	return j
+}
+
+// ── Health ───────────────────────────────────────────────────────────────────
+
+// healthPayload is the JSON body for GET /api/health and SSE health events.
+type healthPayload struct {
+	Goroutines int     `json:"goroutines"`
+	HeapMB     float64 `json:"heapMB"`
+	UptimeS    int64   `json:"uptimeS"`
+	Trees      int     `json:"trees"`
+}
+
+func currentHealth(startTime time.Time) healthPayload {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return healthPayload{
+		Goroutines: runtime.NumGoroutine(),
+		HeapMB:     float64(ms.HeapInuse) / (1024 * 1024),
+		UptimeS:    int64(time.Since(startTime).Seconds()),
+		Trees:      len(utils.ForestInfoList()),
+	}
+}
+
+// ── Validation ───────────────────────────────────────────────────────────────
+
+// validateIssue is one entry in the /api/validate response.
+type validateIssue struct {
+	Path     string `json:"path"`
+	Severity string `json:"severity"` // "error" or "warning"
+	Message  string `json:"message"`
+}
+
+func validateTree(node *utils.Node_t, path string) []validateIssue {
+	var issues []validateIssue
+	if node.NodeType != utils.BRANCH {
+		if node.Description == "" {
+			issues = append(issues, validateIssue{path, "warning", "missing description"})
+		}
+		if node.Datatype == "" {
+			issues = append(issues, validateIssue{path, "error", "missing datatype"})
+		}
+		if (node.NodeType == utils.SENSOR || node.NodeType == utils.ACTUATOR) && node.Unit == "" {
+			issues = append(issues, validateIssue{path, "warning", "missing unit"})
+		}
+		if node.Min != "" && node.Max != "" {
+			minV, errMin := strconv.ParseFloat(node.Min, 64)
+			maxV, errMax := strconv.ParseFloat(node.Max, 64)
+			if errMin == nil && errMax == nil && minV > maxV {
+				issues = append(issues, validateIssue{path, "error",
+					fmt.Sprintf("min (%s) > max (%s)", node.Min, node.Max)})
+			}
+		}
+	}
+	for _, child := range node.Child {
+		issues = append(issues, validateTree(child, path+"."+child.Name)...)
+	}
+	return issues
+}
+
+// ── Search ───────────────────────────────────────────────────────────────────
+
+// searchResult is one entry in the /api/search response.
+type searchResult struct {
+	Path     string `json:"path"`
+	NodeType string `json:"nodeType"`
+	TreeName string `json:"treeName"`
+}
+
+func searchForest(q string) []searchResult {
+	q = strings.ToLower(q)
+	var results []searchResult
+	for _, info := range utils.ForestInfoList() {
+		root := utils.GetForestRoot(info.RootName)
+		if root != nil {
+			searchNode(root, root.Name, info.RootName, q, &results)
+		}
+	}
+	return results
+}
+
+func searchNode(node *utils.Node_t, path, treeName, q string, results *[]searchResult) {
+	if strings.Contains(strings.ToLower(node.Name), q) || strings.Contains(strings.ToLower(path), q) {
+		*results = append(*results, searchResult{path, node.NodeType, treeName})
+	}
+	for _, child := range node.Child {
+		searchNode(child, path+"."+child.Name, treeName, q, results)
+	}
+}
+
+// ── SSE hub ───────────────────────────────────────────────────────────────────
+
+// sseHub fans out SSE messages to all connected browser clients.
+type sseHub struct {
+	mu      sync.Mutex
+	clients map[chan string]struct{}
+}
+
+func newSSEHub() *sseHub {
+	return &sseHub{clients: make(map[chan string]struct{})}
+}
+
+func (h *sseHub) subscribe() chan string {
+	ch := make(chan string, 8)
+	h.mu.Lock()
+	h.clients[ch] = struct{}{}
+	h.mu.Unlock()
+	return ch
+}
+
+func (h *sseHub) unsubscribe(ch chan string) {
+	h.mu.Lock()
+	delete(h.clients, ch)
+	h.mu.Unlock()
+}
+
+func (h *sseHub) publish(eventType, data string) {
+	msg := fmt.Sprintf("event: %s\ndata: %s\n\n", eventType, data)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for ch := range h.clients {
+		select {
+		case ch <- msg:
+		default: // slow client — skip rather than block
+		}
+	}
+}
+
+// ── Mux builder ──────────────────────────────────────────────────────────────
+
+// buildMux constructs the HTTP mux. Extracted for testability.
+func buildMux(startTime time.Time) (*http.ServeMux, error) {
+	mux := http.NewServeMux()
+
+	// Serve embedded static files at /
+	staticRoot, err := fs.Sub(embeddedStatic, "static")
+	if err != nil {
+		return nil, err
+	}
+	mux.Handle("/", http.FileServer(http.FS(staticRoot)))
+
+	hub := newSSEHub()
+
+	// Background health ticker — publishes health events to SSE clients.
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			b, _ := json.Marshal(currentHealth(startTime))
+			hub.publish("health", string(b))
+		}
+	}()
+
+	setJSON := func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+	}
+
+	// GET /api/forest → [{rootName, domain, version}, …]
+	mux.HandleFunc("/api/forest", func(w http.ResponseWriter, r *http.Request) {
+		setJSON(w)
+		if err := json.NewEncoder(w).Encode(utils.ForestInfoList()); err != nil {
+			utils.Error.Printf("webdash: /api/forest encode: %v", err)
+		}
+	})
+
+	// GET /api/tree/{rootName} → full nodeJSON tree
+	mux.HandleFunc("/api/tree/", func(w http.ResponseWriter, r *http.Request) {
+		rootName := strings.TrimPrefix(r.URL.Path, "/api/tree/")
+		root := utils.GetForestRoot(rootName)
+		if root == nil {
+			http.NotFound(w, r)
+			return
+		}
+		setJSON(w)
+		if err := json.NewEncoder(w).Encode(toNodeJSON(root)); err != nil {
+			utils.Error.Printf("webdash: /api/tree/%s encode: %v", rootName, err)
+		}
+	})
+
+	// GET /api/health → goroutines, heapMB, uptimeS, trees
+	mux.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
+		setJSON(w)
+		if err := json.NewEncoder(w).Encode(currentHealth(startTime)); err != nil {
+			utils.Error.Printf("webdash: /api/health encode: %v", err)
+		}
+	})
+
+	// GET /api/validate/{rootName} → [{path, severity, message}, …]
+	mux.HandleFunc("/api/validate/", func(w http.ResponseWriter, r *http.Request) {
+		rootName := strings.TrimPrefix(r.URL.Path, "/api/validate/")
+		root := utils.GetForestRoot(rootName)
+		if root == nil {
+			http.NotFound(w, r)
+			return
+		}
+		issues := validateTree(root, root.Name)
+		if issues == nil {
+			issues = []validateIssue{}
+		}
+		setJSON(w)
+		if err := json.NewEncoder(w).Encode(issues); err != nil {
+			utils.Error.Printf("webdash: /api/validate/%s encode: %v", rootName, err)
+		}
+	})
+
+	// GET /api/search?q=... → [{path, nodeType, treeName}, …]
+	mux.HandleFunc("/api/search", func(w http.ResponseWriter, r *http.Request) {
+		q := strings.TrimSpace(r.URL.Query().Get("q"))
+		var results []searchResult
+		if q != "" {
+			results = searchForest(q)
+		}
+		if results == nil {
+			results = []searchResult{}
+		}
+		setJSON(w)
+		if err := json.NewEncoder(w).Encode(results); err != nil {
+			utils.Error.Printf("webdash: /api/search encode: %v", err)
+		}
+	})
+
+	// GET /api/events → SSE stream (health ticks every 5 s)
+	mux.HandleFunc("/api/events", func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "SSE not supported", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		// Send current health immediately on connect.
+		b, _ := json.Marshal(currentHealth(startTime))
+		fmt.Fprintf(w, "event: health\ndata: %s\n\n", b)
+		flusher.Flush()
+
+		ch := hub.subscribe()
+		defer hub.unsubscribe(ch)
+
+		for {
+			select {
+			case msg := <-ch:
+				fmt.Fprint(w, msg)
+				flusher.Flush()
+			case <-r.Context().Done():
+				return
+			}
+		}
+	})
+
+	return mux, nil
+}
+
+// Start registers the dashboard routes and launches an HTTP server on addr
+// (e.g. ":8090") in a background goroutine. It returns immediately.
+func Start(addr string) error {
+	mux, err := buildMux(time.Now())
+	if err != nil {
+		return err
+	}
+	go func() {
+		utils.Info.Printf("webdash: listening on http://%s", addr)
+		if err := http.ListenAndServe(addr, mux); err != nil {
+			utils.Error.Printf("webdash: server stopped: %v", err)
+		}
+	}()
+	return nil
+}

--- a/server/vissv2server/webdash/webdash_test.go
+++ b/server/vissv2server/webdash/webdash_test.go
@@ -1,0 +1,683 @@
+package webdash
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/covesa/vissr/utils"
+)
+
+func init() {
+	utils.InitLog("webdash-test.log", os.TempDir(), false, "info")
+}
+
+// registerTestTree registers a minimal tree for use in HTTP endpoint tests.
+// Returns the rootName.
+func registerTestTree(t *testing.T, rootName string) string {
+	t.Helper()
+	root := utils.NewBranchNode(rootName)
+	speed := utils.NewSignalNode("Speed", utils.SENSOR, "float", "vehicle speed", "0", "250", "km/h")
+	rpm := utils.NewSignalNode("EngineRPM", utils.SENSOR, "uint16", "", "0", "8000", "rpm")
+	rpm.AllowedDef = []string{"Idle", "Rev"}
+	utils.NewBranchNode(rootName, root) // ensure root name is set
+	root.Name = rootName
+	speed.Parent = root
+	root.Child = append(root.Child, speed, rpm)
+	root.Children = uint8(len(root.Child))
+	if !utils.RegisterServiceTree(rootName, rootName+".Vehicle", "1.0", root) {
+		t.Logf("registerTestTree: %s already registered", rootName)
+	}
+	return rootName
+}
+
+func newTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux, err := buildMux(time.Now().Add(-30 * time.Second))
+	if err != nil {
+		t.Fatalf("buildMux: %v", err)
+	}
+	return httptest.NewServer(mux)
+}
+
+// ── toNodeJSON ────────────────────────────────────────────────────────────────
+
+func TestToNodeJSON_LeafFields(t *testing.T) {
+	n := utils.NewSignalNode("Speed", utils.SENSOR, "float", "vehicle speed", "0", "250", "km/h")
+	n.DefaultValue = "0"
+	n.AllowedDef = []string{"Slow", "Fast"}
+
+	j := toNodeJSON(n)
+
+	if j.Name != "Speed" {
+		t.Errorf("Name = %q, want Speed", j.Name)
+	}
+	if j.NodeType != utils.SENSOR {
+		t.Errorf("NodeType = %q, want sensor", j.NodeType)
+	}
+	if j.Datatype != "float" {
+		t.Errorf("Datatype = %q, want float", j.Datatype)
+	}
+	if j.Unit != "km/h" {
+		t.Errorf("Unit = %q, want km/h", j.Unit)
+	}
+	if j.Min != "0" || j.Max != "250" {
+		t.Errorf("Range = [%q, %q], want [0, 250]", j.Min, j.Max)
+	}
+	if j.Default != "0" {
+		t.Errorf("Default = %q, want 0", j.Default)
+	}
+	if len(j.Allowed) != 2 {
+		t.Errorf("Allowed length = %d, want 2", len(j.Allowed))
+	}
+	if len(j.Children) != 0 {
+		t.Errorf("Children = %d, want 0", len(j.Children))
+	}
+}
+
+func TestToNodeJSON_BranchWithChildren(t *testing.T) {
+	root := utils.NewBranchNode("Vehicle")
+	child := utils.NewSignalNode("Speed", utils.SENSOR, "float", "", "", "", "")
+	root.Child = []*utils.Node_t{child}
+	root.Children = 1
+	child.Parent = root
+
+	j := toNodeJSON(root)
+
+	if j.NodeType != utils.BRANCH {
+		t.Errorf("NodeType = %q, want branch", j.NodeType)
+	}
+	if len(j.Children) != 1 {
+		t.Errorf("Children length = %d, want 1", len(j.Children))
+	}
+	if j.Children[0].Name != "Speed" {
+		t.Errorf("Children[0].Name = %q, want Speed", j.Children[0].Name)
+	}
+}
+
+func TestToNodeJSON_NoAllowedWhenEmpty(t *testing.T) {
+	n := utils.NewSignalNode("Speed", utils.SENSOR, "float", "", "", "", "")
+	j := toNodeJSON(n)
+	if j.Allowed != nil {
+		t.Errorf("Allowed = %v, want nil for node without AllowedDef", j.Allowed)
+	}
+}
+
+// ── /api/forest ───────────────────────────────────────────────────────────────
+
+func TestAPIForest_ReturnsJSON(t *testing.T) {
+	registerTestTree(t, "TestForestVehicle")
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/forest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var forest []utils.ForestInfo
+	if err := json.NewDecoder(resp.Body).Decode(&forest); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(forest) == 0 {
+		t.Error("expected at least one tree in forest list")
+	}
+	found := false
+	for _, f := range forest {
+		if f.RootName == "TestForestVehicle" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("TestForestVehicle not in forest list: %+v", forest)
+	}
+}
+
+// ── /api/tree ─────────────────────────────────────────────────────────────────
+
+func TestAPITree_ReturnsTree(t *testing.T) {
+	registerTestTree(t, "TestTreeVehicle")
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/tree/TestTreeVehicle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var node nodeJSON
+	if err := json.NewDecoder(resp.Body).Decode(&node); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if node.Name != "TestTreeVehicle" {
+		t.Errorf("root name = %q, want TestTreeVehicle", node.Name)
+	}
+	if len(node.Children) == 0 {
+		t.Error("expected children in tree response")
+	}
+}
+
+func TestAPITree_NotFound(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/tree/NoSuchTree")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// ── /api/health ───────────────────────────────────────────────────────────────
+
+func TestAPIHealth_ReturnsPayload(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var h healthPayload
+	if err := json.NewDecoder(resp.Body).Decode(&h); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if h.Goroutines <= 0 {
+		t.Errorf("Goroutines = %d, want > 0", h.Goroutines)
+	}
+	if h.UptimeS < 0 {
+		t.Errorf("UptimeS = %d, want >= 0", h.UptimeS)
+	}
+	// Test server was created with startTime 30s in the past.
+	if h.UptimeS < 29 {
+		t.Errorf("UptimeS = %d, want >= 29 (startTime offset by 30s)", h.UptimeS)
+	}
+}
+
+// ── /api/validate ─────────────────────────────────────────────────────────────
+
+func TestAPIValidate_ReturnsIssues(t *testing.T) {
+	// Register a tree with a node missing unit and description.
+	rootName := "TestValidateVehicle"
+	root := utils.NewBranchNode(rootName)
+	bare := utils.NewSignalNode("BareSignal", utils.SENSOR, "float", "", "", "", "")
+	bare.Parent = root
+	root.Child = []*utils.Node_t{bare}
+	root.Children = 1
+	utils.RegisterServiceTree(rootName, rootName+".Vehicle", "1.0", root)
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/validate/" + rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var issues []validateIssue
+	if err := json.NewDecoder(resp.Body).Decode(&issues); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(issues) == 0 {
+		t.Error("expected validation issues for node missing unit and description")
+	}
+	foundMissingUnit := false
+	for _, iss := range issues {
+		if strings.Contains(iss.Message, "unit") {
+			foundMissingUnit = true
+		}
+	}
+	if !foundMissingUnit {
+		t.Errorf("expected a 'missing unit' issue; got %+v", issues)
+	}
+}
+
+func TestAPIValidate_CleanTreeReturnsEmpty(t *testing.T) {
+	rootName := "TestValidateClean"
+	root := utils.NewBranchNode(rootName)
+	speed := utils.NewSignalNode("Speed", utils.SENSOR, "float", "vehicle speed", "0", "250", "km/h")
+	speed.Parent = root
+	root.Child = []*utils.Node_t{speed}
+	root.Children = 1
+	utils.RegisterServiceTree(rootName, rootName+".Vehicle", "1.0", root)
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/validate/" + rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var issues []validateIssue
+	if err := json.NewDecoder(resp.Body).Decode(&issues); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("expected 0 issues for clean tree, got %d: %+v", len(issues), issues)
+	}
+}
+
+func TestAPIValidate_NotFound(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/validate/NoSuchTree")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestAPIValidate_MinGreaterThanMax(t *testing.T) {
+	rootName := "TestValidateRange"
+	root := utils.NewBranchNode(rootName)
+	bad := utils.NewSignalNode("BadRange", utils.SENSOR, "float", "desc", "250", "0", "km/h")
+	bad.Parent = root
+	root.Child = []*utils.Node_t{bad}
+	root.Children = 1
+	utils.RegisterServiceTree(rootName, rootName+".Vehicle", "1.0", root)
+
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/validate/" + rootName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var issues []validateIssue
+	json.NewDecoder(resp.Body).Decode(&issues)
+
+	found := false
+	for _, iss := range issues {
+		if iss.Severity == "error" && strings.Contains(iss.Message, "min") && strings.Contains(iss.Message, "max") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected min > max error issue; got %+v", issues)
+	}
+}
+
+// ── /api/search ───────────────────────────────────────────────────────────────
+
+func TestAPISearch_FindsMatches(t *testing.T) {
+	registerTestTree(t, "TestSearchVehicle")
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/search?q=Speed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var results []searchResult
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(results) == 0 {
+		t.Error("expected at least one search result for 'Speed'")
+	}
+	found := false
+	for _, r := range results {
+		if strings.Contains(r.Path, "Speed") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no Speed result in %+v", results)
+	}
+}
+
+func TestAPISearch_EmptyQueryReturnsEmpty(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/search?q=")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var results []searchResult
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for empty query, got %d", len(results))
+	}
+}
+
+func TestAPISearch_NoMatch(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/search?q=xyzzy_no_such_signal_12345")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var results []searchResult
+	json.NewDecoder(resp.Body).Decode(&results)
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for non-matching query, got %d", len(results))
+	}
+}
+
+// ── /api/events (SSE) ─────────────────────────────────────────────────────────
+
+func TestAPIEvents_ReceivesHealthOnConnect(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(srv.URL + "/api/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+
+	// Read the first event (health payload sent immediately on connect).
+	buf := make([]byte, 1024)
+	n, err := resp.Body.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("read: %v", err)
+	}
+	body := string(buf[:n])
+	if !strings.Contains(body, "event: health") {
+		t.Errorf("expected 'event: health' in first SSE frame; got: %q", body)
+	}
+	if !strings.Contains(body, "goroutines") {
+		t.Errorf("expected goroutines field in health SSE data; got: %q", body)
+	}
+}
+
+// ── validateTree ──────────────────────────────────────────────────────────────
+
+func TestValidateTree_MissingDescription(t *testing.T) {
+	root := utils.NewBranchNode("Root")
+	n := utils.NewSignalNode("Speed", utils.SENSOR, "float", "", "0", "250", "km/h")
+	n.Parent = root
+	root.Child = []*utils.Node_t{n}
+
+	issues := validateTree(root, "Root")
+	found := false
+	for _, iss := range issues {
+		if strings.Contains(iss.Message, "description") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected missing-description warning; got %+v", issues)
+	}
+}
+
+func TestValidateTree_BranchNotChecked(t *testing.T) {
+	// Branches are exempt from signal-level checks.
+	root := utils.NewBranchNode("Root")
+	issues := validateTree(root, "Root")
+	if len(issues) != 0 {
+		t.Errorf("expected 0 issues for branch-only tree; got %+v", issues)
+	}
+}
+
+func TestValidateTree_MissingDatatype(t *testing.T) {
+	root := utils.NewBranchNode("Root")
+	n := &utils.Node_t{Name: "Signal", NodeType: utils.SENSOR, Description: "desc", Unit: "km/h"}
+	n.Parent = root
+	root.Child = []*utils.Node_t{n}
+
+	issues := validateTree(root, "Root")
+	found := false
+	for _, iss := range issues {
+		if iss.Severity == "error" && strings.Contains(iss.Message, "datatype") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected missing-datatype error; got %+v", issues)
+	}
+}
+
+// ── searchForest / searchNode ─────────────────────────────────────────────────
+
+func TestSearchForest_CaseInsensitive(t *testing.T) {
+	registerTestTree(t, "TestSearchCI")
+	results := searchForest("speed")
+	if len(results) == 0 {
+		t.Error("expected results for lowercase 'speed'")
+	}
+}
+
+func TestSearchForest_EmptyQuery(t *testing.T) {
+	results := searchForest("")
+	// empty query returns all nodes (every name contains "")
+	// but the function short-circuits in the HTTP handler; searchForest itself does not.
+	// Verify it doesn't panic and returns a non-nil slice.
+	_ = results
+}
+
+func TestStart_ListensAndResponds(t *testing.T) {
+	// Start binds a random OS port; we use a fixed high port unlikely to conflict.
+	// If the port is taken the test is skipped rather than failed.
+	const addr = ":19234"
+	if err := Start(addr); err != nil {
+		t.Skipf("Start(%q): %v — port in use?", addr, err)
+	}
+	time.Sleep(60 * time.Millisecond)
+	resp, err := http.Get("http://localhost:19234/api/health")
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestSSEHub_Publish(t *testing.T) {
+	h := newSSEHub()
+	ch := h.subscribe()
+	defer h.unsubscribe(ch)
+
+	h.publish("health", `{"goroutines":5}`)
+
+	select {
+	case msg := <-ch:
+		if !strings.Contains(msg, "event: health") {
+			t.Errorf("published message = %q, want event: health prefix", msg)
+		}
+		if !strings.Contains(msg, `{"goroutines":5}`) {
+			t.Errorf("published message = %q, want goroutines payload", msg)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("timed out waiting for published SSE message")
+	}
+}
+
+func TestSSEHub_SlowClientSkipped(t *testing.T) {
+	h := newSSEHub()
+	// Full channel — publish must not block.
+	ch := make(chan string, 1)
+	ch <- "fill" // pre-fill to capacity
+	h.mu.Lock()
+	h.clients[ch] = struct{}{}
+	h.mu.Unlock()
+	defer h.unsubscribe(ch)
+
+	done := make(chan struct{})
+	go func() {
+		h.publish("test", "data")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Error("publish blocked on slow client")
+	}
+}
+
+func TestCurrentHealth_UptimeGrows(t *testing.T) {
+	start := time.Now().Add(-10 * time.Second)
+	h := currentHealth(start)
+	if h.UptimeS < 9 {
+		t.Errorf("UptimeS = %d, want >= 9", h.UptimeS)
+	}
+	if h.Goroutines <= 0 {
+		t.Errorf("Goroutines = %d, want > 0", h.Goroutines)
+	}
+	if h.HeapMB <= 0 {
+		t.Errorf("HeapMB = %f, want > 0", h.HeapMB)
+	}
+}
+
+// ── SSE non-flusher path ───────────────────────────────────────────────────────
+
+// noFlushWriter implements http.ResponseWriter without http.Flusher, triggering
+// the "SSE not supported" error branch in the /api/events handler.
+type noFlushWriter struct {
+	header http.Header
+	code   int
+	body   strings.Builder
+}
+
+func newNoFlushWriter() *noFlushWriter {
+	return &noFlushWriter{header: make(http.Header), code: http.StatusOK}
+}
+
+func (w *noFlushWriter) Header() http.Header         { return w.header }
+func (w *noFlushWriter) WriteHeader(code int)         { w.code = code }
+func (w *noFlushWriter) Write(b []byte) (int, error) { return w.body.Write(b) }
+
+// TestAPIEvents_NonFlusherResponseWriter verifies that the /api/events handler
+// returns 500 when the ResponseWriter does not implement http.Flusher.
+func TestAPIEvents_NonFlusherResponseWriter(t *testing.T) {
+	mux, err := buildMux(time.Now())
+	if err != nil {
+		t.Fatalf("buildMux: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	w := newNoFlushWriter()
+	mux.ServeHTTP(w, req)
+
+	if w.code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 when Flusher not supported", w.code)
+	}
+	if !strings.Contains(w.body.String(), "SSE not supported") {
+		t.Errorf("body = %q, want 'SSE not supported'", w.body.String())
+	}
+}
+
+// ── SSE hub publish via ticker (structural coverage) ─────────────────────────
+
+// TestSSEHub_PublishIntegration verifies the complete SSE publish→receive cycle
+// end-to-end through buildMux by reading a hub-published message.
+// This exercises the msg := <-ch branch in the SSE for/select handler.
+func TestSSEHub_PublishIntegration(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	// Use a client with a generous timeout so the SSE stream stays open.
+	client := &http.Client{Timeout: 5 * time.Second}
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/events", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	// Read the initial health event.
+	buf := make([]byte, 4096)
+	n, _ := resp.Body.Read(buf)
+	initial := string(buf[:n])
+	if !strings.Contains(initial, "event: health") {
+		t.Fatalf("expected initial health event, got: %q", initial)
+	}
+	// Cancel the context to trigger r.Context().Done() in the SSE handler
+	// (covers the context-done return branch).
+	cancel()
+}
+
+// ── Start error path ──────────────────────────────────────────────────────────
+
+// TestStart_MultipleCallsOnDifferentPorts verifies that Start can be called
+// multiple times on different ports without returning an error. Each call
+// launches an independent server goroutine.
+func TestStart_MultipleCallsOnDifferentPorts(t *testing.T) {
+	for _, addr := range []string{":19240", ":19241"} {
+		if err := Start(addr); err != nil {
+			t.Skipf("Start(%q): %v — port in use?", addr, err)
+		}
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	for _, port := range []string{"19240", "19241"} {
+		resp, err := http.Get("http://localhost:" + port + "/api/health")
+		if err != nil {
+			t.Fatalf("port %s: %v", port, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("port %s: status = %d, want 200", port, resp.StatusCode)
+		}
+	}
+}

--- a/spec/VISSv4.0_VDM.html
+++ b/spec/VISSv4.0_VDM.html
@@ -1,0 +1,548 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>VISSv4.0 – VDM Integration Specification</title>
+<style>
+  body { font-family: Arial, Helvetica, sans-serif; max-width: 900px; margin: 0 auto; padding: 2rem; line-height: 1.6; color: #222; }
+  h1 { border-bottom: 3px solid #004080; padding-bottom: .5rem; }
+  h2 { border-bottom: 1px solid #ccc; margin-top: 2rem; }
+  h3 { margin-top: 1.5rem; }
+  code, pre { background: #f4f4f4; font-family: "Courier New", monospace; }
+  pre { padding: 1rem; overflow-x: auto; border-left: 4px solid #004080; }
+  code { padding: 0 .25rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: .5rem .75rem; text-align: left; }
+  th { background: #e8f0fe; }
+  .note { background: #fffbe6; border-left: 4px solid #f0c040; padding: .75rem 1rem; margin: 1rem 0; }
+  .normative { font-style: italic; color: #004080; }
+  nav { background: #f0f0f0; padding: 1rem; margin-bottom: 2rem; border-radius: 4px; }
+  nav ul { margin: 0; padding-left: 1.5rem; }
+  nav li { margin: .25rem 0; }
+  a { color: #004080; }
+</style>
+</head>
+<body>
+
+<h1>VISSv4.0 — VDM Integration Specification</h1>
+
+<p><strong>Status:</strong> Alpha draft &nbsp;|&nbsp;
+   <strong>Date:</strong> 2026-06-06 &nbsp;|&nbsp;
+   <strong>Authors:</strong> COVESA vissr contributors</p>
+
+<p>This document specifies how the COVESA <strong>VDM</strong> (Vehicle Data Model)
+   GraphQL SDL format is loaded and used inside the
+   <strong>vissr</strong> (VISS v2 Reference Server) as of version 4.0.</p>
+
+<nav>
+  <strong>Contents</strong>
+  <ul>
+    <li><a href="#overview">§1 Overview</a></li>
+    <li><a href="#vdm-background">§2 VDM Background</a></li>
+    <li><a href="#directives">§3 Supported SDL Directives</a></li>
+    <li><a href="#node-mapping">§4 Node Type Mapping</a></li>
+    <li><a href="#datatype-mapping">§5 Datatype Mapping</a></li>
+    <li><a href="#tree-reconstruction">§6 Tree Reconstruction Algorithm</a></li>
+    <li><a href="#instance-tags">§7 Instance Tags (multi-instance)</a></li>
+    <li><a href="#viss-service-extension">§8 @viss_service Extension</a></li>
+    <li><a href="#server-integration">§9 Server Integration (--vdm flag)</a></li>
+    <li><a href="#him-interop">§10 HIM / VDM Interoperability</a></li>
+    <li><a href="#ci-validation">§11 CI Validation with s2dm</a></li>
+    <li><a href="#conformance">§12 Conformance</a></li>
+    <li><a href="#appendix-a">Appendix A — SDL Directives Preamble</a></li>
+    <li><a href="#appendix-b">Appendix B — Example VDM File</a></li>
+  </ul>
+</nav>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="overview">§1 Overview</h2>
+
+<p>VISSv4.0 extends vissr with native support for the
+   <a href="https://github.com/COVESA/vdm">COVESA VDM</a> signal-model format.
+   Where earlier releases required a compiled VSS binary tree (loaded via the
+   <code>viss.him</code> forest manifest), v4.0 allows operators to supply a
+   directory of raw <code>.graphql</code> SDL files instead.
+   The server parses them at startup, builds the equivalent
+   <code>utils.Node_t</code> signal trees in memory, and registers them in the
+   HIM forest — with no binary pre-compilation step required.</p>
+
+<p>Key additions:</p>
+<ul>
+  <li><strong><code>vdmloader</code> package</strong> — pure-Go SDL parser
+      (uses <code>github.com/vektah/gqlparser/v2</code>).</li>
+  <li><strong><code>--vdm &lt;dir&gt;</code> server flag</strong> — alternative
+      to <code>--him</code>; loads every <code>*.graphql</code> file in
+      <em>dir</em>.</li>
+  <li><strong><code>@viss_service</code> directive</strong> — marks a VDM field
+      as a service procedure entry point, enabling VISSv3.2 invoke/monitor
+      semantics on VDM-defined signals.</li>
+</ul>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="vdm-background">§2 VDM Background</h2>
+
+<p>The <strong>Vehicle Data Model (VDM)</strong> is a COVESA initiative that
+   expresses the VSS signal catalog in <strong>GraphQL Schema Definition Language
+   (SDL)</strong> rather than YAML.  The SDL is authored using the
+   <strong>s2dm</strong> (Simplified Semantic Data Modeling) methodology and
+   toolchain, which validates structural and semantic constraints beyond what
+   the GraphQL type system alone enforces.</p>
+
+<p>A VDM SDL file contains:</p>
+<ul>
+  <li><strong>Object types</strong> annotated with
+      <code>@vspec(element: BRANCH, fqn: "Dot.Path")</code> — tree branch
+      nodes.</li>
+  <li><strong>Field definitions</strong> annotated with
+      <code>@vspec(element: SENSOR|ACTUATOR|ATTRIBUTE, fqn: "Dot.Leaf.Path")</code>
+      — signal leaf nodes.</li>
+  <li>Custom scalars (<code>Int8</code>, <code>UInt8</code>, etc.) that map to
+      VSS datatypes.</li>
+  <li>Optional <code>@range(min, max)</code> for numeric bounds.</li>
+</ul>
+
+<p>VDM has no notion of mutations or procedures — it is a pure signal/data
+   model. The <code>@viss_service</code> directive described in §8 is a vissr
+   extension that does not yet exist in upstream VDM.</p>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="directives">§3 Supported SDL Directives</h2>
+
+<h3>3.1 @vspec</h3>
+<pre><code>directive @vspec(
+  element: VspecElement!   # node kind — see §4
+  fqn:     String!         # fully-qualified dot-separated signal path
+  description: String      # human-readable description
+  comment:     String      # implementation note (ignored at runtime)
+  deprecation: String      # deprecation notice (ignored at runtime)
+) on OBJECT | FIELD_DEFINITION</code></pre>
+
+<h3>3.2 @range</h3>
+<pre><code>directive @range(min: Float, max: Float) on FIELD_DEFINITION</code></pre>
+<p>Populates <code>Node_t.Min</code> and <code>Node_t.Max</code> as decimal
+   strings.</p>
+
+<h3>3.3 @viss_service (v4.0 extension)</h3>
+<pre><code>directive @viss_service on FIELD_DEFINITION</code></pre>
+<p>When present on a field definition, the loader creates a
+   <code>PROCEDURE</code> node instead of the element type declared in
+   <code>@vspec</code>.  This enables VISSv3.2 service semantics (invoke,
+   monitor, cancel, discover) on the field.  See §8 for details.</p>
+
+<h3>3.4 VspecElement enum</h3>
+<table>
+  <tr><th>Value</th><th>Meaning</th></tr>
+  <tr><td>BRANCH</td><td>Intermediate tree node with children</td></tr>
+  <tr><td>SENSOR</td><td>Read-only signal leaf</td></tr>
+  <tr><td>ACTUATOR</td><td>Writable signal leaf</td></tr>
+  <tr><td>ATTRIBUTE</td><td>Static configuration leaf</td></tr>
+  <tr><td>STRUCT</td><td>Composite structure (future use)</td></tr>
+  <tr><td>PROPERTY</td><td>Property within a struct (future use)</td></tr>
+</table>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="node-mapping">§4 Node Type Mapping</h2>
+
+<p>The loader maps VDM elements to <code>utils.Node_t.NodeType</code> as
+   follows:</p>
+
+<table>
+  <tr><th>VDM element / condition</th><th>utils constant</th></tr>
+  <tr><td>BRANCH (on OBJECT or FIELD_DEFINITION)</td><td><code>utils.BRANCH</code></td></tr>
+  <tr><td>SENSOR</td><td><code>utils.SENSOR</code></td></tr>
+  <tr><td>ACTUATOR</td><td><code>utils.ACTUATOR</code></td></tr>
+  <tr><td>ATTRIBUTE</td><td><code>utils.ATTRIBUTE</code></td></tr>
+  <tr><td>Any field annotated with <code>@viss_service</code></td><td><code>utils.PROCEDURE</code></td></tr>
+</table>
+
+<p class="note"><strong>Note:</strong> The <code>@viss_service</code> override
+   takes precedence over the <code>@vspec(element: …)</code> value on the same
+   field.</p>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="datatype-mapping">§5 Datatype Mapping</h2>
+
+<table>
+  <tr><th>GraphQL type</th><th>VSS / Node_t datatype string</th></tr>
+  <tr><td>Int8</td><td>int8</td></tr>
+  <tr><td>UInt8</td><td>uint8</td></tr>
+  <tr><td>Int16</td><td>int16</td></tr>
+  <tr><td>UInt16</td><td>uint16</td></tr>
+  <tr><td>Int</td><td>int32</td></tr>
+  <tr><td>UInt32</td><td>uint32</td></tr>
+  <tr><td>Int64</td><td>int64</td></tr>
+  <tr><td>UInt64</td><td>uint64</td></tr>
+  <tr><td>Float</td><td>float</td></tr>
+  <tr><td>Boolean</td><td>bool</td></tr>
+  <tr><td>String</td><td>string</td></tr>
+  <tr><td>Any other type name</td><td>lower-cased type name</td></tr>
+</table>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="tree-reconstruction">§6 Tree Reconstruction Algorithm</h2>
+
+<p>The <code>@vspec(fqn: …)</code> attribute is the authoritative source of
+   tree structure.  The GraphQL type hierarchy is
+   <em>not</em> used for parent-child relationships; only the FQN strings are.</p>
+
+<ol>
+  <li>Parse the combined preamble + SDL with
+      <code>gqlparser.LoadSchema</code>.</li>
+  <li>Walk every type and field definition.  For each
+      <code>@vspec</code>-annotated node, record <code>fqn → Node_t</code>
+      in a flat map.</li>
+  <li>Sort all FQN strings lexicographically so parents always appear before
+      children.</li>
+  <li>For each non-root FQN, compute the parent FQN by stripping the last
+      dot-segment.  If the parent is missing from the map, synthesise an
+      intermediate <code>BRANCH</code> node and insert it.</li>
+  <li>Call <code>appendChild(parent, child)</code> to link the node and
+      maintain the <code>Children</code> counter.</li>
+  <li>Collect all root nodes (FQN contains no <code>.</code>) and return
+      them.</li>
+</ol>
+
+<p class="normative">Implementations MUST preserve the invariant
+   <code>node.Children == uint8(len(node.Child))</code> after every
+   <code>appendChild</code> call.</p>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="instance-tags">§7 Instance Tags (multi-instance)</h2>
+
+<p>VDM represents multi-instance nodes (e.g., seat rows × sides) using
+   <em>instance-tag</em> types and dimension enums.  A type named
+   <code>{Base}_InstanceTag</code> bearing <code>@instanceTag</code> is a
+   multi-instance template: the loader expands it into one subtree per
+   combination of dimension values and attaches those subtrees under the base
+   FQN branch.</p>
+
+<h3>7.1 SDL pattern</h3>
+<pre><code>type VehicleCabinSeat @vspec(element: BRANCH, fqn: "Vehicle.Cabin.Seat") {
+  IsOccupied: Boolean @vspec(element: SENSOR, fqn: "Vehicle.Cabin.Seat.IsOccupied")
+  Position:   UInt8   @vspec(element: ACTUATOR, fqn: "Vehicle.Cabin.Seat.Position") @range(min: 0, max: 100)
+}
+
+type VehicleCabinSeat_InstanceTag @instanceTag @vspec(element: BRANCH, fqn: "Vehicle.Cabin.Seat") {
+  dimension1: VehicleCabinSeat_InstanceTag_Dimension1
+  dimension2: VehicleCabinSeat_InstanceTag_Dimension2
+}
+
+enum VehicleCabinSeat_InstanceTag_Dimension1 {
+  ROW1 @vspec(originalName: "Row1")
+  ROW2 @vspec(originalName: "Row2")
+}
+
+enum VehicleCabinSeat_InstanceTag_Dimension2 {
+  DRIVER_SIDE    @vspec(originalName: "DriverSide")
+  PASSENGER_SIDE @vspec(originalName: "PassengerSide")
+}</code></pre>
+
+<h3>7.2 Expansion result</h3>
+<p>The loader expands the above into the following tree (all leaf signals
+   cloned into every instance):</p>
+<pre><code>Vehicle.Cabin.Seat (BRANCH)
+  ├── Row1 (BRANCH)
+  │    ├── DriverSide (BRANCH)
+  │    │    ├── IsOccupied (SENSOR, bool)
+  │    │    └── Position   (ACTUATOR, uint8, range 0–100)
+  │    └── PassengerSide (BRANCH)
+  │         ├── IsOccupied (SENSOR, bool)
+  │         └── Position   (ACTUATOR, uint8, range 0–100)
+  └── Row2 (BRANCH)
+       ├── DriverSide (BRANCH)
+       │    ├── IsOccupied (SENSOR, bool)
+       │    └── Position   (ACTUATOR, uint8, range 0–100)
+       └── PassengerSide (BRANCH)
+            ├── IsOccupied (SENSOR, bool)
+            └── Position   (ACTUATOR, uint8, range 0–100)</code></pre>
+
+<h3>7.3 Naming and SCREAMING_SNAKE_CASE fallback</h3>
+<p>Each enum value's expanded path segment comes from
+   <code>@vspec(originalName: "...")</code>.  If this argument is absent the
+   loader converts the enum value name from SCREAMING_SNAKE_CASE to PascalCase:
+   <code>DRIVER_SIDE</code> → <code>DriverSide</code>, <code>ROW1</code> →
+   <code>Row1</code>.</p>
+
+<h3>7.4 Dimensions</h3>
+<p>Up to N dimensions are supported (VDM currently uses 1 or 2).
+   Dimension fields must be named <code>dimension1</code>,
+   <code>dimension2</code>, … in order on the <code>_InstanceTag</code>
+   type.  Instances are generated in lexicographic order of dimension value
+   combinations.</p>
+
+<p class="normative">A conforming implementation MUST deep-clone the full
+   signal subtree of the base FQN into every generated instance, preserving
+   all field values (datatype, min, max, unit, description) and maintaining
+   independent <code>*Node_t</code> pointers per instance so mutations to one
+   instance do not affect others.</p>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="unit-default-allowed">§8 Unit, Default Value, and Allowed Values</h2>
+
+<h3>8.1 Unit</h3>
+<p>A signal's physical unit is declared with the <code>@unit(value:)</code>
+   directive or the <code>unit</code> argument of <code>@vspec</code>.  The
+   value may be a plain string (<code>"km/h"</code>) or a SCREAMING_SNAKE_CASE
+   enum name that the loader maps to a standard string:</p>
+<pre><code>Speed: Float @vspec(element: SENSOR, fqn: "Vehicle.Speed") @unit(value: "KM_PER_HOUR")
+# → Node_t.Unit = "km/h"</code></pre>
+<p>The full normalisation table is defined in <code>vdmloader/vdmloader.go</code>
+   (<code>normalizeUnit</code>).  Values not in the table are passed through
+   unchanged.</p>
+
+<h3>8.2 Default value</h3>
+<p>A signal's initial value at startup is declared with
+   <code>@defaultValue(value: "…")</code>:</p>
+<pre><code>IsEnabled: Boolean @vspec(element: ACTUATOR, fqn: "…") @defaultValue(value: "false")
+# → Node_t.DefaultValue = "false"</code></pre>
+
+<h3>8.3 Allowed values (enum signals)</h3>
+<p>When a signal field is typed as a user-defined GraphQL enum, the loader
+   populates <code>Node_t.AllowedDef</code> with the enum values.
+   <code>@vspec(originalName:)</code> on each enum value controls the string
+   stored in <code>AllowedDef</code>; it falls back to SCREAMING_SNAKE_CASE →
+   PascalCase conversion.</p>
+<pre><code>enum GearPosition {
+  PARK    @vspec(originalName: "Park")
+  REVERSE @vspec(originalName: "Reverse")
+  DRIVE   @vspec(originalName: "Drive")
+}
+type Vehicle … {
+  CurrentGear: GearPosition
+    @vspec(element: SENSOR, fqn: "Vehicle.CurrentGear")
+    @defaultValue(value: "Park")
+}
+# → Node_t.AllowedDef = ["Park","Reverse","Drive"]
+# → Node_t.Allowed = 3
+# → Node_t.DefaultValue = "Park"</code></pre>
+<p>Internal VDM enums (VspecElement, <code>*_InstanceTag_Dimension*</code>) are
+   never exposed as allowed values.</p>
+
+<h2 id="viss-service-extension">§9 @viss_service Extension</h2>
+
+<p>VDM itself has no concept of procedures or mutations.  The
+   <code>@viss_service</code> directive is a vissr-specific extension that
+   service developers add to their VDM field definitions to expose them as
+   callable service procedures over VISSv3.2 invoke/monitor channels.</p>
+
+<h3>8.1 Declaring a service procedure</h3>
+<pre><code>type VehicleSeating @vspec(element: BRANCH, fqn: "VehicleSeating", description: "Seating service") {
+  MoveSeat: Boolean
+    @vspec(element: SENSOR, fqn: "VehicleSeating.MoveSeat", description: "Adjust a seat position")
+    @viss_service
+}</code></pre>
+
+<p>The loader will create a <code>PROCEDURE</code> node at
+   <code>VehicleSeating.MoveSeat</code>.  The vissr service manager
+   (<code>vissServiceMgr</code>) treats <code>PROCEDURE</code> nodes exactly as
+   it does procedure nodes loaded from a <code>.Service</code> HIM tree.</p>
+
+<h3>8.2 Interaction with VISSv3.2 service protocol</h3>
+<p>Once the VDM tree is registered, clients can interact with
+   <code>@viss_service</code> fields using the standard VISSv3.2 actions:
+   <code>invoke</code>, <code>monitor</code>, <code>cancel</code>, and
+   <code>discover</code>.</p>
+
+<p class="note"><strong>Note:</strong> The <code>@viss_service</code>
+   directive is not part of the upstream VDM or s2dm specification.  It is
+   intended as a vissr-specific overlay that service authors add to their own
+   VDM extension files without modifying the base VDM schema.</p>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="server-integration">§10 Server Integration (--vdm flag)</h2>
+
+<h3>9.1 Command-line flag</h3>
+<pre><code>vissv2server --vdm &lt;dir&gt;</code></pre>
+
+<p>When <code>--vdm</code> is supplied, the server skips
+   <code>viss.him</code> loading and instead calls
+   <code>vdmloader.LoadDir(dir)</code> at startup.  All
+   <code>*.graphql</code> files in <em>dir</em> are parsed in lexicographic
+   order.  Each distinct root FQN (e.g., <code>Vehicle</code>) becomes a
+   separate tree registered in the HIM forest via
+   <code>utils.RegisterServiceTree</code>.</p>
+
+<h3>9.2 Mutual exclusivity</h3>
+<p><code>--vdm</code> and the default <code>viss.him</code> loading are
+   mutually exclusive.  If both a VDM directory and a
+   <code>viss.him</code> file are relevant, run the server with <code>--vdm</code>
+   (the <code>viss.him</code> path will not be read).</p>
+
+<h3>9.3 Multiple SDL files</h3>
+<p>All <code>*.graphql</code> files in the directory are loaded.  If two files
+   define a root with the same FQN (e.g., both export a
+   <code>Vehicle</code> root), the second registration is silently skipped and
+   a warning is logged.  Only the first file's tree is used.</p>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h3>10.4 Web dashboard (--web-addr)</h3>
+<p>The optional embedded web dashboard is enabled with:</p>
+<pre><code>vissv2server --vdm &lt;dir&gt; --web-addr :8090</code></pre>
+<p>The dashboard serves an interactive signal-tree explorer at
+   <code>http://localhost:8090</code>.  JSON API endpoints:</p>
+<table>
+  <tr><th>Path</th><th>Description</th></tr>
+  <tr><td><code>GET /api/forest</code></td><td>Array of <code>{rootName, domain, version}</code> objects for every loaded tree.</td></tr>
+  <tr><td><code>GET /api/tree/{rootName}</code></td><td>Full node tree as JSON with name, nodeType, datatype, unit, min, max, default, allowed, children.</td></tr>
+</table>
+<p>The dashboard is disabled by default (empty <code>--web-addr</code>) and has
+   no runtime dependencies beyond Go's standard library.</p>
+
+<h2 id="him-interop">§11 HIM / VDM Interoperability</h2>
+
+<p>v4.0 VDM trees and v3.x HIM trees use the same internal
+   <code>utils.Node_t</code> representation.  A server instance can only load
+   one or the other at startup, but the VISS protocol layer cannot distinguish
+   between the two at runtime — signal paths, subscriptions, and discovery
+   work identically regardless of how the tree was loaded.</p>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="vdminfo">§12 vdminfo Inspection Tool</h2>
+
+<p>The <code>tools/vdminfo</code> package is a standalone CLI for inspecting
+   VDM SDL files without starting the full server:</p>
+<pre><code>go run ./tools/vdminfo ./my-vdm-files/
+
+# Example output:
+=== Vehicle  (domain: Vehicle, version: 1.0) ===
+Vehicle  [branch, 6 children]
+  Speed  (sensor, float, km/h, 0..250)
+  CurrentGear  (sensor, vehiclegearposition, default=Park, allowed=[Park|Reverse|Neutral|Drive])
+  ADAS  [branch, 2 children]
+    ABS  [branch, 2 children]
+      IsEnabled  (actuator, bool, default=false)
+    …</code></pre>
+<p>Useful in CI to diff tree output between VDM revisions and to verify that
+   instance tag expansion produces the expected signal paths.</p>
+
+<h2 id="ci-validation">§13 CI Validation with s2dm</h2>
+
+<p>The <strong>s2dm</strong> Python toolchain validates that VDM SDL files are
+   structurally and semantically correct (naming conventions, forbidden
+   patterns, required directive presence, etc.).  vissr does not depend on
+   s2dm at runtime; s2dm is a CI gate only.</p>
+
+<p>To add s2dm validation to a vissr CI pipeline:</p>
+
+<pre><code># In .github/workflows/test.yml, before Go tests:
+- name: Validate VDM SDL (s2dm)
+  run: |
+    pip install uv
+    uv run poe validate --input path/to/vdm-files/</code></pre>
+
+<p>s2dm validates that every type has a valid <code>@vspec</code> annotation,
+   that FQN strings are well-formed, and that COVESA naming conventions are
+   respected.  The loader's own tests cover parse correctness; s2dm covers
+   semantic compliance with the VDM authoring rules.</p>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="conformance">§14 Conformance</h2>
+
+<p>A conforming v4.0 VDM loader implementation MUST:</p>
+<ol>
+  <li>Accept the preamble in Appendix A as valid SDL without error.</li>
+  <li>Reconstruct the tree hierarchy from <code>@vspec(fqn: …)</code> values,
+      not from the GraphQL type graph.</li>
+  <li>Map all GraphQL types listed in §5 to the correct VSS datatype
+      string.</li>
+  <li>Populate <code>Node_t.Min</code> and <code>Node_t.Max</code> from
+      <code>@range</code> as decimal strings without trailing zeros.</li>
+  <li>Override <code>NodeType</code> to <code>PROCEDURE</code> for any field
+      bearing <code>@viss_service</code>.</li>
+  <li>Synthesise intermediate <code>BRANCH</code> nodes for any FQN parent not
+      explicitly declared in the SDL.</li>
+  <li>Maintain <code>Node_t.Children == uint8(len(Node_t.Child))</code> at all
+      times.</li>
+  <li>Expand every <code>*_InstanceTag</code> type bearing <code>@instanceTag</code>
+      into one subtree per dimension-value combination, deep-cloning the base
+      signal subtree into each instance with independent <code>*Node_t</code>
+      pointers.</li>
+  <li>Derive instance path segments from <code>@vspec(originalName:)</code>
+      on enum values, falling back to SCREAMING_SNAKE_CASE → PascalCase
+      conversion when the argument is absent.</li>
+  <li>Reject SDL that contains no <code>@vspec</code>-annotated type (return an
+      error).</li>
+  <li>Reject SDL that contains no root-level <code>BRANCH</code> type
+      (return an error).</li>
+</ol>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="appendix-a">Appendix A — SDL Directives Preamble</h2>
+
+<p>The following preamble is automatically prepended to every SDL string
+   by the loader.  Authors do not need to repeat it in their files.</p>
+
+<pre><code>directive @vspec(
+  element: VspecElement!
+  fqn: String!
+  description: String
+  comment: String
+  deprecation: String
+) on OBJECT | FIELD_DEFINITION
+
+directive @range(min: Float, max: Float) on FIELD_DEFINITION
+
+directive @instanceTag on OBJECT
+
+directive @viss_service on FIELD_DEFINITION
+
+enum VspecElement {
+  BRANCH
+  SENSOR
+  ACTUATOR
+  ATTRIBUTE
+  STRUCT
+  PROPERTY
+}
+
+scalar Int8
+scalar UInt8
+scalar Int16
+scalar UInt16
+scalar UInt32
+scalar Int64
+scalar UInt64</code></pre>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<h2 id="appendix-b">Appendix B — Example VDM File</h2>
+
+<p>The following <code>vehicle.graphql</code> file demonstrates a minimal but
+   representative VDM signal model that the v4.0 loader can consume directly.</p>
+
+<pre><code># vehicle.graphql — minimal VDM SDL example for vissr v4.0
+
+type Vehicle @vspec(element: BRANCH, fqn: "Vehicle", description: "Top-level vehicle object") {
+  Speed: Float         @vspec(element: SENSOR,    fqn: "Vehicle.Speed",    description: "Current speed in km/h") @range(min: 0, max: 250)
+  ADAS:  VehicleADAS   @vspec(element: BRANCH,    fqn: "Vehicle.ADAS")
+  Cabin: VehicleCabin  @vspec(element: BRANCH,    fqn: "Vehicle.Cabin")
+}
+
+type VehicleADAS @vspec(element: BRANCH, fqn: "Vehicle.ADAS", description: "Advanced driver-assistance systems") {
+  ActiveAutonomyLevel: String  @vspec(element: ATTRIBUTE, fqn: "Vehicle.ADAS.ActiveAutonomyLevel", description: "Current autonomy level")
+  ABS: VehicleADASABS          @vspec(element: BRANCH,    fqn: "Vehicle.ADAS.ABS")
+}
+
+type VehicleADASABS @vspec(element: BRANCH, fqn: "Vehicle.ADAS.ABS", description: "Antilock braking system") {
+  IsEnabled: Boolean @vspec(element: ACTUATOR, fqn: "Vehicle.ADAS.ABS.IsEnabled", description: "Enable or disable ABS")
+  IsActive:  Boolean @vspec(element: SENSOR,   fqn: "Vehicle.ADAS.ABS.IsActive",  description: "ABS is currently active")
+}
+
+type VehicleCabin @vspec(element: BRANCH, fqn: "Vehicle.Cabin", description: "Vehicle cabin") {
+  Temperature: Float @vspec(element: SENSOR, fqn: "Vehicle.Cabin.Temperature", description: "Cabin temperature in °C") @range(min: -40, max: 100)
+}</code></pre>
+
+<p>Start the server with:</p>
+<pre><code>vissv2server --vdm /path/to/vdm-files/</code></pre>
+
+<p>Then query a signal in the loaded tree:</p>
+<pre><code>{"action":"get","path":"Vehicle.Speed","requestId":"req-1"}</code></pre>
+
+<hr>
+<p style="font-size:.9em;color:#666;">
+VISSv4.0 VDM Integration Specification · COVESA vissr project ·
+<a href="https://github.com/covesa/vissr">github.com/covesa/vissr</a>
+</p>
+
+</body>
+</html>

--- a/spec/VISSv4.0_VDM_Quickstart.md
+++ b/spec/VISSv4.0_VDM_Quickstart.md
@@ -241,6 +241,30 @@ also query these endpoints directly with `curl` for scripting.
 
 ---
 
+## Live reload of VDM files
+
+Start the server with `--vdm-watch` to automatically reload the signal trees
+whenever a `.graphql` file in the VDM directory is created, modified, or removed:
+
+```bash
+vissv2server --vdm ./my-vdm/ --vdm-watch
+```
+
+When any `.graphql` file changes:
+1. All trees previously loaded from that directory are deregistered from the
+   HIM forest.
+2. The entire directory is re-parsed and the new trees are registered.
+
+Transport managers see the updated forest on their next lookup — no restart
+needed.  `--vdm-watch` has no effect when `--vdm` is not set.
+
+> **Note**: live reload modifies the HIM forest concurrently with incoming
+> requests. The forest is protected by a `sync.RWMutex` so there are no
+> data races, but in-flight requests that hold a reference to an old tree
+> will continue to use it until they complete.
+
+---
+
 ## Running the test suite
 
 Unit tests for the VDM loader:

--- a/spec/VISSv4.0_VDM_Quickstart.md
+++ b/spec/VISSv4.0_VDM_Quickstart.md
@@ -1,0 +1,377 @@
+# VISSv4.0 VDM Integration — Quickstart Guide
+
+This guide gets you from a COVESA VDM `.graphql` file to a running vissr
+server in five minutes. For the full specification see `VISSv4.0_VDM.html`.
+
+---
+
+## What is new in v4.0?
+
+VISSv4.0 adds native support for the COVESA **VDM (Vehicle Data Model)**
+GraphQL SDL format. Instead of compiling a VSS YAML catalog into a binary tree
+and listing it in `viss.him`, you can point the server directly at a directory
+of `.graphql` files:
+
+```
+vissv2server --vdm ./my-vdm-signals/
+```
+
+The server parses the SDL at startup, builds the equivalent signal trees in
+memory, and registers them — no binary compilation step required.
+
+---
+
+## Prerequisites
+
+| Tool | Why |
+|---|---|
+| Go 1.22+ | Build the server |
+| vissr source | `git clone https://github.com/covesa/vissr && cd vissr` |
+| A `.graphql` VDM file | Your signal model |
+
+---
+
+## Step 1: Write a VDM SDL file
+
+Create `my-vdm/vehicle.graphql`:
+
+```graphql
+type Vehicle @vspec(element: BRANCH, fqn: "Vehicle", description: "Top-level vehicle object") {
+  Speed: Float         @vspec(element: SENSOR,    fqn: "Vehicle.Speed",    description: "Current speed in km/h") @range(min: 0, max: 250)
+  ADAS:  VehicleADAS   @vspec(element: BRANCH,    fqn: "Vehicle.ADAS")
+  Cabin: VehicleCabin  @vspec(element: BRANCH,    fqn: "Vehicle.Cabin")
+}
+
+type VehicleADAS @vspec(element: BRANCH, fqn: "Vehicle.ADAS", description: "Advanced driver-assistance") {
+  ActiveAutonomyLevel: String @vspec(element: ATTRIBUTE, fqn: "Vehicle.ADAS.ActiveAutonomyLevel", description: "Current autonomy level")
+  ABS: VehicleADASABS         @vspec(element: BRANCH,    fqn: "Vehicle.ADAS.ABS")
+}
+
+type VehicleADASABS @vspec(element: BRANCH, fqn: "Vehicle.ADAS.ABS", description: "Antilock braking") {
+  IsEnabled: Boolean @vspec(element: ACTUATOR, fqn: "Vehicle.ADAS.ABS.IsEnabled", description: "Enable or disable ABS")
+  IsActive:  Boolean @vspec(element: SENSOR,   fqn: "Vehicle.ADAS.ABS.IsActive",  description: "ABS active")
+}
+
+type VehicleCabin @vspec(element: BRANCH, fqn: "Vehicle.Cabin", description: "Vehicle cabin") {
+  Temperature: Float @vspec(element: SENSOR, fqn: "Vehicle.Cabin.Temperature", description: "Cabin temp °C") @range(min: -40, max: 100)
+}
+```
+
+**Key rules:**
+- Every type needs `@vspec(element: BRANCH, fqn: "...")` on the `type` declaration.
+- Every signal field needs `@vspec(element: SENSOR|ACTUATOR|ATTRIBUTE, fqn: "...")`.
+- The `fqn` values define the tree; the GraphQL type hierarchy is ignored.
+- You do **not** need to include the directive preamble — the loader adds it automatically.
+
+---
+
+## Step 2: Build and start the server
+
+```bash
+# From the vissr repo root
+go build ./server/vissv2server/
+
+cd server/vissv2server/
+./vissv2server --vdm ../../my-vdm/
+```
+
+You should see a log line like:
+
+```
+VDM loader: registered 1 tree(s) from ../../my-vdm/
+```
+
+The server is now accepting WebSocket connections on port 8080 (default).
+
+---
+
+## Step 3: Query a signal
+
+Connect with any VISS WebSocket client and send a `get` request:
+
+```json
+{"action":"get","path":"Vehicle.Speed","requestId":"req-1"}
+```
+
+Expected response (value depends on your state-storage backend):
+
+```json
+{
+  "action": "get",
+  "path": "Vehicle.Speed",
+  "data": {"dp": {"value": "0", "ts": "2026-06-06T12:00:00Z"}},
+  "requestId": "req-1",
+  "ts": "2026-06-06T12:00:00Z"
+}
+```
+
+---
+
+## Step 4: Set an actuator signal
+
+```json
+{"action":"set","path":"Vehicle.ADAS.ABS.IsEnabled","value":"true","requestId":"req-2"}
+```
+
+---
+
+## Step 5: Add a service procedure with @viss_service
+
+If you want to expose a callable procedure using VISSv3.2 service semantics,
+add `@viss_service` to a field:
+
+```graphql
+type SeatingService @vspec(element: BRANCH, fqn: "SeatingService", description: "Seating control") {
+  MoveSeat: Boolean
+    @vspec(element: SENSOR, fqn: "SeatingService.MoveSeat", description: "Adjust seat position")
+    @viss_service
+}
+```
+
+The loader creates a `PROCEDURE` node for `SeatingService.MoveSeat`.
+Clients can now invoke it using the VISSv3.2 `invoke` action:
+
+```json
+{
+  "action": "invoke",
+  "path": "SeatingService.MoveSeat",
+  "input": {"SeatId": "1", "Position": "40"},
+  "filter": {"variant": "all"},
+  "requestId": "inv-1"
+}
+```
+
+See `VISSv3.2_Service_Quickstart.md` for the full invoke/monitor/cancel flow.
+
+---
+
+## Using multiple SDL files
+
+You can split your VDM across multiple `.graphql` files in the same directory:
+
+```
+my-vdm/
+  vehicle.graphql      # Vehicle.* signals
+  seating.graphql      # SeatingService.* procedures
+```
+
+All files are loaded at startup. Each distinct root FQN becomes an independent
+tree in the HIM forest.
+
+---
+
+## Validating SDL with s2dm (recommended for CI)
+
+The COVESA **s2dm** toolchain enforces naming conventions and structural rules
+beyond what the GraphQL parser checks.  Add it as a CI gate:
+
+```bash
+# Install uv (if not already available)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Validate all SDL files
+uv run poe validate --input ./my-vdm/
+```
+
+s2dm is a Python tool and is **not** required at runtime — it is a CI-only
+validation step.  The vissr loader will accept any syntactically valid SDL that
+contains `@vspec` annotations; s2dm additionally checks semantic compliance
+with COVESA VDM authoring rules.
+
+---
+
+## HIM vs VDM: when to use each
+
+| Scenario | Use |
+|---|---|
+| Existing VSS YAML catalog compiled to binary | `viss.him` (default) |
+| Authoring a new signal model with VDM tooling | `--vdm <dir>` |
+| Mixing legacy HIM trees with new VDM trees | Not yet supported; use one or the other |
+
+---
+
+## Inspecting your signal tree with vdminfo
+
+Before starting the server, verify what the loader will produce:
+
+```bash
+go run ./tools/vdminfo ./my-vdm/
+```
+
+Example output:
+```
+=== Vehicle  (domain: Vehicle, version: 1.0) ===
+Vehicle  [branch, 6 children]
+  Speed  (sensor, float, km/h, 0..250)
+  CurrentGear  (sensor, vehiclegearposition, default=Park, allowed=[Park|Reverse|Neutral|Drive])
+  Cabin  [branch, 1 children]
+    Seat  [branch, 2 children]
+      Row1  [branch, 2 children]
+        DriverSide  [branch, 3 children]
+          IsOccupied  (sensor, bool)
+          Position  (actuator, uint8, 0..100)
+        PassengerSide  [branch, 3 children]
+          ...
+```
+
+Use it in CI to diff tree output between VDM versions:
+```bash
+go run ./tools/vdminfo ./my-vdm/ > tree-new.txt
+diff tree-baseline.txt tree-new.txt
+```
+
+---
+
+## Web dashboard
+
+Start the server with `--web-addr` to open the embedded signal-tree dashboard:
+
+```bash
+vissv2server --vdm ./my-vdm/ --web-addr :8090
+```
+
+Then open **http://localhost:8090** in a browser. The dashboard shows:
+
+- A collapsible signal tree on the left (searchable)
+- Node details on the right: path, type, datatype, unit, range, default, allowed values
+- Switch between loaded trees via the dropdown at the top
+
+The dashboard reads from `/api/forest` and `/api/tree/{rootName}` — you can
+also query these endpoints directly with `curl` for scripting.
+
+---
+
+## Running the test suite
+
+Unit tests for the VDM loader:
+
+```bash
+go test -race -count=1 ./server/vissv2server/vdmloader/...
+```
+
+Full CI (unit + MQTT integration):
+
+```bash
+# Start the mosquitto broker container
+docker compose -f docker-compose.test.yml up -d
+
+# Run all tests
+go test -race -count=1 ./server/vissv2server/vissServiceMgr/...
+go test -race -count=1 ./server/vissv2server/vdmloader/...
+go test -v       -count=1 ./paho-mqtt/...
+
+# Tear down
+docker compose -f docker-compose.test.yml down
+```
+
+CI runs all of the above automatically on every push/PR via
+`.github/workflows/test.yml`.
+
+---
+
+## Units, default values, and allowed values
+
+### Units
+
+Add `@unit(value: "…")` to any signal field. Pass a standard string or a
+SCREAMING_SNAKE_CASE name — the loader normalises both:
+
+```graphql
+Speed: Float @vspec(element: SENSOR, fqn: "Vehicle.Speed") @unit(value: "km/h")
+Temp:  Float @vspec(element: SENSOR, fqn: "Vehicle.Cabin.Temperature") @unit(value: "DEGREES_CELSIUS")
+# → Node_t.Unit = "celsius"
+```
+
+Common normalised names: `km/h`, `m/s`, `mph`, `celsius`, `degrees`, `radians`,
+`percent`, `m`, `km`, `kW`, `kWh`, `V`, `A`, `Nm`, `rpm`, `s`, `ms`, `Hz`.
+
+### Default values
+
+```graphql
+IsEnabled: Boolean @vspec(element: ACTUATOR, fqn: "…") @defaultValue(value: "false")
+CurrentGear: GearEnum @vspec(element: SENSOR, fqn: "…") @defaultValue(value: "Park")
+```
+
+The value is stored as a string in `Node_t.DefaultValue` and used by the server
+to seed the state-storage backend at startup.
+
+### Allowed values (enum signals)
+
+Type a signal field as a GraphQL enum and the loader automatically populates
+`Node_t.AllowedDef`:
+
+```graphql
+enum GearPosition {
+  PARK    @vspec(originalName: "Park")
+  REVERSE @vspec(originalName: "Reverse")
+  NEUTRAL @vspec(originalName: "Neutral")
+  DRIVE   @vspec(originalName: "Drive")
+}
+
+type Vehicle … {
+  CurrentGear: GearPosition
+    @vspec(element: SENSOR, fqn: "Vehicle.CurrentGear")
+    @defaultValue(value: "Park")
+}
+```
+
+The server will reject `set` requests with values outside the allowed list.
+
+---
+
+## Multi-instance signals (instance tags)
+
+VDM's instance tag mechanism lets one signal definition expand to cover many
+physical instances — for example one seat template that becomes
+`Row1.DriverSide`, `Row1.PassengerSide`, `Row2.DriverSide`, etc.
+
+Add an `_InstanceTag` type and its dimension enums to your SDL:
+
+```graphql
+type VehicleCabinSeat @vspec(element: BRANCH, fqn: "Vehicle.Cabin.Seat") {
+  IsOccupied: Boolean @vspec(element: SENSOR,   fqn: "Vehicle.Cabin.Seat.IsOccupied")
+  Position:   UInt8   @vspec(element: ACTUATOR, fqn: "Vehicle.Cabin.Seat.Position") @range(min: 0, max: 100)
+}
+
+type VehicleCabinSeat_InstanceTag @instanceTag @vspec(element: BRANCH, fqn: "Vehicle.Cabin.Seat") {
+  dimension1: VehicleCabinSeat_InstanceTag_Dimension1
+  dimension2: VehicleCabinSeat_InstanceTag_Dimension2
+}
+
+enum VehicleCabinSeat_InstanceTag_Dimension1 {
+  ROW1 @vspec(originalName: "Row1")
+  ROW2 @vspec(originalName: "Row2")
+}
+
+enum VehicleCabinSeat_InstanceTag_Dimension2 {
+  DRIVER_SIDE    @vspec(originalName: "DriverSide")
+  PASSENGER_SIDE @vspec(originalName: "PassengerSide")
+}
+```
+
+The loader expands this automatically into:
+```
+Vehicle.Cabin.Seat.Row1.DriverSide.IsOccupied
+Vehicle.Cabin.Seat.Row1.DriverSide.Position
+Vehicle.Cabin.Seat.Row1.PassengerSide.IsOccupied
+Vehicle.Cabin.Seat.Row1.PassengerSide.Position
+Vehicle.Cabin.Seat.Row2.DriverSide.IsOccupied
+...
+```
+
+Query any instance directly:
+```json
+{"action":"get","path":"Vehicle.Cabin.Seat.Row1.DriverSide.Position","requestId":"req-3"}
+```
+
+Up to N dimensions are supported; VDM today uses 1 or 2.
+
+---
+
+## Known limitations (v4.0)
+
+| Limitation | Planned fix |
+|---|---|
+| `@viss_service` is a vissr extension, not part of upstream VDM | Upstreaming TBD |
+| `--vdm` and `viss.him` are mutually exclusive at startup | Mixed mode planned |
+| STRUCT / PROPERTY element types are parsed but not expanded | v4.1 |

--- a/tools/vdminfo/main.go
+++ b/tools/vdminfo/main.go
@@ -1,0 +1,125 @@
+// vdminfo prints the signal tree from one or more VDM .graphql SDL files.
+//
+// Usage:
+//
+//	vdminfo <dir-or-file> [<dir-or-file> …]
+//
+// For directories every *.graphql file is parsed. For individual files the
+// path is parsed directly. The signal tree is printed in indented form with
+// per-node metadata (nodeType, datatype, range, unit, default, allowed).
+//
+// Example:
+//
+//	go run ./tools/vdminfo ./server/vissv2server/vdmloader/testdata/
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/covesa/vissr/server/vissv2server/vdmloader"
+	"github.com/covesa/vissr/utils"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: vdminfo <dir-or-file> [<dir-or-file> …]")
+		os.Exit(1)
+	}
+
+	// Initialise a silent logger so vdmloader doesn't panic on nil Info.
+	utils.InitLog("vdminfo.log", os.TempDir(), false, "error")
+
+	exitCode := 0
+	for _, arg := range os.Args[1:] {
+		info, err := os.Stat(arg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "vdminfo: %v\n", err)
+			exitCode = 1
+			continue
+		}
+		var roots []*utils.Node_t
+		var metas []vdmloader.TreeMeta
+
+		if info.IsDir() {
+			entries, err := os.ReadDir(arg)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "vdminfo: reading %s: %v\n", arg, err)
+				exitCode = 1
+				continue
+			}
+			for _, e := range entries {
+				if e.IsDir() || !strings.HasSuffix(e.Name(), ".graphql") {
+					continue
+				}
+				r, m, err := vdmloader.ParseFile(arg + "/" + e.Name())
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "vdminfo: %s: %v\n", e.Name(), err)
+					exitCode = 1
+					continue
+				}
+				roots = append(roots, r...)
+				metas = append(metas, m...)
+			}
+		} else {
+			r, m, err := vdmloader.ParseFile(arg)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "vdminfo: %s: %v\n", arg, err)
+				exitCode = 1
+				continue
+			}
+			roots = append(roots, r...)
+			metas = append(metas, m...)
+		}
+
+		for i, root := range roots {
+			meta := metas[i]
+			fmt.Printf("=== %s  (domain: %s, version: %s) ===\n", meta.RootName, meta.Domain, meta.Version)
+			printNode(root, 0)
+			fmt.Println()
+		}
+	}
+	os.Exit(exitCode)
+}
+
+func printNode(n *utils.Node_t, depth int) {
+	indent := strings.Repeat("  ", depth)
+	fmt.Printf("%s%s", indent, n.Name)
+
+	// Collect metadata annotations
+	var parts []string
+	if n.NodeType != "" && n.NodeType != utils.BRANCH {
+		parts = append(parts, n.NodeType)
+	}
+	if n.Datatype != "" {
+		parts = append(parts, n.Datatype)
+	}
+	if n.Unit != "" {
+		parts = append(parts, n.Unit)
+	}
+	if n.Min != "" || n.Max != "" {
+		parts = append(parts, fmt.Sprintf("%s..%s", n.Min, n.Max))
+	}
+	if n.DefaultValue != "" {
+		parts = append(parts, fmt.Sprintf("default=%s", n.DefaultValue))
+	}
+	if len(n.AllowedDef) > 0 {
+		parts = append(parts, fmt.Sprintf("allowed=[%s]", strings.Join(n.AllowedDef, "|")))
+	}
+
+	if len(parts) > 0 {
+		fmt.Printf("  (%s)", strings.Join(parts, ", "))
+	}
+	if n.NodeType == utils.BRANCH || n.NodeType == "" {
+		fmt.Printf("  [branch, %d children]", len(n.Child))
+	}
+	if n.Description != "" && depth == 0 {
+		fmt.Printf("  — %s", n.Description)
+	}
+	fmt.Println()
+
+	for _, child := range n.Child {
+		printNode(child, depth+1)
+	}
+}

--- a/tools/vdminfo/vdminfo_test.go
+++ b/tools/vdminfo/vdminfo_test.go
@@ -1,0 +1,148 @@
+/**
+* (C) 2026 Matt Jones
+*
+* Unit tests for vdminfo.
+*
+* printNode is the only pure logic function; main requires filesystem paths
+* and is integration-only.
+**/
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/covesa/vissr/utils"
+)
+
+func init() {
+	utils.InitLog("vdminfo-test.log", os.TempDir(), false, "error")
+}
+
+// captureOutput redirects stdout during fn and returns what was printed.
+func captureOutput(fn func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = old
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	return string(buf[:n])
+}
+
+// ── printNode ─────────────────────────────────────────────────────────────────
+
+func TestPrintNode_LeafNode(t *testing.T) {
+	node := &utils.Node_t{
+		Name:     "Speed",
+		NodeType: "sensor",
+		Datatype: "float",
+		Unit:     "km/h",
+	}
+	out := captureOutput(func() { printNode(node, 0) })
+	if !strings.Contains(out, "Speed") {
+		t.Errorf("output missing node name: %q", out)
+	}
+	if !strings.Contains(out, "sensor") {
+		t.Errorf("output missing NodeType: %q", out)
+	}
+	if !strings.Contains(out, "float") {
+		t.Errorf("output missing Datatype: %q", out)
+	}
+	if !strings.Contains(out, "km/h") {
+		t.Errorf("output missing Unit: %q", out)
+	}
+}
+
+func TestPrintNode_BranchNode(t *testing.T) {
+	child := &utils.Node_t{Name: "Speed", NodeType: "sensor"}
+	node := &utils.Node_t{
+		Name:     "Vehicle",
+		NodeType: utils.BRANCH,
+		Child:    []*utils.Node_t{child},
+	}
+	out := captureOutput(func() { printNode(node, 0) })
+	if !strings.Contains(out, "Vehicle") {
+		t.Errorf("output missing branch name: %q", out)
+	}
+	if !strings.Contains(out, "branch") {
+		t.Errorf("output missing branch marker: %q", out)
+	}
+	// Child should appear indented.
+	if !strings.Contains(out, "Speed") {
+		t.Errorf("output missing child node: %q", out)
+	}
+}
+
+func TestPrintNode_WithRangeAndDefault(t *testing.T) {
+	node := &utils.Node_t{
+		Name:         "PedalPosition",
+		NodeType:     "sensor",
+		Datatype:     "uint8",
+		Min:          "0",
+		Max:          "100",
+		DefaultValue: "0",
+	}
+	out := captureOutput(func() { printNode(node, 0) })
+	if !strings.Contains(out, "0..100") {
+		t.Errorf("output missing range: %q", out)
+	}
+	if !strings.Contains(out, "default=0") {
+		t.Errorf("output missing default: %q", out)
+	}
+}
+
+func TestPrintNode_WithAllowed(t *testing.T) {
+	node := &utils.Node_t{
+		Name:       "GearMode",
+		NodeType:   "actuator",
+		AllowedDef: []string{"P", "R", "N", "D"},
+	}
+	out := captureOutput(func() { printNode(node, 0) })
+	if !strings.Contains(out, "allowed=") {
+		t.Errorf("output missing allowed values: %q", out)
+	}
+}
+
+func TestPrintNode_DepthIndent(t *testing.T) {
+	node := &utils.Node_t{Name: "Lights", NodeType: "sensor"}
+	out := captureOutput(func() { printNode(node, 3) })
+	// depth=3 → 6 leading spaces ("  " * 3)
+	if !strings.HasPrefix(out, "      Lights") {
+		t.Errorf("depth-3 node should have 6 leading spaces; got: %q", out)
+	}
+}
+
+func TestPrintNode_DescriptionAtDepthZero(t *testing.T) {
+	node := &utils.Node_t{
+		Name:        "Vehicle",
+		NodeType:    utils.BRANCH,
+		Description: "Root VSS node",
+	}
+	out := captureOutput(func() { printNode(node, 0) })
+	if !strings.Contains(out, "Root VSS node") {
+		t.Errorf("description should be printed at depth 0: %q", out)
+	}
+}
+
+func TestPrintNode_DescriptionSuppressedBelowDepthZero(t *testing.T) {
+	node := &utils.Node_t{
+		Name:        "Body",
+		NodeType:    utils.BRANCH,
+		Description: "Body node",
+	}
+	out := captureOutput(func() { printNode(node, 1) })
+	if strings.Contains(out, "Body node") {
+		t.Errorf("description should be suppressed at depth > 0: %q", out)
+	}
+}
+
+// Integration-only entry points — NOT unit-tested here:
+//
+//   main — reads filesystem paths from os.Args, calls vdmloader.ParseFile.

--- a/utils/coverage_gap_test.go
+++ b/utils/coverage_gap_test.go
@@ -794,53 +794,6 @@ func TestGetForestRoot_NotFoundGap(t *testing.T) {
 }
 
 // ============================================================================
-// treeutils.go — RegisterServiceTree / DeregisterServiceTree
-// ============================================================================
-
-func TestRegisterServiceTree_DoubleRegistration(t *testing.T) {
-	old := himForest
-	himForest = nil
-	defer func() { himForest = old }()
-
-	root := NewBranchNode("SvcRoot")
-	if ok := RegisterServiceTree("MySvc", "org.example.MySvc.Service", "1.0", root); !ok {
-		t.Fatalf("first RegisterServiceTree failed")
-	}
-	// Second registration with same rootName should return false
-	if ok := RegisterServiceTree("MySvc", "org.example.MySvc.Service", "1.0", root); ok {
-		t.Errorf("duplicate RegisterServiceTree should return false; got true")
-	}
-}
-
-func TestDeregisterServiceTree_RemovesEntry(t *testing.T) {
-	old := himForest
-	himForest = nil
-	defer func() { himForest = old }()
-
-	root := NewBranchNode("SvcRoot")
-	RegisterServiceTree("MySvc", "org.example.MySvc.Service", "1.0", root)
-	DeregisterServiceTree("MySvc")
-
-	if GetForestRoot("MySvc") != nil {
-		t.Errorf("DeregisterServiceTree did not remove the entry")
-	}
-}
-
-func TestDeregisterServiceTree_NotFound(t *testing.T) {
-	old := himForest
-	himForest = nil
-	defer func() { himForest = old }()
-
-	// Must not panic on unknown rootName
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("DeregisterServiceTree panicked on unknown rootName: %v", r)
-		}
-	}()
-	DeregisterServiceTree("NonExistent")
-}
-
-// ============================================================================
 // treeutils.go — VSSsearchNodes
 // ============================================================================
 
@@ -1368,6 +1321,53 @@ func TestValidateSecConfig_TransportSecYes_ExistingServerName(t *testing.T) {
 	if cfg.ServerName != "myserver.example.com" {
 		t.Errorf("ServerName = %q; want \"myserver.example.com\" (not overwritten)", cfg.ServerName)
 	}
+}
+
+// ============================================================================
+// treeutils.go — RegisterServiceTree / DeregisterServiceTree
+// ============================================================================
+
+func TestRegisterServiceTree_DoubleRegistration(t *testing.T) {
+	old := himForest
+	himForest = nil
+	defer func() { himForest = old }()
+
+	root := NewBranchNode("SvcRoot")
+	if ok := RegisterServiceTree("MySvc", "org.example.MySvc.Service", "1.0", root); !ok {
+		t.Fatalf("first RegisterServiceTree failed")
+	}
+	// Second registration with same rootName should return false
+	if ok := RegisterServiceTree("MySvc", "org.example.MySvc.Service", "1.0", root); ok {
+		t.Errorf("duplicate RegisterServiceTree should return false; got true")
+	}
+}
+
+func TestDeregisterServiceTree_RemovesEntry(t *testing.T) {
+	old := himForest
+	himForest = nil
+	defer func() { himForest = old }()
+
+	root := NewBranchNode("SvcRoot")
+	RegisterServiceTree("MySvc", "org.example.MySvc.Service", "1.0", root)
+	DeregisterServiceTree("MySvc")
+
+	if GetForestRoot("MySvc") != nil {
+		t.Errorf("DeregisterServiceTree did not remove the entry")
+	}
+}
+
+func TestDeregisterServiceTree_NotFound(t *testing.T) {
+	old := himForest
+	himForest = nil
+	defer func() { himForest = old }()
+
+	// Must not panic on unknown rootName
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("DeregisterServiceTree panicked on unknown rootName: %v", r)
+		}
+	}()
+	DeregisterServiceTree("NonExistent")
 }
 
 // ============================================================================

--- a/utils/treeutils.go
+++ b/utils/treeutils.go
@@ -54,6 +54,32 @@ type HimTree struct {
 
 var himForest []HimTree
 
+// ForestInfo is a JSON-serialisable summary of one tree in the HIM forest.
+type ForestInfo struct {
+	RootName string `json:"rootName"`
+	Domain   string `json:"domain"`
+	Version  string `json:"version"`
+}
+
+// ForestInfoList returns metadata for every tree currently in the HIM forest.
+func ForestInfoList() []ForestInfo {
+	out := make([]ForestInfo, 0, len(himForest))
+	for _, t := range himForest {
+		out = append(out, ForestInfo{RootName: t.RootName, Domain: t.Domain, Version: t.Version})
+	}
+	return out
+}
+
+// GetForestRoot returns the root Node_t for the named tree, or nil.
+func GetForestRoot(rootName string) *Node_t {
+	for i := range himForest {
+		if himForest[i].RootName == rootName {
+			return himForest[i].Handle
+		}
+	}
+	return nil
+}
+
 type LeafPathList struct {
 	LeafPaths []string
 }
@@ -241,73 +267,6 @@ func GetInfoType(treeHandle *Node_t) string {
 	return "Missing" //???
 }
 
-func CreatePathListFile(pListPath string) {
-	j := 1
-	for i:=0; i < len(himForest); i++ {
-		if himForest[i].Handle != nil {
-			pListFile := pListPath + "pathlist" + strconv.Itoa(j) + ".json"
-			os.Remove(pListFile)
-			VSSGetLeafNodesList(himForest[i].Handle, himForest[i].RootName, pListFile)
-			sortPathList(pListFile)
-			Info.Printf(pListFile + " created.")
-			j++
-		}
-	}
-}
-
-// NewBranchNode creates a branch Node_t with the given name and children.
-func NewBranchNode(name string, children ...*Node_t) *Node_t {
-	n := &Node_t{Name: name, NodeType: BRANCH, Children: uint8(len(children))}
-	if len(children) > 0 {
-		n.Child = make([]*Node_t, len(children))
-		for i, c := range children {
-			n.Child[i] = c
-			c.Parent = n
-		}
-	}
-	return n
-}
-
-// NewSignalNode creates a signal Node_t (sensor, actuator, or attribute).
-// nodeType must be one of the SENSOR, ACTUATOR, ATTRIBUTE constants.
-func NewSignalNode(name, nodeType, datatype, description, min, max, unit string) *Node_t {
-	return &Node_t{
-		Name:        name,
-		NodeType:    nodeType,
-		Datatype:    datatype,
-		Description: description,
-		Min:         min,
-		Max:         max,
-		Unit:        unit,
-	}
-}
-
-// ForestInfo is a JSON-serialisable summary of one tree in the HIM forest.
-type ForestInfo struct {
-	RootName string `json:"rootName"`
-	Domain   string `json:"domain"`
-	Version  string `json:"version"`
-}
-
-// ForestInfoList returns metadata for every tree currently in the HIM forest.
-func ForestInfoList() []ForestInfo {
-	out := make([]ForestInfo, 0, len(himForest))
-	for _, t := range himForest {
-		out = append(out, ForestInfo{RootName: t.RootName, Domain: t.Domain, Version: t.Version})
-	}
-	return out
-}
-
-// GetForestRoot returns the root Node_t for the named tree, or nil.
-func GetForestRoot(rootName string) *Node_t {
-	for i := range himForest {
-		if himForest[i].RootName == rootName {
-			return himForest[i].Handle
-		}
-	}
-	return nil
-}
-
 // RegisterServiceTree adds a dynamically-built service tree to the HIM forest.
 // Called by vissServiceMgr when a service process registers its procedure path.
 // domain must end in ".Service" so GetInfoType returns "Service".
@@ -338,7 +297,20 @@ func DeregisterServiceTree(rootName string) {
 	}
 }
 
-// NewProcedureNode creates a procedure Node_t for a VISSv3.3 service procedure.
+// NewBranchNode creates a branch Node_t with the given name and children.
+func NewBranchNode(name string, children ...*Node_t) *Node_t {
+	n := &Node_t{Name: name, NodeType: BRANCH, Children: uint8(len(children))}
+	if len(children) > 0 {
+		n.Child = make([]*Node_t, len(children))
+		for i, c := range children {
+			n.Child[i] = c
+			c.Parent = n
+		}
+	}
+	return n
+}
+
+// NewProcedureNode creates a procedure Node_t for a VISSv3.2 service procedure.
 func NewProcedureNode(name, description string, children ...*Node_t) *Node_t {
 	n := &Node_t{Name: name, NodeType: PROCEDURE, Description: description, Children: uint8(len(children))}
 	if len(children) > 0 {
@@ -367,6 +339,34 @@ func NewIoStructNode(name string, children ...*Node_t) *Node_t {
 // NewPropertyNode creates a property Node_t for a service parameter.
 func NewPropertyNode(name, datatype, description string) *Node_t {
 	return &Node_t{Name: name, NodeType: PROPERTY, Datatype: datatype, Description: description}
+}
+
+// NewSignalNode creates a signal Node_t (sensor, actuator, or attribute).
+// nodeType must be one of the SENSOR, ACTUATOR, ATTRIBUTE constants.
+func NewSignalNode(name, nodeType, datatype, description, min, max, unit string) *Node_t {
+	return &Node_t{
+		Name:        name,
+		NodeType:    nodeType,
+		Datatype:    datatype,
+		Description: description,
+		Min:         min,
+		Max:         max,
+		Unit:        unit,
+	}
+}
+
+func CreatePathListFile(pListPath string) {
+	j := 1
+	for i:=0; i < len(himForest); i++ {
+		if himForest[i].Handle != nil {
+			pListFile := pListPath + "pathlist" + strconv.Itoa(j) + ".json"
+			os.Remove(pListFile)
+			VSSGetLeafNodesList(himForest[i].Handle, himForest[i].RootName, pListFile)
+			sortPathList(pListFile)
+			Info.Printf(pListFile + " created.")
+			j++
+		}
+	}
 }
 
 func PopulateDefault() {

--- a/utils/treeutils.go
+++ b/utils/treeutils.go
@@ -53,6 +53,7 @@ type HimTree struct {
 }
 
 var himForest []HimTree
+var himForestMu sync.RWMutex
 
 // ForestInfo is a JSON-serialisable summary of one tree in the HIM forest.
 type ForestInfo struct {
@@ -63,6 +64,8 @@ type ForestInfo struct {
 
 // ForestInfoList returns metadata for every tree currently in the HIM forest.
 func ForestInfoList() []ForestInfo {
+	himForestMu.RLock()
+	defer himForestMu.RUnlock()
 	out := make([]ForestInfo, 0, len(himForest))
 	for _, t := range himForest {
 		out = append(out, ForestInfo{RootName: t.RootName, Domain: t.Domain, Version: t.Version})
@@ -72,6 +75,8 @@ func ForestInfoList() []ForestInfo {
 
 // GetForestRoot returns the root Node_t for the named tree, or nil.
 func GetForestRoot(rootName string) *Node_t {
+	himForestMu.RLock()
+	defer himForestMu.RUnlock()
 	for i := range himForest {
 		if himForest[i].RootName == rootName {
 			return himForest[i].Handle
@@ -205,6 +210,7 @@ func InitForest(himPath string) bool {
 	scanner.Split(bufio.ScanLines)
 	var text string
 	continueScan := true
+	var local []HimTree
 	i := -1
 	for continueScan {
 		continueScan = scanner.Scan()
@@ -215,37 +221,42 @@ func InitForest(himPath string) bool {
 		rootIndex := strings.Index(text, "HIM.") + 4
 		if rootIndex != 3 && text[len(text)-1] == ':' {
 			i++
-			himForest = append(himForest, HimTree{})
-			himForest[i].RootName = text[rootIndex:len(text)-1]
+			local = append(local, HimTree{})
+			local[i].RootName = text[rootIndex : len(text)-1]
 		} else if text[0] != '#' && strings.Contains(text, "type:") && i != -1 {
 			typeIndex := strings.Index(text, "type:") + 5
-			himForest[i].TreeType = strings.TrimSpace(text[typeIndex:len(text)])
+			local[i].TreeType = strings.TrimSpace(text[typeIndex:len(text)])
 		} else if text[0] != '#' && strings.Contains(text, "domain:") {
 			domainIndex := strings.Index(text, "domain:") + 7
-			himForest[i].Domain = strings.TrimSpace(text[domainIndex:len(text)])
+			local[i].Domain = strings.TrimSpace(text[domainIndex:len(text)])
 		} else if text[0] != '#' && strings.Contains(text, "version:") {
 			versionIndex := strings.Index(text, "version:") + 8
-			himForest[i].Version = strings.TrimSpace(text[versionIndex:len(text)])
+			local[i].Version = strings.TrimSpace(text[versionIndex:len(text)])
 		} else if text[0] != '#' && strings.Contains(text, "local:") {
 			localIndex := strings.Index(text, "local:") + 6
 			localPath := strings.TrimSpace(text[localIndex:len(text)])
-			himForest[i].Handle = VSSReadTree(localPath)
-			if himForest[i].Handle == nil {
+			local[i].Handle = VSSReadTree(localPath)
+			if local[i].Handle == nil {
 				Error.Printf("Error parsing %s", localPath)
+				file.Close()
 				return false
 			}
-			himForest[i].Handle.Name = himForest[i].RootName
+			local[i].Handle.Name = local[i].RootName
 		}
-		
 	}
 	file.Close()
+	himForestMu.Lock()
+	himForest = append(himForest, local...)
+	himForestMu.Unlock()
 	return true
 }
 
 func SetRootNodePointer(rootPath string) *Node_t {
 	dotIndex := GetFirstDotIndex(rootPath)
 	rootNodeName := rootPath[:dotIndex]
-	for i:=0; i < len(himForest); i++ {
+	himForestMu.RLock()
+	defer himForestMu.RUnlock()
+	for i := 0; i < len(himForest); i++ {
 		if himForest[i].RootName == rootNodeName {
 			return himForest[i].Handle
 		}
@@ -254,14 +265,15 @@ func SetRootNodePointer(rootPath string) *Node_t {
 }
 
 func GetInfoType(treeHandle *Node_t) string {
-	for i:=0; i < len(himForest); i++ {
+	himForestMu.RLock()
+	defer himForestMu.RUnlock()
+	for i := 0; i < len(himForest); i++ {
 		if himForest[i].Handle == treeHandle {
 			infoTypeIndex := strings.LastIndex(himForest[i].Domain, ".")
 			if infoTypeIndex == -1 {
 				return "Missing" //???
-			} else {
-				return himForest[i].Domain[infoTypeIndex+1:]
 			}
+			return himForest[i].Domain[infoTypeIndex+1:]
 		}
 	}
 	return "Missing" //???
@@ -272,6 +284,8 @@ func GetInfoType(treeHandle *Node_t) string {
 // domain must end in ".Service" so GetInfoType returns "Service".
 // Returns false if a tree for rootName already exists (no double-registration).
 func RegisterServiceTree(rootName, domain, version string, root *Node_t) bool {
+	himForestMu.Lock()
+	defer himForestMu.Unlock()
 	for i := 0; i < len(himForest); i++ {
 		if himForest[i].RootName == rootName {
 			return false
@@ -289,6 +303,8 @@ func RegisterServiceTree(rootName, domain, version string, root *Node_t) bool {
 
 // DeregisterServiceTree removes a dynamically-registered service tree by rootName.
 func DeregisterServiceTree(rootName string) {
+	himForestMu.Lock()
+	defer himForestMu.Unlock()
 	for i := 0; i < len(himForest); i++ {
 		if himForest[i].RootName == rootName {
 			himForest = append(himForest[:i], himForest[i+1:]...)
@@ -356,12 +372,16 @@ func NewSignalNode(name, nodeType, datatype, description, min, max, unit string)
 }
 
 func CreatePathListFile(pListPath string) {
+	himForestMu.RLock()
+	snap := make([]HimTree, len(himForest))
+	copy(snap, himForest)
+	himForestMu.RUnlock()
 	j := 1
-	for i:=0; i < len(himForest); i++ {
-		if himForest[i].Handle != nil {
+	for i := 0; i < len(snap); i++ {
+		if snap[i].Handle != nil {
 			pListFile := pListPath + "pathlist" + strconv.Itoa(j) + ".json"
 			os.Remove(pListFile)
-			VSSGetLeafNodesList(himForest[i].Handle, himForest[i].RootName, pListFile)
+			VSSGetLeafNodesList(snap[i].Handle, snap[i].RootName, pListFile)
 			sortPathList(pListFile)
 			Info.Printf(pListFile + " created.")
 			j++
@@ -370,11 +390,15 @@ func CreatePathListFile(pListPath string) {
 }
 
 func PopulateDefault() {
+	himForestMu.RLock()
+	snap := make([]HimTree, len(himForest))
+	copy(snap, himForest)
+	himForestMu.RUnlock()
 	j := 1
-	for i:=0; i < len(himForest); i++ {
-		if himForest[i].Handle != nil {
+	for i := 0; i < len(snap); i++ {
+		if snap[i].Handle != nil {
 			dListFile := "defaultList" + strconv.Itoa(j) + ".json"
-			numOfDefaults := VSSGetDefaultList(himForest[i].Handle, himForest[i].RootName, dListFile)
+			numOfDefaults := VSSGetDefaultList(snap[i].Handle, snap[i].RootName, dListFile)
 			if numOfDefaults == 0 {
 				os.Remove(dListFile)
 			} else {

--- a/utils/treeutils_test.go
+++ b/utils/treeutils_test.go
@@ -490,3 +490,249 @@ func TestReadBytesE_ZeroLengthReturnsNilAndNoError(t *testing.T) {
 	}
 }
 
+// ── New node constructors ────────────────────────────────────────────────────
+
+func TestNewBranchNode_NoChildren(t *testing.T) {
+	n := NewBranchNode("Root")
+	if n.Name != "Root" {
+		t.Errorf("Name = %q, want Root", n.Name)
+	}
+	if n.NodeType != BRANCH {
+		t.Errorf("NodeType = %q, want %q", n.NodeType, BRANCH)
+	}
+	if n.Children != 0 || len(n.Child) != 0 {
+		t.Errorf("expected 0 children, got Children=%d Child=%d", n.Children, len(n.Child))
+	}
+}
+
+func TestNewBranchNode_WithChildren(t *testing.T) {
+	leaf1 := NewSignalNode("Speed", SENSOR, "float", "vehicle speed", "0", "300", "km/h")
+	leaf2 := NewPropertyNode("Gear", "uint8", "current gear")
+	root := NewBranchNode("Vehicle", leaf1, leaf2)
+
+	if root.Children != 2 || len(root.Child) != 2 {
+		t.Fatalf("want 2 children, got Children=%d Child=%d", root.Children, len(root.Child))
+	}
+	if root.Child[0] != leaf1 || root.Child[1] != leaf2 {
+		t.Error("children not stored in order")
+	}
+	if leaf1.Parent != root || leaf2.Parent != root {
+		t.Error("Parent pointers not set on children")
+	}
+}
+
+func TestNewProcedureNode_Fields(t *testing.T) {
+	input := NewIoStructNode("Input")
+	proc := NewProcedureNode("MoveSeat", "adjusts seat position", input)
+
+	if proc.NodeType != PROCEDURE {
+		t.Errorf("NodeType = %q, want %q", proc.NodeType, PROCEDURE)
+	}
+	if proc.Description != "adjusts seat position" {
+		t.Errorf("Description = %q", proc.Description)
+	}
+	if proc.Children != 1 || proc.Child[0] != input {
+		t.Error("child not linked")
+	}
+	if input.Parent != proc {
+		t.Error("Parent not set on child")
+	}
+}
+
+func TestNewIoStructNode_Empty(t *testing.T) {
+	n := NewIoStructNode("Output")
+	if n.NodeType != IOSTRUCT {
+		t.Errorf("NodeType = %q, want %q", n.NodeType, IOSTRUCT)
+	}
+	if n.Children != 0 {
+		t.Errorf("want 0 children, got %d", n.Children)
+	}
+}
+
+func TestNewIoStructNode_WithChildren(t *testing.T) {
+	p1 := NewPropertyNode("Angle", "int8", "steering angle")
+	p2 := NewPropertyNode("Force", "float", "applied force")
+	n := NewIoStructNode("Input", p1, p2)
+
+	if n.Children != 2 || len(n.Child) != 2 {
+		t.Fatalf("want 2 children, got Children=%d Child=%d", n.Children, len(n.Child))
+	}
+	if n.Child[0] != p1 || n.Child[1] != p2 {
+		t.Error("children not stored in order")
+	}
+	if p1.Parent != n || p2.Parent != n {
+		t.Error("Parent pointers not set on children")
+	}
+}
+
+func TestNewPropertyNode_Fields(t *testing.T) {
+	p := NewPropertyNode("Position", "uint8", "seat position 0-100")
+	if p.NodeType != PROPERTY {
+		t.Errorf("NodeType = %q, want %q", p.NodeType, PROPERTY)
+	}
+	if p.Datatype != "uint8" {
+		t.Errorf("Datatype = %q, want uint8", p.Datatype)
+	}
+	if p.Description != "seat position 0-100" {
+		t.Errorf("Description = %q", p.Description)
+	}
+}
+
+func TestNewSignalNode_AllFields(t *testing.T) {
+	s := NewSignalNode("Temperature", SENSOR, "float", "cabin temp", "-40", "85", "celsius")
+	if s.Name != "Temperature" || s.NodeType != SENSOR || s.Datatype != "float" {
+		t.Errorf("basic fields wrong: %+v", s)
+	}
+	if s.Min != "-40" || s.Max != "85" || s.Unit != "celsius" {
+		t.Errorf("range/unit fields wrong: %+v", s)
+	}
+	if s.Description != "cabin temp" {
+		t.Errorf("Description = %q", s.Description)
+	}
+}
+
+// ── Path helpers ─────────────────────────────────────────────────────────────
+
+func TestGetFirstDotIndex_HasDot(t *testing.T) {
+	cases := []struct {
+		path string
+		want int
+	}{
+		{"Vehicle.Speed", 7},
+		{"A.B.C", 1},
+		{"A.B", 1},
+	}
+	for _, tc := range cases {
+		got := GetFirstDotIndex(tc.path)
+		if got != tc.want {
+			t.Errorf("GetFirstDotIndex(%q) = %d, want %d", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestGetFirstDotIndex_NoDot(t *testing.T) {
+	path := "VehicleOnly"
+	got := GetFirstDotIndex(path)
+	if got != len(path) {
+		t.Errorf("GetFirstDotIndex(%q) = %d, want %d (len)", path, got, len(path))
+	}
+}
+
+func TestGetLastDotSegment_Normal(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"Vehicle.Body.Speed", "Speed"},
+		{"Root.Leaf", "Leaf"},
+		{"Trailing.", ""},
+	}
+	for _, tc := range cases {
+		got := GetLastDotSegment(tc.path)
+		if got != tc.want {
+			t.Errorf("GetLastDotSegment(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestGetLastDotSegment_NoDot(t *testing.T) {
+	// No dot: strings.LastIndex returns -1; path[-1+1:] = path[0:] = full string.
+	got := GetLastDotSegment("NoDot")
+	if got != "NoDot" {
+		t.Errorf("GetLastDotSegment(\"NoDot\") = %q, want \"NoDot\"", got)
+	}
+}
+
+// ── Forest management ────────────────────────────────────────────────────────
+
+func saveAndRestoreForest(t *testing.T) {
+	t.Helper()
+	saved := make([]HimTree, len(himForest))
+	copy(saved, himForest)
+	t.Cleanup(func() { himForest = saved })
+}
+
+func TestRegisterServiceTree_AddsToForest(t *testing.T) {
+	saveAndRestoreForest(t)
+	root := NewBranchNode("RegSvc")
+	before := len(himForest)
+
+	ok := RegisterServiceTree("RegSvc", "reg.Service", "1.0.0", root)
+	if !ok {
+		t.Fatal("RegisterServiceTree returned false on first registration")
+	}
+	if len(himForest) != before+1 {
+		t.Errorf("forest len = %d, want %d", len(himForest), before+1)
+	}
+	if root.Name != "RegSvc" {
+		t.Errorf("root.Name = %q, want RegSvc", root.Name)
+	}
+}
+
+func TestRegisterServiceTree_NoDuplicates(t *testing.T) {
+	saveAndRestoreForest(t)
+	RegisterServiceTree("DupSvc", "d.Service", "1.0", NewBranchNode("DupSvc"))
+	ok := RegisterServiceTree("DupSvc", "d.Service", "1.1", NewBranchNode("DupSvc"))
+	if ok {
+		t.Error("second RegisterServiceTree for same name should return false")
+	}
+}
+
+func TestDeregisterServiceTree_Removes(t *testing.T) {
+	saveAndRestoreForest(t)
+	RegisterServiceTree("RemSvc", "r.Service", "1.0", NewBranchNode("RemSvc"))
+	before := len(himForest)
+	DeregisterServiceTree("RemSvc")
+	if len(himForest) != before-1 {
+		t.Errorf("after deregister: len=%d, want %d", len(himForest), before-1)
+	}
+	if GetForestRoot("RemSvc") != nil {
+		t.Error("root still reachable after deregister")
+	}
+}
+
+func TestDeregisterServiceTree_NoopOnMissing(t *testing.T) {
+	saveAndRestoreForest(t)
+	before := len(himForest)
+	DeregisterServiceTree("DoesNotExist")
+	if len(himForest) != before {
+		t.Errorf("forest len changed after deregister of missing tree")
+	}
+}
+
+func TestForestInfoList_ReturnsAllTrees(t *testing.T) {
+	saveAndRestoreForest(t)
+	himForest = nil
+	RegisterServiceTree("Alpha", "a.Service", "1.0", NewBranchNode("Alpha"))
+	RegisterServiceTree("Beta", "b.Service", "2.0", NewBranchNode("Beta"))
+
+	list := ForestInfoList()
+	if len(list) != 2 {
+		t.Fatalf("want 2, got %d: %+v", len(list), list)
+	}
+	names := map[string]bool{}
+	for _, fi := range list {
+		names[fi.RootName] = true
+	}
+	if !names["Alpha"] || !names["Beta"] {
+		t.Errorf("unexpected list: %+v", list)
+	}
+}
+
+func TestGetForestRoot_Found(t *testing.T) {
+	saveAndRestoreForest(t)
+	root := NewBranchNode("FindMe")
+	RegisterServiceTree("FindMe", "f.Service", "1.0", root)
+
+	got := GetForestRoot("FindMe")
+	if got != root {
+		t.Errorf("GetForestRoot returned %p, want %p", got, root)
+	}
+}
+
+func TestGetForestRoot_NotFound(t *testing.T) {
+	if got := GetForestRoot("Ghost_xyz_999"); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+


### PR DESCRIPTION
## Summary
Adds hot-reload of VDM `.graphql` SDL files: the server watches the SDL directory (fsnotify) and rebuilds the HIM forest in place when files change, no restart needed (`server/vissv2server/vdmloader/watcher.go`). Includes a `himForestMu` fix that guards the forest slice against the concurrent read (serveRequest) / write (reload) that live-reload introduces.

VDM-specific, so on the `v4.0` line per the agreed split.

## Testing
`server/vissv2server/vdmloader/watcher_test.go`; `go build ./...`, `go vet`, `go test ./server/vissv2server/vdmloader/... ./server/vissv2server/` pass.

## Sequencing
Depends on the VDM loader — **stacks on #160**; merge #160 first. Diff reduces to the live-reload changes once #160 lands.