### PR TITLE
fix(service): route monitoring events by RouterId and harden RemoveInternalData

### DIFF
--- a/server/vissv2server/httpMgr/httpMgr.go
+++ b/server/vissv2server/httpMgr/httpMgr.go
@@ -21,6 +21,10 @@ var HttpClientChan = []chan string{
 
 func RemoveRoutingForwardResponse(response string, transportMgrChan chan string) {
 	trimmedResponse, clientId := utils.RemoveInternalData(response)
+	if clientId < 0 || clientId >= len(HttpClientChan) {
+		utils.Error.Printf("httpMgr:RemoveRoutingForwardResponse: invalid clientId=%d (response=%q); dropping", clientId, trimmedResponse)
+		return
+	}
 	HttpClientChan[clientId] <- trimmedResponse
 }
 

--- a/server/vissv2server/httpMgr/httpMgr_dispatch_test.go
+++ b/server/vissv2server/httpMgr/httpMgr_dispatch_test.go
@@ -198,3 +198,28 @@ func TestHandleHttpClientRequest_ValidRequestForwarded(t *testing.T) {
 	}
 	<-done
 }
+
+// TestHandleHttpTransportResponse_NoRouterIdDropped is the regression for the
+// server-wide panic reported against v3.2: a service "monitoring" event with
+// no RouterId reached RemoveInternalData (clientId -1) and used to index
+// HttpClientChan[-1]. The handler must now drop it without panicking and
+// without sending to any client channel.
+func TestHandleHttpTransportResponse_NoRouterIdDropped(t *testing.T) {
+	for len(HttpClientChan[0]) > 0 {
+		<-HttpClientChan[0]
+	}
+	transportMgrChan := make(chan string, 4)
+	resp := `{"action":"monitoring","path":"VehicleService.Seating.Row1.DriverSide.MoveSeat","serviceId":"769516","status":"ONGOING","ts":"2026-06-16T11:13:07Z"}`
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleHttpTransportResponse(resp, transportMgrChan) // must not panic
+	}()
+
+	select {
+	case <-done: // dropped cleanly
+	case forwarded := <-HttpClientChan[0]:
+		t.Fatalf("unroutable event should be dropped, not forwarded: %q", forwarded)
+	}
+}

