### PR TITLE
fix(core): split transport hub channel into request/response directions

### DIFF
--- a/server/vissv2server/README.md
+++ b/server/vissv2server/README.md
@@ -47,6 +47,7 @@ The core server hub, running in the main context, spawns the following Go routin
 - The service manager registration server.<br>
 - Service data channel servers, each having separate frontend and a backend go routines.<br>
 The Go routines communicate in between using Go channels.<br>
+Each transport data channel server uses a **pair of unidirectional channels** with its transport manager: one carries client requests inward (transport manager &rarr; core) and a separate one carries responses and subscription/monitoring events outward (core &rarr; transport manager). The two directions must not share a single channel: with a shared channel a goroutine can read back its own just-written message before the peer goroutine takes it, which re-injects high-frequency monitoring events into the request path. Keeping the directions on separate channels means every channel has exactly one sender and one receiver.<br>
 The communication with the transport protocol and service managers is realized using the Websocket protocol.<br>
 ![Core server design](../pics/Core_server_SwA.jpg)<br>
 * Fig. 1 Core server design<br><br>

--- a/server/vissv2server/grpcMgr/grpcMgr.go
+++ b/server/vissv2server/grpcMgr/grpcMgr.go
@@ -379,10 +379,13 @@ func handleGrpcNewClientSession(reqMessage GrpcRequestMessage, mgrId int, transp
 	reqMessage.GrpcRespChan <- `{"action": "get","requestId": "9999","error": {"number": "404", "reason": "max_client_sessions", "description": "Max no of gRPC client sessions reached."},"ts": "2000-01-01T13:37:00Z"}` // requestId and ts values incorrect
 }
 
