### PR TITLE
fix(service): stop leaking internal routerIndex onto service responses

### DIFF
--- a/server/vissv2server/vissServiceMgr/vissServiceMgr.go
+++ b/server/vissv2server/vissServiceMgr/vissServiceMgr.go
@@ -908,6 +908,19 @@ func extractRouterIndex(requestMap map[string]interface{}) int {
 	return 0
 }
 
+// extractRouterId returns the originating "mgrId?clientId" RouterId string from
+// a request so that asynchronous monitoring events can be addressed back to the
+// requesting client. Without it the transport managers cannot recover a
+// clientId and (post-fix) drop the event. Returns "" when absent.
+func extractRouterId(requestMap map[string]interface{}) string {
+	for _, k := range []string{"RouterId", "routerId"} {
+		if v, ok := requestMap[k].(string); ok {
+			return v
+		}
+	}
+	return ""
+}
+
 // copyRouteFields copies the client-addressing RouterId from a request onto a
 // response so the transport manager can route it back and then strip it
 // (RemoveInternalData). It deliberately does NOT copy "routerIndex": that is a

--- a/server/vissv2server/vissServiceMgr/vissServiceMgr.go
+++ b/server/vissv2server/vissServiceMgr/vissServiceMgr.go
@@ -899,8 +899,15 @@ func extractRouterIndex(requestMap map[string]interface{}) int {
 	return 0
 }
 
+// copyRouteFields copies the client-addressing RouterId from a request onto a
+// response so the transport manager can route it back and then strip it
+// (RemoveInternalData). It deliberately does NOT copy "routerIndex": that is a
+// server-internal transport-channel index injected by serveRequest and read
+// only from the request (extractRouterIndex). Copying it onto the response
+// leaked it to clients, who would receive e.g. "routerIndex":1 in an invoke
+// reply. No transport manager strips routerIndex, so it must never be added.
 func copyRouteFields(src, dst map[string]interface{}) {
-	for _, k := range []string{"RouterId", "routerId", "routerIndex"} {
+	for _, k := range []string{"RouterId", "routerId"} {
 		if v, ok := src[k]; ok {
 			dst[k] = v
 		}

--- a/server/vissv2server/vissServiceMgr/vissServiceMgr_test.go
+++ b/server/vissv2server/vissServiceMgr/vissServiceMgr_test.go
@@ -196,17 +196,57 @@ func TestCopyMap_Independent(t *testing.T) {
 // ---- copyRouteFields -------------------------------------------------------
 
 func TestCopyRouteFields(t *testing.T) {
-	src := map[string]interface{}{"RouterId": "1?x", "routerIndex": 3, "other": "skip"}
+	src := map[string]interface{}{"RouterId": "1?x", "routerId": "9?9", "routerIndex": 3, "other": "skip"}
 	dst := map[string]interface{}{}
 	copyRouteFields(src, dst)
 	if dst["RouterId"] != "1?x" {
 		t.Error("RouterId not copied")
 	}
-	if dst["routerIndex"] != 3 {
-		t.Error("routerIndex not copied")
+	if dst["routerId"] != "9?9" {
+		t.Error("routerId not copied")
+	}
+	// routerIndex is a server-internal channel index and must NOT be copied
+	// onto a response — it would leak to the client (e.g. "routerIndex":1 in
+	// an invoke reply).
+	if _, ok := dst["routerIndex"]; ok {
+		t.Error("routerIndex leaked onto response — must not be copied")
 	}
 	if _, ok := dst["other"]; ok {
 		t.Error("unexpected key copied")
+	}
+}
+
+// TestHandleInvoke_ResponseHasNoRouterIndex is the regression for the leak:
+// an invoke reply forwarded to the client must not carry the internal
+// routerIndex field.
+func TestHandleInvoke_ResponseHasNoRouterIndex(t *testing.T) {
+	resetState()
+	loadVehicleServiceTree(t)
+	t.Cleanup(stopServiceGoroutines)
+
+	bc := make(chan map[string]interface{}, 8)
+	bcs := []chan map[string]interface{}{bc}
+	req := map[string]interface{}{
+		"action":      "invoke",
+		"path":        moveSeatPath,
+		"input":       map[string]interface{}{"MovementType": "longitudinal", "Position": "40"},
+		"requestId":   "8756",
+		"routerIndex": 0,
+		"RouterId":    "1?0",
+	}
+
+	HandleInvoke(req, bcs)
+
+	select {
+	case resp := <-bc:
+		if _, ok := resp["routerIndex"]; ok {
+			t.Errorf("invoke response leaked internal routerIndex: %v", resp)
+		}
+		if resp["RouterId"] != "1?0" {
+			t.Errorf("RouterId missing from response: %v", resp["RouterId"])
+		}
+	default:
+		t.Fatal("HandleInvoke produced no response")
 	}
 }
 


### PR DESCRIPTION
## Problem

A service `invoke`/`monitor`/`discover` reply forwarded to the client carries a server-internal field:

```json
{"action":"invoke","path":"VehicleService.Seating.Row1.DriverSide.MoveSeat","requestId":"8756","routerIndex":1,"serviceId":"769303","status":"ONGOING","ts":"2026-06-16T07:31:34Z"}
```

`routerIndex` is the transport-channel index injected by `serveRequest` (`requestMap["routerIndex"] = tDChanIndex`) purely for internal dispatch. `copyRouteFields` copied it onto the response alongside `RouterId` — but unlike `RouterId`, no transport manager strips it (`RemoveInternalData` removes only `RouterId`), so it leaked to clients.

Nothing reads `routerIndex` from a response: `extractRouterIndex` only ever reads it from the *request*. So it has no value on the wire.

## Fix

`copyRouteFields` no longer copies `"routerIndex"` — only the client-addressing `RouterId`/`routerId`, which the transport manager subsequently strips. The internal `routerIndex` is therefore never placed on a response in the first place (root-cause fix rather than adding another strip step).

## Tests

- `TestCopyRouteFields` updated to assert `routerIndex` is **not** propagated (and that `routerId` is).
- New `TestHandleInvoke_ResponseHasNoRouterIndex`: the invoke reply contains no `routerIndex` and still carries the `RouterId`.

`go build ./...`, `go vet`, `go test -race ./server/vissv2server/vissServiceMgr/` all pass.

Reported by @UlfBj. Independent of #181 (RouterId routing/crash) — separate concern, both off `v3.2`.