--- a/server/vissv2server/vissServiceMgr/vissServiceMgr.go
+++ b/server/vissv2server/vissServiceMgr/vissServiceMgr.go
@@ -119,8 +119,9 @@ type monitorSession struct {
 	sessionId    string
 	serviceId    string // which invocation is being watched
 	path         string
-	isInvoke     bool // true = session owner invoked; false = monitor-only
-	routerIndex  int
+	isInvoke     bool   // true = session owner invoked; false = monitor-only
+	routerIndex  int    // transport-manager channel index (which transport)
+	routerId     string // originating "mgrId?clientId" (which client within it)
 	filterKind   string
 	filterPeriod time.Duration // >0 for timebased
 	lastEventAt  time.Time
@@ -224,6 +225,9 @@ func startTimebasedTicker(sess *monitorSession, period time.Duration,
 					"status":    string(inv.status),
 					"ts":        getTimestamp(),
 				}
+				if sess.routerId != "" {
+					event["RouterId"] = sess.routerId // address the event back to the requesting client
+				}
 				if inv.outdata != nil {
 					event["outdata"] = copyMap(inv.outdata)
 				}
@@ -296,6 +300,7 @@ func HandleInvoke(requestMap map[string]interface{}, backendChans []chan map[str
 			path:        path,
 			isInvoke:    true,
 			routerIndex: tDChanIndex,
+			routerId:    extractRouterId(requestMap),
 			filterKind:  filterVariant,
 		}
 		if filterVariant == "timebased" {
@@ -370,6 +375,7 @@ func HandleMonitor(requestMap map[string]interface{}, backendChans []chan map[st
 			path:        path,
 			isInvoke:    false,
 			routerIndex: tDChanIndex,
+			routerId:    extractRouterId(requestMap),
 			filterKind:  filterVariant,
 		}
 		if filterVariant == "timebased" {
@@ -629,6 +635,9 @@ func UpdateServiceState(serviceId string, status ServiceStatus,
 			"serviceId": t.sess.sessionId,
 			"status":    string(status),
 			"ts":        ts,
+		}
+		if t.sess.routerId != "" {
+			event["RouterId"] = t.sess.routerId // address the event back to the requesting client
 		}
 		if outdataWrapped != nil {
 			event["outdata"] = outdataWrapped
@@ -897,6 +906,19 @@ func extractRouterIndex(requestMap map[string]interface{}) int {
 		return v
 	}
 	return 0
+}
+
+// extractRouterId returns the originating "mgrId?clientId" RouterId string from
+// a request so that asynchronous monitoring events can be addressed back to the
+// requesting client. Without it the transport managers cannot recover a
+// clientId and (post-fix) drop the event. Returns "" when absent.
+func extractRouterId(requestMap map[string]interface{}) string {
+	for _, k := range []string{"RouterId", "routerId"} {
+		if v, ok := requestMap[k].(string); ok {
+			return v
+		}
+	}
+	return ""
 }
 
 func copyRouteFields(src, dst map[string]interface{}) {

--- a/server/vissv2server/vissServiceMgr/vissServiceMgr_e2e_test.go
+++ b/server/vissv2server/vissServiceMgr/vissServiceMgr_e2e_test.go
@@ -22,6 +22,7 @@ package vissServiceMgr
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/covesa/vissr/utils"
 )
@@ -155,6 +156,72 @@ func TestHandleInvoke_AppclientRequest_RoutesAndReturnsOngoing(t *testing.T) {
 		}
 	default:
 		t.Fatal("HandleInvoke produced no response")
+	}
+}
+
+// TestHandleInvoke_MonitoringEventCarriesRouterId is the regression for the
+// follow-up bug found after the path-resolution fix landed: the invoke
+// response routed fine (copyRouteFields), but the asynchronous "monitoring"
+// events emitted by the timebased ticker carried no RouterId. The transport
+// managers could not recover a clientId from them — wsMgr's RemoveInternalData
+// sliced response[-2:] and panicked the whole server. The monitoring session
+// must now remember the originating RouterId and stamp it onto every event.
+func TestHandleInvoke_MonitoringEventCarriesRouterId(t *testing.T) {
+	resetState()
+	loadVehicleServiceTree(t)
+	t.Cleanup(stopServiceGoroutines)
+
+	bc := make(chan map[string]interface{}, 16)
+	bcs := []chan map[string]interface{}{bc}
+
+	const routerId = "1?0"
+	req := map[string]interface{}{
+		"action": "invoke",
+		"path":   moveSeatPath,
+		"input": map[string]interface{}{
+			"MovementType": "longitudinal",
+			"Position":     "40",
+		},
+		"filter": map[string]interface{}{
+			"variant":   "timebased",
+			"parameter": map[string]interface{}{"period": "50"}, // fast ticker for the test
+		},
+		"requestId":   "8756",
+		"routerIndex": 0,
+		"RouterId":    routerId,
+	}
+
+	HandleInvoke(req, bcs)
+
+	// The synchronous invoke ACK must carry the RouterId (copyRouteFields).
+	select {
+	case resp := <-bc:
+		if resp["action"] != "invoke" {
+			t.Fatalf("first message action = %v, want invoke ACK", resp["action"])
+		}
+		if resp["RouterId"] != routerId {
+			t.Errorf("invoke ACK RouterId = %v, want %q", resp["RouterId"], routerId)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("HandleInvoke produced no invoke ACK")
+	}
+
+	// The asynchronous monitoring event(s) from the ticker must also carry it,
+	// otherwise the transport manager drops them (or, pre-fix, panicked).
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-bc:
+			if ev["action"] != "monitoring" {
+				continue
+			}
+			if ev["RouterId"] != routerId {
+				t.Fatalf("monitoring event RouterId = %v, want %q", ev["RouterId"], routerId)
+			}
+			return // success: routed monitoring event observed
+		case <-deadline:
+			t.Fatal("no monitoring event observed within 2s")
+		}
 	}
 }
 

--- a/server/vissv2server/wsMgr/wsMgr.go
+++ b/server/vissv2server/wsMgr/wsMgr.go
@@ -57,6 +57,10 @@ func initChannels() {
 }
 func RemoveRoutingForwardResponse(response string, transportMgrChan chan string) {
 	trimmedResponse, clientId := utils.RemoveInternalData(response)
+	if clientId < 0 || clientId >= NUMOFWSCLIENTS {
+		utils.Error.Printf("wsMgr:RemoveRoutingForwardResponse: invalid clientId=%d (response=%q); dropping", clientId, trimmedResponse)
+		return
+	}
 	if strings.Contains(trimmedResponse, "\"subscription\"") {
 		select {
 		case clientBackendChan[clientId] <- trimmedResponse: //subscription notification

--- a/server/vissv2server/wsMgr/wsMgr_dispatch_test.go
+++ b/server/vissv2server/wsMgr/wsMgr_dispatch_test.go
@@ -97,6 +97,29 @@ func TestHandleWsTransportResponse_ForwardsToClient(t *testing.T) {
 	<-done
 }
 
+// TestHandleWsTransportResponse_NoRouterIdDropped is the regression for the
+// server-wide panic reported against v3.2: a service "monitoring" event with
+// no RouterId reached RemoveInternalData, which sliced response[-2:] and
+// crashed. The handler must now drop it (clientId -1) without panicking and
+// without sending to any wsClientChan.
+func TestHandleWsTransportResponse_NoRouterIdDropped(t *testing.T) {
+	transportMgrChan := make(chan string, 4)
+	// Exact shape from the crash report's server log.
+	resp := `{"action":"monitoring","path":"VehicleService.Seating.Row1.DriverSide.MoveSeat","serviceId":"769516","status":"ONGOING","ts":"2026-06-16T11:13:07Z"}`
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleWsTransportResponse(resp, transportMgrChan) // must not panic
+	}()
+
+	select {
+	case <-done: // dropped cleanly
+	case forwarded := <-wsClientChan[0]:
+		t.Fatalf("unroutable event should be dropped, not forwarded: %q", forwarded)
+	}
+}
+
 // TestHandleWsTransportResponse_ErrorPassesThrough exercises the
 // short-circuit branch of checkCompressionResponse.
 func TestHandleWsTransportResponse_ErrorPassesThrough(t *testing.T) {

--- a/utils/managerhandlers.go
+++ b/utils/managerhandlers.go
@@ -584,12 +584,45 @@ func GetTLSConfig(host string, caCertFile string, certOpt tls.ClientAuthType, se
 	}
 }
 
+// RemoveInternalData strips the internal "RouterId":"mgrId?clientId" property
+// that AddRoutingForwardRequest prepends to a request, returning the cleaned
+// response together with the clientId used for transport-side routing.
+//
+// A response that carries no RouterId (e.g. a service "monitoring" event
+// emitted without one) used to panic here: strings.Index returned -1, making
+// routerIdStart == -2 and response[-2:] an out-of-range slice that crashed the
+// whole server. It now returns the response unchanged with clientId == -1 on
+// any malformed/missing RouterId, so callers can detect the missing route and
+// drop the message instead of crashing or misrouting it.
 func RemoveInternalData(response string) (string, int) { // "RouterId":"mgrId?clientId",
-	routerIdStart := strings.Index(response, "RouterId") - 1
-	clientIdStart := strings.Index(response[routerIdStart:], "?") + 1 + routerIdStart
+	routerIdKey := strings.Index(response, "RouterId")
+	if routerIdKey <= 0 { // must be preceded by at least the opening quote
+		return response, -1
+	}
+	routerIdStart := routerIdKey - 1
+	qMark := strings.Index(response[routerIdStart:], "?")
+	if qMark < 0 {
+		return response, -1
+	}
+	clientIdStart := qMark + 1 + routerIdStart
 	clientIdStop := NextQuoteMark([]byte(response), clientIdStart)
-	clientId, _ := strconv.Atoi(response[clientIdStart:clientIdStop])
-	routerIdStop := strings.Index(response[clientIdStop:], ",") + 1 + clientIdStop
+	if clientIdStop <= clientIdStart || clientIdStop > len(response) {
+		return response, -1 // no closing quote on the clientId
+	}
+	clientId, err := strconv.Atoi(response[clientIdStart:clientIdStop])
+	if err != nil {
+		return response, -1 // non-numeric clientId
+	}
+	// Remove the RouterId property. It is normally the first field and
+	// comma-terminated, but tolerate it being last (no trailing comma): the
+	// clientId is still valid, so we route rather than drop.
+	routerIdStop := clientIdStop + 1 // past the closing quote of the value
+	if comma := strings.Index(response[clientIdStop:], ","); comma >= 0 {
+		routerIdStop = comma + 1 + clientIdStop
+	}
+	if routerIdStop > len(response) {
+		routerIdStop = len(response)
+	}
 	trimmedResponse := response[:routerIdStart] + response[routerIdStop:]
 	//Info.Printf("response=%s, trimmedResponse=%s, clientId=%d", response, trimmedResponse, clientId)
 	return trimmedResponse, clientId

--- a/utils/managerhandlers_coverage_test.go
+++ b/utils/managerhandlers_coverage_test.go
@@ -47,6 +47,60 @@ func TestRemoveInternalData_ClientId0(t *testing.T) {
 	}
 }
 
+// A RouterId that is the last field (no trailing comma) is still valid: the
+// clientId must be returned and the property removed.
+func TestRemoveInternalData_RouterIdLastField(t *testing.T) {
+	response := `{"action":"get","path":"Vehicle.Speed","RouterId":"3?7"}`
+	trimmed, clientId := RemoveInternalData(response)
+	if clientId != 7 {
+		t.Errorf("clientId = %d; want 7", clientId)
+	}
+	if strings.Contains(trimmed, "RouterId") {
+		t.Errorf("RouterId not removed: %q", trimmed)
+	}
+}
+
+// Regression: a response that carries no RouterId must not panic. A service
+// "monitoring" event emitted without a RouterId used to make routerIdStart
+// == -2 and response[-2:] crash the whole server (reported against v3.2).
+// RemoveInternalData must now return the response unchanged with clientId -1
+// so the transport managers can drop it.
+func TestRemoveInternalData_NoRouterId_NoPanic(t *testing.T) {
+	// Exact shape from the crash report's server log.
+	response := `{"action":"monitoring","path":"VehicleService.Seating.Row1.DriverSide.MoveSeat","serviceId":"769516","status":"ONGOING","ts":"2026-06-16T11:13:07Z"}`
+	trimmed, clientId := RemoveInternalData(response)
+	if clientId != -1 {
+		t.Errorf("clientId = %d; want -1 for missing RouterId", clientId)
+	}
+	if trimmed != response {
+		t.Errorf("response should be returned unchanged when no RouterId; got %q", trimmed)
+	}
+}
+
+func TestRemoveInternalData_Malformed(t *testing.T) {
+	cases := []struct {
+		name     string
+		response string
+	}{
+		{"empty", ``},
+		{"routerId at index 0 (no opening quote)", `RouterId":"0?1","action":"get"}`},
+		{"no question mark", `{"RouterId":"01", "action":"get"}`},
+		{"no closing quote on clientId", `{"RouterId":"0?1, "action":"get"}`},
+		{"non-numeric clientId", `{"RouterId":"0?abc", "action":"get"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			trimmed, clientId := RemoveInternalData(tc.response)
+			if clientId != -1 {
+				t.Errorf("clientId = %d; want -1 for malformed input", clientId)
+			}
+			if trimmed != tc.response {
+				t.Errorf("malformed input should be returned unchanged; got %q", trimmed)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // createRouterIdProperty — internal helper
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Reported against v3.2 after the service path-resolution fix (#173) landed: a service `invoke` now routes correctly and returns `ONGOING`, but the first asynchronous `monitoring` event crashes the **entire server**:

```
panic: runtime error: slice bounds out of range [-2:]
github.com/covesa/vissr/utils.RemoveInternalData(...) utils/managerhandlers.go:589
github.com/covesa/vissr/server/vissv2server/wsMgr.RemoveRoutingForwardResponse(...) wsMgr.go:59
github.com/covesa/vissr/server/vissv2server/wsMgr.handleWsTransportResponse(...) wsMgr.go:404
```

The triggering message is the `monitoring` notification, e.g.
`{"action":"monitoring","path":"VehicleService.Seating.Row1.DriverSide.MoveSeat","serviceId":"769516","status":"ONGOING","ts":"..."}` — note it carries **no `RouterId`**.

## Root causes

**1. Monitoring events were emitted without a `RouterId`.**
The invoke ACK routes fine because `HandleInvoke` copies the request's `RouterId` onto the response via `copyRouteFields`. But the timebased-ticker event and the on-change fan-out event in `vissServiceMgr` were built as fresh maps with no `RouterId`. A `monitorSession` only stored `routerIndex` (which transport manager), never the `"mgrId?clientId"` (which client within it). The transport manager therefore could not recover a `clientId`.

**2. `RemoveInternalData` assumed a `RouterId` was always present.**
`strings.Index(response, "RouterId") - 1` yields `-2` when absent, and `response[-2:]` panics, taking down the server.

## Fix

- `monitorSession` now stores the originating `RouterId`, captured at both session-creation sites, and stamps it onto every monitoring event (ticker + fan-out).
- `RemoveInternalData` never panics: it returns the response unchanged with `clientId == -1` on any missing/malformed `RouterId`, and tolerates a `RouterId` that is the last field (no trailing comma — `clientId` is still valid, so it routes rather than drops).
- `wsMgr` and `httpMgr` gained the `clientId` bounds guard that `udsMgr` already had, so an unroutable message is dropped with a log line instead of indexing a channel slice with `-1`. (`mqttMgr`/`grpcMgr` lookups already tolerate `-1`.)

## Tests

- `utils`: `RemoveInternalData` with the exact crash payload (missing `RouterId`), other malformed shapes, and the `RouterId`-last-field case — all no-panic.
- `wsMgr`/`httpMgr`: a no-`RouterId` monitoring event is dropped (not forwarded, no panic).
- `vissServiceMgr` e2e: the appclient invoke (requestId 8756, `VehicleService.Seating.Row1.DriverSide.MoveSeat`) emits a monitoring event that carries the originating `RouterId`.

`go build ./...`, `go vet`, and `go test -race` pass across `utils`, `wsMgr`, `httpMgr`, `vissServiceMgr` (and the other `RemoveInternalData` consumers `udsMgr`/`grpcMgr`/`mqttMgr`).

Builds on #173 (merged).