-func GrpcMgrInit(mgrId int, transportMgrChan chan string) {
+// GrpcMgrInit runs the gRPC transport hub. reqChan carries client requests to
+// the server core; respChan carries responses back from the core. They are
+// separate channels so a response can never be read back here as a request.
+func GrpcMgrInit(mgrId int, reqChan chan string, respChan chan string) {
 	utils.ReadTransportSecConfig()
 	grpcMgrId = mgrId
-	grpcMgrChan = transportMgrChan
+	grpcMgrChan = reqChan // request side: used by the subscription-kill forward
 	grpcClientIndexList = make([]bool, MAXGRPCCLIENTS)
 	grpcRoutingDataList = make([]GrpcRoutingData, MAXGRPCCLIENTS)
 	grpcCompression = utils.PROTOBUF // set via viss2server command line param?
@@ -393,10 +396,10 @@ func GrpcMgrInit(mgrId int, transportMgrChan chan string) {
 
 	for {
 		select {
-		case respMessage := <-transportMgrChan:
+		case respMessage := <-respChan:
 			handleGrpcTransportResponse(respMessage)
 		case reqMessage := <-grpcClientChan[0]:
-			handleGrpcNewClientSession(reqMessage, mgrId, transportMgrChan)
+			handleGrpcNewClientSession(reqMessage, mgrId, reqChan)
 		}
 	}
 }

--- a/server/vissv2server/httpMgr/httpMgr.go
+++ b/server/vissv2server/httpMgr/httpMgr.go
@@ -57,7 +57,10 @@ func handleHttpTransportResponse(respMessage string, transportMgrChan chan strin
 	RemoveRoutingForwardResponse(respMessage, transportMgrChan)
 }
 
-func HttpMgrInit(mgrId int, transportMgrChan chan string) {
+// HttpMgrInit runs the HTTP transport hub. reqChan carries client requests
+// to the server core; respChan carries responses back from the core. They are
+// separate channels so a response can never be read back here as a request.
+func HttpMgrInit(mgrId int, reqChan chan string, respChan chan string) {
 	utils.ReadTransportSecConfig()
 	utils.JsonSchemaInit()
 
@@ -68,9 +71,9 @@ func HttpMgrInit(mgrId int, transportMgrChan chan string) {
 	for {
 		select {
 		case reqMessage := <-HttpClientChan[0]:
-			handleHttpClientRequest(reqMessage, mgrId, transportMgrChan)
-		case respMessage := <-transportMgrChan:
-			handleHttpTransportResponse(respMessage, transportMgrChan)
+			handleHttpClientRequest(reqMessage, mgrId, reqChan)
+		case respMessage := <-respChan:
+			handleHttpTransportResponse(respMessage, respChan)
 		}
 	}
 }

--- a/server/vissv2server/mqttMgr/mqttMgr.go
+++ b/server/vissv2server/mqttMgr/mqttMgr.go
@@ -216,7 +216,7 @@ func getVissV2TopicFromEnv() string {
 	return "/" + vin + "/Vehicle"
 }
 
-func getVissV2Topic(transportMgrChan chan string, mgrId int) string {
+func getVissV2Topic(reqChan chan string, respChan chan string, mgrId int) string {
 	// Fast path: MQTT_VIN env var bypasses the channel round-trip (useful for
 	// local development where state storage has no VIN populated yet).
 	if topic := getVissV2TopicFromEnv(); topic != "" {
@@ -224,16 +224,14 @@ func getVissV2Topic(transportMgrChan chan string, mgrId int) string {
 	}
 
 	vinRequest := "{\"RouterId\":\"" + strconv.Itoa(mgrId) + `?0", "action":"get", "path":"Vehicle.VehicleIdentification.VIN", "requestId":"570415", "origin":"internal"}`
-	transportMgrChan <- vinRequest
+	reqChan <- vinRequest
 
-	// transportMgrChan is bidirectional (requests go server-ward, responses
-	// come back on the same channel via transportDataSession). We rely on the
-	// channel being unbuffered: if it were buffered our own send would sit in
-	// the buffer and we'd echo-read it before transportDataSession consumes it.
-	// vissv2server.initChannels explicitly keeps transportMgrChannel[2] unbuffered
-	// for exactly this reason.
+	// The VIN request goes server-ward on reqChan; the response comes back on
+	// respChan. Because the two directions are distinct channels there is no
+	// echo risk (the send can never be read back here), so reqChan/respChan may
+	// be buffered like every other transport.
 	select {
-	case response := <-transportMgrChan:
+	case response := <-respChan:
 		vin := extractVin(string(response))
 		utils.Info.Printf("VIN=%s", vin)
 		if !isValidVin(vin) {
@@ -311,14 +309,17 @@ func AddRoutingInfoAndForward(reqMessage string, mgrId int, clientId int, transp
 	transportMgrChan <- request
 }
 
-func MqttMgrInit(mgrId int, transportMgrChan chan string) {
+// MqttMgrInit runs the MQTT transport hub. reqChan carries client requests to
+// the server core; respChan carries responses back from the core. They are
+// separate channels so a response can never be read back here as a request.
+func MqttMgrInit(mgrId int, reqChan chan string, respChan chan string) {
 	mqttChannel = make(chan string)
 	vissv2Channel := make(chan string)
 
 	brokerSocket := getBrokerSocket(false)
 	// wait for 2 seconds to allow the server and feeder to start
 	time.Sleep(2 * time.Second)
-	topic := getVissV2Topic(transportMgrChan, mgrId)
+	topic := getVissV2Topic(reqChan, respChan, mgrId)
 	if topic == "" {
 		// Refused by isValidVin in getVissV2Topic — don't even try.
 		utils.Error.Printf("MqttMgrInit: refusing to start; could not derive a valid VISS v2 topic")
@@ -334,7 +335,7 @@ func MqttMgrInit(mgrId int, transportMgrChan chan string) {
 
 	utils.JsonSchemaInit()
 
-	go vissV2Receiver(transportMgrChan, vissv2Channel) //message reception from server core
+	go vissV2Receiver(respChan, vissv2Channel) //message reception from server core
 
 	utils.Info.Println("**** MQTT manager hub entering server loop... ****")
 
@@ -370,7 +371,7 @@ func MqttMgrInit(mgrId int, transportMgrChan chan string) {
 				continue
 			}
 			pushTopic(topic, topicId)
-			AddRoutingInfoAndForward(payload, mgrId, topicId, transportMgrChan)
+			AddRoutingInfoAndForward(payload, mgrId, topicId, reqChan)
 			topicId++
 
 		case vissv2Message := <-vissv2Channel:

--- a/server/vissv2server/mqttMgr/mqttMgr_test.go
+++ b/server/vissv2server/mqttMgr/mqttMgr_test.go
@@ -418,9 +418,9 @@ func TestGetVissV2Topic_EnvVarFastPath(t *testing.T) {
 	os.Setenv("MQTT_VIN", "TESTVIN123")
 	defer os.Unsetenv("MQTT_VIN")
 
-	// We pass a nil channel: if the code tried to use the channel it
-	// would panic — so this also proves the fast path is taken.
-	got := getVissV2Topic(nil, 0)
+	// We pass nil channels: if the code tried to use them it would
+	// panic — so this also proves the fast path is taken.
+	got := getVissV2Topic(nil, nil, 0)
 	want := "/TESTVIN123/Vehicle"
 	if got != want {
 		t.Fatalf("getVissV2Topic with MQTT_VIN = %q; want %q", got, want)
@@ -428,22 +428,24 @@ func TestGetVissV2Topic_EnvVarFastPath(t *testing.T) {
 }
 
 // TestGetVissV2Topic_ChannelPath: with no MQTT_VIN env var set,
-// getVissV2Topic sends the VIN request on the channel and waits for
-// a response. We simulate the server core with a goroutine.
+// getVissV2Topic sends the VIN request on reqChan and waits for a response
+// on respChan. We simulate the server core with a goroutine. Note the request
+// and response now travel on separate channels — no shared-channel echo risk,
+// so the channels may be buffered.
 func TestGetVissV2Topic_ChannelPath(t *testing.T) {
 	os.Unsetenv("MQTT_VIN")
 
-	// Use an unbuffered channel to match the production constraint.
-	ch := make(chan string)
+	reqChan := make(chan string, 1)
+	respChan := make(chan string, 1)
 	vinResp := `{"action":"get","data":{"dp":{"value":"WVWZZZ1JZ3W386752","ts":"2026-01-01T00:00:00Z"}}}`
 
 	// Simulate the server core: consume the VIN request and reply.
 	go func() {
-		<-ch       // consume the VIN request sent by getVissV2Topic
-		ch <- vinResp // send the VIN response
+		<-reqChan          // consume the VIN request sent by getVissV2Topic
+		respChan <- vinResp // send the VIN response
 	}()
 
-	got := getVissV2Topic(ch, 2)
+	got := getVissV2Topic(reqChan, respChan, 2)
 	want := "/WVWZZZ1JZ3W386752/Vehicle"
 	if got != want {
 		t.Fatalf("getVissV2Topic channel path = %q; want %q", got, want)
@@ -455,16 +457,17 @@ func TestGetVissV2Topic_ChannelPath(t *testing.T) {
 func TestGetVissV2Topic_ChannelPathInvalidVin(t *testing.T) {
 	os.Unsetenv("MQTT_VIN")
 
-	ch := make(chan string)
+	reqChan := make(chan string, 1)
+	respChan := make(chan string, 1)
 	// Response with a VIN containing MQTT wildcards — should be rejected.
 	badVinResp := `{"action":"get","data":{"dp":{"value":"+bad#vin","ts":"2026-01-01T00:00:00Z"}}}`
 
 	go func() {
-		<-ch
-		ch <- badVinResp
+		<-reqChan
+		respChan <- badVinResp
 	}()
 
-	got := getVissV2Topic(ch, 2)
+	got := getVissV2Topic(reqChan, respChan, 2)
 	if got != "" {
 		t.Fatalf("getVissV2Topic with invalid VIN = %q; want \"\"", got)
 	}
@@ -651,15 +654,16 @@ func TestGetVissV2Topic_TimeoutPath(t *testing.T) {
 	t.Parallel()
 	os.Unsetenv("MQTT_VIN")
 
-	ch := make(chan string) // unbuffered, matches production constraint
+	reqChan := make(chan string, 1)
+	respChan := make(chan string, 1)
 
-	// Consume the outgoing VIN request but never reply.
+	// Consume the outgoing VIN request but never reply on respChan.
 	go func() {
-		<-ch // drain the send; never send back
+		<-reqChan // drain the send; never send back
 	}()
 
 	start := time.Now()
-	got := getVissV2Topic(ch, 99)
+	got := getVissV2Topic(reqChan, respChan, 99)
 	elapsed := time.Since(start)
 
 	if got != "" {

--- a/server/vissv2server/udsMgr/udsMgr.go
+++ b/server/vissv2server/udsMgr/udsMgr.go
@@ -636,7 +636,11 @@ func isKillSubscriptions(reqMessage string) bool {
 	return action == "internal-killsubscriptions"
 }
 
-func UdsMgrInit(mgrId int, transportMgrChan chan string) {
+// UdsMgrInit runs the Unix-domain-socket transport hub. reqChan carries client
+// requests to the server core; respChan carries responses back from the core.
+// They are separate channels so a response can never be read back here as a
+// request.
+func UdsMgrInit(mgrId int, reqChan chan string, respChan chan string) {
 	var reqMessage string
 	var clientId int
 	utils.ReadTransportSecConfig()
@@ -648,8 +652,8 @@ func UdsMgrInit(mgrId int, transportMgrChan chan string) {
 
 	for {
 		select {
-		case respMessage := <-transportMgrChan:
-			handleUdsTransportResponse(respMessage, transportMgrChan)
+		case respMessage := <-respChan:
+			handleUdsTransportResponse(respMessage, respChan)
 			continue
 		// NOTE: the case list below is hand-coupled to NUMOFUDSCLIENTS. If
 		// NUMOFUDSCLIENTS changes, this select must change to match - extend
@@ -695,7 +699,7 @@ func UdsMgrInit(mgrId int, transportMgrChan chan string) {
 		case reqMessage = <-udsClientChan[19]:
 			clientId = 19
 		}
-		handleUdsClientRequest(reqMessage, mgrId, clientId, transportMgrChan)
+		handleUdsClientRequest(reqMessage, mgrId, clientId, reqChan)
 	}
 }
 

--- a/server/vissv2server/vissv2server.go
+++ b/server/vissv2server/vissv2server.go
@@ -68,7 +68,8 @@ var serverComponents []string = []string{
  * If support for new transport protocol is added, add element to channel
  */
  const NUMOFTRANSPORTMGRS = 5  // order assigned to channels: HTTP, WS, MQTT, gRPC, UDS
-var transportMgrChannel []chan string
+var transportMgrChannel []chan string // requests, transport mgr -> core (read by transportDataSession)
+var toTransportChannel []chan string   // responses, core -> transport mgr (written by transportDataSession)
 var transportDataChan []chan map[string]interface{}
 var backendChan []chan map[string]interface{}
 
@@ -122,11 +123,25 @@ func serviceDataSession(serviceMgrChannel chan map[string]interface{}, serviceDa
 	}
 }
 
-func transportDataSession(transportMgrChannel chan string, transportDataChannel chan map[string]interface{}, backendChannel chan map[string]interface{}) {
+// transportDataSession bridges one transport manager and the server core.
+// reqChan carries inbound client requests (transport mgr -> core) and is read
+// here; respChan carries outbound responses/events (core -> transport mgr) and
+// is written here. The two directions MUST be separate channels.
+//
+// Previously a single channel was shared bidirectionally. Because that channel
+// was buffered, after this goroutine wrote a response it could read it straight
+// back from its own select (an echo/loopback) before the transport manager's
+// goroutine took it. The looped-back message was then treated as a fresh
+// inbound request: high-frequency service "monitoring" events were re-injected
+// into serveRequest, running a binary-tree search on every event and never
+// reaching the client. Two unidirectional channels remove the ambiguity — each
+// has exactly one sender and one receiver, so a message can only ever flow the
+// intended way.
+func transportDataSession(reqChan chan string, respChan chan string, transportDataChannel chan map[string]interface{}, backendChannel chan map[string]interface{}) {
 	for {
 		select {
 
-		case msg := <-transportMgrChannel:
+		case msg := <-reqChan:
 			var msgMap map[string]interface{}
 			utils.MapRequest(msg, &msgMap)
 			// Bug fix: previously unconditional send could wedge the per-transport
@@ -139,7 +154,7 @@ func transportDataSession(transportMgrChannel chan string, transportDataChannel 
 			}
 		case message := <-backendChannel:
 			select {
-			case transportMgrChannel <- utils.FinalizeMessage(message):
+			case respChan <- utils.FinalizeMessage(message):
 			default:
 				utils.Error.Printf("server hub: Event dropped")
 			}
@@ -1035,19 +1050,19 @@ func initChannels() {
 	serviceDataChan = make([]chan map[string]interface{}, 1)
 	serviceDataChan[0] = make(chan map[string]interface{}, pipelineBuf)
 	transportMgrChannel = make([]chan string, NUMOFTRANSPORTMGRS)
+	toTransportChannel = make([]chan string, NUMOFTRANSPORTMGRS)
 	transportDataChan = make([]chan map[string]interface{}, NUMOFTRANSPORTMGRS)
 	backendChan = make([]chan map[string]interface{}, NUMOFTRANSPORTMGRS)
 	for i := 0; i < NUMOFTRANSPORTMGRS; i++ {
-		transportMgrChannel[i] = make(chan string, pipelineBuf)
+		transportMgrChannel[i] = make(chan string, pipelineBuf) // requests: transport mgr -> core
+		toTransportChannel[i] = make(chan string, pipelineBuf)  // responses: core -> transport mgr
 		transportDataChan[i] = make(chan map[string]interface{}, pipelineBuf)
 		backendChan[i] = make(chan map[string]interface{}, pipelineBuf)
 	}
-	// MQTT's channel must stay unbuffered. MqttMgrInit performs a synchronous
-	// VIN-fetch by sending on and receiving from the same channel in one
-	// goroutine. A buffered channel causes an echo: the goroutine reads its own
-	// send before transportDataSession can consume it. Unbuffered forces the
-	// send to block until transportDataSession reads, preserving ordering.
-	transportMgrChannel[2] = make(chan string)
+	// Note: with the request and response directions on separate channels,
+	// buffering is safe for every transport (each channel has a single sender
+	// and a single receiver). The old MQTT "must stay unbuffered to avoid an
+	// echo on the shared channel" special case is no longer needed.
 	atsChannel = make([]chan string, 2)
 	atsChannel[0] = make(chan string) // access token verification (serialized by atsChannelMu)
 	atsChannel[1] = make(chan string) // token cancellation
@@ -1130,24 +1145,24 @@ func main() {
 	for _, serverComponent := range serverComponents {
 		switch serverComponent {
 		case "httpMgr":
-			go httpMgr.HttpMgrInit(0, transportMgrChannel[0])
-			go transportDataSession(transportMgrChannel[0], transportDataChan[0], backendChan[0])
+			go httpMgr.HttpMgrInit(0, transportMgrChannel[0], toTransportChannel[0])
+			go transportDataSession(transportMgrChannel[0], toTransportChannel[0], transportDataChan[0], backendChan[0])
 		case "wsMgr":
-			go wsMgr.WsMgrInit(1, transportMgrChannel[1])
-			go transportDataSession(transportMgrChannel[1], transportDataChan[1], backendChan[1])
+			go wsMgr.WsMgrInit(1, transportMgrChannel[1], toTransportChannel[1])
+			go transportDataSession(transportMgrChannel[1], toTransportChannel[1], transportDataChan[1], backendChan[1])
 		case "wsMgrFT":
 			go wsMgrFT.WsMgrFTInit(ftChannel)
 		case "mqttMgr":
 			if *mqttEnable {
-				go mqttMgr.MqttMgrInit(2, transportMgrChannel[2])
-				go transportDataSession(transportMgrChannel[2], transportDataChan[2], backendChan[2])
+				go mqttMgr.MqttMgrInit(2, transportMgrChannel[2], toTransportChannel[2])
+				go transportDataSession(transportMgrChannel[2], toTransportChannel[2], transportDataChan[2], backendChan[2])
 			}
 		case "grpcMgr":
-			go grpcMgr.GrpcMgrInit(3, transportMgrChannel[3])
-			go transportDataSession(transportMgrChannel[3], transportDataChan[3], backendChan[3])
+			go grpcMgr.GrpcMgrInit(3, transportMgrChannel[3], toTransportChannel[3])
+			go transportDataSession(transportMgrChannel[3], toTransportChannel[3], transportDataChan[3], backendChan[3])
 		case "udsMgr":
-			go udsMgr.UdsMgrInit(4, transportMgrChannel[4])
-			go transportDataSession(transportMgrChannel[4], transportDataChan[4], backendChan[4])
+			go udsMgr.UdsMgrInit(4, transportMgrChannel[4], toTransportChannel[4])
+			go transportDataSession(transportMgrChannel[4], toTransportChannel[4], transportDataChan[4], backendChan[4])
 		case "serviceMgr":
 			go serviceMgr.ServiceMgrInit(0, serviceMgrChannel[0], *stateDB, *historySupport, *dbFile)
 			go serviceDataSession(serviceMgrChannel[0], serviceDataChan[0], backendChan)

--- a/server/vissv2server/vissv2server_coverage_test.go
+++ b/server/vissv2server/vissv2server_coverage_test.go
@@ -279,26 +279,86 @@ func TestServiceDataSession_ForwardsRequestUpstream(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // The existing test (TestTransportDataSession_DropsOnFullDispatcher) covers
-// the transportMgrChannel → transportDataChannel direction. This test covers
-// the backendChan → transportMgrChannel direction.
+// the reqChan → transportDataChannel direction. This test covers the
+// backendChan → respChan direction, and also asserts the response does NOT
+// leak onto reqChan (the loopback that misrouted monitoring events).
 func TestTransportDataSession_BackendToTransport(t *testing.T) {
-	mgrChan := make(chan string, 2)
+	reqChan := make(chan string, 2)
+	respChan := make(chan string, 2)
 	dataChan := make(chan map[string]interface{}, 2)
 	beChan := make(chan map[string]interface{}, 2)
 
-	go transportDataSession(mgrChan, dataChan, beChan)
+	go transportDataSession(reqChan, respChan, dataChan, beChan)
 
 	// Push a response from the backend
 	beChan <- map[string]interface{}{"action": "get", "path": "Vehicle.Speed"}
 
 	select {
-	case got := <-mgrChan:
+	case got := <-respChan:
 		// Should be a JSON string (from FinalizeMessage)
 		if got == "" {
 			t.Errorf("expected non-empty JSON from FinalizeMessage; got empty")
 		}
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timeout — backend response not forwarded to transportMgrChannel")
+		t.Fatal("timeout — backend response not forwarded to respChan")
+	}
+
+	// The response must never appear on the request channel: that loopback was
+	// the root cause of monitoring events being re-run through serveRequest.
+	select {
+	case leaked := <-reqChan:
+		t.Fatalf("response looped back onto request channel: %q", leaked)
+	default:
+	}
+}
+
+// TestTransportDataSession_MonitoringStreamNoLoopback reproduces the failure
+// Ulf reported: a service "monitoring" event stream (one every ~250ms) was
+// being re-injected into the request pipeline (serveRequest), which ran a
+// binary-tree search ("Matches=2") on every event and never delivered them to
+// the client. With request and response on separate channels, every event must
+// arrive on respChan and none may ever reach transportDataChannel (the request
+// side feeding serveRequest).
+func TestTransportDataSession_MonitoringStreamNoLoopback(t *testing.T) {
+	const events = 50
+	reqChan := make(chan string, events)
+	respChan := make(chan string, events)
+	// transportDataChannel is what feeds serveRequest. A looped-back event
+	// would land here; it must stay empty for the whole run.
+	dataChan := make(chan map[string]interface{}, events)
+	beChan := make(chan map[string]interface{}, events)
+
+	go transportDataSession(reqChan, respChan, dataChan, beChan)
+
+	for i := 0; i < events; i++ {
+		beChan <- map[string]interface{}{
+			"action":    "monitoring",
+			"path":      "VehicleService.Seating.Row1.DriverSide.MoveSeat",
+			"serviceId": "659839",
+			"status":    "ONGOING",
+		}
+	}
+
+	deadline := time.After(2 * time.Second)
+	for got := 0; got < events; {
+		select {
+		case msg := <-respChan:
+			if msg == "" {
+				t.Fatalf("empty event on respChan")
+			}
+			got++
+		case leaked := <-dataChan:
+			t.Fatalf("monitoring event looped back into request pipeline: %+v", leaked)
+		case <-deadline:
+			t.Fatalf("only %d/%d monitoring events reached the transport before timeout", got, events)
+		}
+	}
+
+	// Nothing should have leaked into the request pipeline.
+	select {
+	case leaked := <-dataChan:
+		t.Fatalf("monitoring event looped back into request pipeline: %+v", leaked)
+	default:
 	}
 }
 
@@ -331,25 +391,26 @@ func TestCalculateHash_ReadError(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestTransportDataSession_DropsWhenTransportMgrFull(t *testing.T) {
-	// Use a 0-capacity (unbuffered) mgrChan with no reader so sends are
+	// Use a 0-capacity (unbuffered) respChan with no reader so sends are
 	// immediately non-blocking-and-dropped, exercising the default branch.
-	mgrChan := make(chan string) // unbuffered — sends will drop
+	reqChan := make(chan string, 4)
+	respChan := make(chan string) // unbuffered — sends will drop
 	dataChan := make(chan map[string]interface{}, 4)
 	beChan := make(chan map[string]interface{}, 4)
 
-	go transportDataSession(mgrChan, dataChan, beChan)
+	go transportDataSession(reqChan, respChan, dataChan, beChan)
 
-	// Push a backend response: the session tries to send on mgrChan (unbuffered),
+	// Push a backend response: the session tries to send on respChan (unbuffered),
 	// which has no reader → hits the default/drop branch.
 	beChan <- map[string]interface{}{"action": "get"}
 
 	// Give the goroutine time to process and drop.
 	time.Sleep(50 * time.Millisecond)
 
-	// mgrChan should be empty (drop path taken).
+	// respChan should be empty (drop path taken).
 	select {
-	case <-mgrChan:
-		t.Error("expected drop but got delivery on unbuffered mgrChan")
+	case <-respChan:
+		t.Error("expected drop but got delivery on unbuffered respChan")
 	default:
 		// Good — was dropped
 	}

--- a/server/vissv2server/vissv2server_test.go
+++ b/server/vissv2server/vissv2server_test.go
@@ -347,18 +347,16 @@ func TestInitChannels_BuffersPipeline(t *testing.T) {
 		t.Errorf("serviceDataChan[0] should be buffered")
 	}
 	for i := 0; i < NUMOFTRANSPORTMGRS; i++ {
-		// MQTT (index 2) is intentionally unbuffered: MqttMgrInit performs a
-		// synchronous VIN-fetch handshake in one goroutine. A buffered channel
-		// causes the goroutine to echo-read its own send before
-		// transportDataSession can consume it.
-		if i == 2 {
-			if cap(transportMgrChannel[i]) != 0 {
-				t.Errorf("transportMgrChannel[%d] (MQTT) should be unbuffered", i)
-			}
-		} else {
-			if cap(transportMgrChannel[i]) == 0 {
-				t.Errorf("transportMgrChannel[%d] should be buffered", i)
-			}
+		// Every transport channel is buffered, including MQTT (index 2). The
+		// request and response directions now have separate channels
+		// (transportMgrChannel = requests, toTransportChannel = responses), each
+		// with a single sender and single receiver, so the old shared-channel
+		// echo hazard that forced MQTT to stay unbuffered no longer exists.
+		if cap(transportMgrChannel[i]) == 0 {
+			t.Errorf("transportMgrChannel[%d] should be buffered", i)
+		}
+		if cap(toTransportChannel[i]) == 0 {
+			t.Errorf("toTransportChannel[%d] should be buffered", i)
 		}
 		if cap(transportDataChan[i]) == 0 {
 			t.Errorf("transportDataChan[%d] should be buffered", i)
@@ -421,18 +419,19 @@ func TestServiceDataSession_BadRouterIdIsSafe(t *testing.T) {
 // --------------------------------------------------------------------------
 
 func TestTransportDataSession_DropsOnFullDispatcher(t *testing.T) {
-	mgrChan := make(chan string, 1)
+	reqChan := make(chan string, 1)
+	respChan := make(chan string, 1)
 	dataChan := make(chan map[string]interface{}, 1)
 	beChan := make(chan map[string]interface{}, 1)
 
-	go transportDataSession(mgrChan, dataChan, beChan)
+	go transportDataSession(reqChan, respChan, dataChan, beChan)
 
 	// Fill the data channel first
 	dataChan <- map[string]interface{}{"filler": true}
 
 	// Now push two requests — second should be dropped, not block.
-	mgrChan <- `{"action":"get","path":"X"}`
-	mgrChan <- `{"action":"get","path":"Y"}`
+	reqChan <- `{"action":"get","path":"X"}`
+	reqChan <- `{"action":"get","path":"Y"}`
 
 	done := make(chan struct{})
 	go func() {

--- a/server/vissv2server/wsMgr/wsMgr.go
+++ b/server/vissv2server/wsMgr/wsMgr.go
@@ -428,7 +428,10 @@ func handleWsClientRequest(reqMessage string, mgrId int, clientId int, transport
 	utils.AddRoutingForwardRequest(reqMessage, mgrId, clientId, transportMgrChan)
 }
 
-func WsMgrInit(mgrId int, transportMgrChan chan string) {
+// WsMgrInit runs the WebSocket transport hub. reqChan carries client requests
+// to the server core; respChan carries responses back from the core. They are
+// separate channels so a response can never be read back here as a request.
+func WsMgrInit(mgrId int, reqChan chan string, respChan chan string) {
 	var reqMessage string
 	var clientId int
 	utils.ReadTransportSecConfig()
@@ -440,8 +443,8 @@ func WsMgrInit(mgrId int, transportMgrChan chan string) {
 
 	for {
 		select {
-		case respMessage := <-transportMgrChan:
-			handleWsTransportResponse(respMessage, transportMgrChan)
+		case respMessage := <-respChan:
+			handleWsTransportResponse(respMessage, respChan)
 			continue
 		case reqMessage = <-wsClientChan[0]: clientId = 0
 		case reqMessage = <-wsClientChan[1]: clientId = 1
@@ -464,6 +467,6 @@ func WsMgrInit(mgrId int, transportMgrChan chan string) {
 		case reqMessage = <-wsClientChan[18]: clientId = 18
 		case reqMessage = <-wsClientChan[19]: clientId = 19
 		}
-		handleWsClientRequest(reqMessage, mgrId, clientId, transportMgrChan)
+		handleWsClientRequest(reqMessage, mgrId, clientId, reqChan)
 	}
 }


### PR DESCRIPTION
## Problem (reported by Ulf)

After PRs #181/#182/#183, an `invoke` with a timebased filter returns `ONGOING`
correctly, but the service **`monitoring` events never reach the client**, and
the server logs a binary-tree search on every event:

```
vissv2server.go: Matches=2. Max validation from search=0   (repeats every ~250 ms)
vissv2server.go: server hub: Event dropped                  (after the buffers back up)
```

Ulf correctly observed that a tree search should *not* be done on event
messages — the path was already validated on the request.

## Root cause

Each transport data session shared a **single, buffered** Go channel with its
transport manager for **both** directions (client→core requests and
core→client responses). Because the channel was buffered, after
`transportDataSession` wrote a response it could read it straight back from its
own `select` (an echo/loopback) before the transport manager's goroutine took
it. The looped-back message — e.g. `{"action":"monitoring",...}` — was then
treated as a fresh inbound request and run through `serveRequest` /
`issueServiceRequest`, hitting the tree search and never being delivered.

`"monitoring"` is not in `isServiceAction` (invoke/monitor/cancel/discover), so
a looped-back event falls through to the signal-data pipeline and the tree
search. Sparse get/subscribe traffic mostly survived because the manager was
usually parked-waiting (Go hands a buffered send directly to a waiting
receiver), so the sustained 250 ms service-event stream is what exposed it.

## Fix

Give every transport a **pair of unidirectional channels**:

- `transportMgrChannel` — requests, transport mgr → core (read by `transportDataSession`)
- `toTransportChannel` *(new)* — responses/events, core → transport mgr (written by `transportDataSession`)

`transportDataSession` now reads the request channel and writes the response
channel, so it can never read back its own write. Each channel has a single
sender and a single receiver, which also removes the old MQTT "must stay
unbuffered to avoid an echo" special case and the latent deadlock of a shared
unbuffered channel.

Touches all five transport managers (http/ws/mqtt/grpc/uds), the `main()`
wiring, and `getVissV2Topic` (the MQTT VIN handshake now uses the two channels).

## Tests

- `transportDataSession` tests assert responses reach the response channel and
  **never leak onto the request channel**.
- New `TestTransportDataSession_MonitoringStreamNoLoopback` pushes 50 monitoring
  events and asserts every one reaches the transport and none is re-injected
  into the request pipeline (`transportDataChannel`).
- `initChannels` and `getVissV2Topic` tests updated for the split.

`go build ./...`, `go vet ./server/...`, and `go test -race -count=1
./server/vissv2server/...` all pass.

## Notes

- The separate "Matches=**2**" (two `MoveSeat` nodes in the tree) is unrelated
  and prio-2 per Ulf — this PR stops events from being searched at all, which is
  the prio-1.

Signed-off-by: Matt Jones <matt@jellybaby.com>