### PR TITLE
fix(transport): route service monitoring events to the async client channel

### DIFF
--- a/server/vissv2server/udsMgr/udsMgr.go
+++ b/server/vissv2server/udsMgr/udsMgr.go
@@ -115,11 +115,11 @@ func RemoveRoutingForwardResponse(response string, transportMgrChan chan string)
 		utils.Error.Printf("udsMgr:RemoveRoutingForwardResponse: invalid clientId=%d (response=%q); dropping", clientId, trimmedResponse)
 		return
 	}
-	if strings.Contains(trimmedResponse, "\"subscription\"") {
+	if isAsyncServerPush(trimmedResponse) {
 		select {
-		case clientBackendChan[clientId] <- trimmedResponse: //subscription notification
+		case clientBackendChan[clientId] <- trimmedResponse: // subscription notification or service monitoring event
 		default:
-			utils.Error.Printf("udsMgr:subscription event dropped, clientId=%d", clientId)
+			utils.Error.Printf("udsMgr:async push dropped, clientId=%d", clientId)
 		}
 		return
 	}
@@ -131,6 +131,16 @@ func RemoveRoutingForwardResponse(response string, transportMgrChan chan string)
 	case <-time.After(channelSendTimeout):
 		utils.Error.Printf("udsMgr:response dropped (clientId=%d not consuming after %s)", clientId, channelSendTimeout)
 	}
+}
+
+// isAsyncServerPush reports whether a message is an unsolicited server push
+// (a subscribe notification carrying "subscription", or a VISSv3.2 service
+// monitoring event carrying "action":"monitoring") rather than the response to
+// a client request. Pushes must go to the asynchronous clientBackendChan, not
+// the synchronous udsClientChan that only carries request/response pairs.
+func isAsyncServerPush(message string) bool {
+	return strings.Contains(message, "\"subscription\"") ||
+		strings.Contains(message, "\"action\":\"monitoring\"")
 }
 
 func checkCompressionRequest(reqMessage string) {

--- a/server/vissv2server/udsMgr/udsMgr_test.go
+++ b/server/vissv2server/udsMgr/udsMgr_test.go
@@ -734,6 +734,48 @@ func TestRemoveRoutingForwardResponse_ResponseRouted(t *testing.T) {
 	wg.Wait()
 }
 
+// A VISSv3.2 service "monitoring" event is an unsolicited push and must be
+// routed to the asynchronous clientBackendChan, like a subscription
+// notification — not to the synchronous udsClientChan (where a missing reader
+// would otherwise stall the hub for channelSendTimeout per event).
+func TestRemoveRoutingForwardResponse_MonitoringRouted(t *testing.T) {
+	resetChannels(t)
+	resp := `{"RouterId":"0?0","action":"monitoring","path":"VehicleService.Seating.Row1.DriverSide.MoveSeat","serviceId":"860818","status":"ONGOING","ts":"2026-06-17T14:29:37Z"}`
+	target := clientBackendChan[0]
+	got := make(chan string, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		select {
+		case v := <-target:
+			got <- v
+		case <-time.After(2 * time.Second):
+		}
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	// No reader on udsClientChan[0]; routing to the async channel must let this
+	// return promptly (well under channelSendTimeout).
+	done := make(chan struct{})
+	go func() { RemoveRoutingForwardResponse(resp, nil); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("RemoveRoutingForwardResponse stalled on a monitoring event (should use the async channel)")
+	}
+
+	select {
+	case msg := <-got:
+		if !strings.Contains(msg, `"action":"monitoring"`) {
+			t.Errorf("got %q", msg)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("monitoring event not routed to clientBackendChan")
+	}
+	wg.Wait()
+}
+
 func TestRemoveRoutingForwardResponse_DeadReaderTimesOut(t *testing.T) {
 	// Pre-fix would block forever. Now bounded by channelSendTimeout.
 	// We use a very short test by overriding the const in the test only

--- a/server/vissv2server/wsMgr/wsMgr.go
+++ b/server/vissv2server/wsMgr/wsMgr.go
@@ -61,15 +61,32 @@ func RemoveRoutingForwardResponse(response string, transportMgrChan chan string)
 		utils.Error.Printf("wsMgr:RemoveRoutingForwardResponse: invalid clientId=%d (response=%q); dropping", clientId, trimmedResponse)
 		return
 	}
-	if strings.Contains(trimmedResponse, "\"subscription\"") {
+	if isAsyncServerPush(trimmedResponse) {
 		select {
-		case clientBackendChan[clientId] <- trimmedResponse: //subscription notification
-		default: 
+		case clientBackendChan[clientId] <- trimmedResponse: // subscription notification or service monitoring event
+		default:
 			utils.Error.Printf("wsmgr:Event dropped")
 		}
 	} else {
 		wsClientChan[clientId] <- trimmedResponse
 	}
+}
+
+// isAsyncServerPush reports whether a message is an unsolicited server push
+// rather than the response to a client request. Pushes must go to the
+// asynchronous write-pump channel (clientBackendChan), which backendWSAppSession
+// drains continuously. The synchronous wsClientChan is only read by the
+// frontend goroutine in the window between sending a request and receiving its
+// response; once a request handshake completes the frontend is parked on
+// conn.ReadMessage(), so a blocking send of a push to wsClientChan would wedge
+// the hub and back up the transport channel ("server hub: Event dropped").
+//
+// Two kinds of push exist:
+//   - subscribe notifications, carrying a "subscription":"<id>" field, and
+//   - VISSv3.2 service monitoring events, carrying "action":"monitoring".
+func isAsyncServerPush(message string) bool {
+	return strings.Contains(message, "\"subscription\"") ||
+		strings.Contains(message, "\"action\":\"monitoring\"")
 }
 
 func checkCompressionRequest(reqMessage string) {

--- a/server/vissv2server/wsMgr/wsMgr_monitoring_test.go
+++ b/server/vissv2server/wsMgr/wsMgr_monitoring_test.go
@@ -1,0 +1,123 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* Regression tests for the routing of VISSv3.2 service "monitoring" events.
+*
+* Background: a WS app-client talks to the hub over two per-client channels.
+* wsClientChan is a synchronous request/response rendezvous — the frontend
+* goroutine only reads it in the window between sending a request and receiving
+* that request's response (forwardWsRequest). clientBackendChan is the
+* asynchronous write-pump channel that backendWSAppSession drains continuously.
+*
+* Service monitoring events are unsolicited server pushes that arrive long
+* after the invoke handshake has completed, when the frontend is parked on
+* conn.ReadMessage() and is NOT reading wsClientChan. Routing them to the
+* synchronous wsClientChan therefore blocked the hub on an unbuffered send,
+* which backed up the transport channel and produced the "server hub: Event
+* dropped" stream Ulf reported after PR #187. They must go to the async
+* clientBackendChan, like subscription notifications.
+**/
+package wsMgr
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// A monitoring event (with a RouterId so RemoveInternalData yields a valid
+// clientId) must be delivered to the asynchronous clientBackendChan and never
+// to the synchronous wsClientChan.
+func TestRemoveRoutingForwardResponse_MonitoringRoutedToAsyncChannel(t *testing.T) {
+	// Buffer the async channel so the non-blocking send always lands without a
+	// racing reader, then restore the package global.
+	saved := clientBackendChan[0]
+	clientBackendChan[0] = make(chan string, 4)
+	defer func() { clientBackendChan[0] = saved }()
+
+	// Exact shape from Ulf's log, with the internal RouterId prefix.
+	resp := `{"RouterId":"0?0","action":"monitoring","path":"VehicleService.Seating.Row1.DriverSide.MoveSeat","serviceId":"860818","status":"ONGOING","ts":"2026-06-17T14:29:37Z"}`
+
+	RemoveRoutingForwardResponse(resp, nil)
+
+	select {
+	case got := <-clientBackendChan[0]:
+		if !strings.Contains(got, "\"action\":\"monitoring\"") {
+			t.Fatalf("async channel got %q; want the monitoring event", got)
+		}
+		if strings.Contains(got, "RouterId") {
+			t.Fatalf("internal RouterId leaked to client: %q", got)
+		}
+	default:
+		t.Fatal("monitoring event was not routed to the asynchronous clientBackendChan")
+	}
+
+	// It must NOT have been sent to the synchronous request/response channel.
+	select {
+	case leaked := <-wsClientChan[0]:
+		t.Fatalf("monitoring event leaked onto synchronous wsClientChan: %q", leaked)
+	default:
+	}
+}
+
+// Reproduces Ulf's wedge directly: with NO reader on the synchronous
+// wsClientChan (the frontend is parked on conn.ReadMessage after the invoke
+// handshake), a stream of monitoring events must still be delivered via the
+// async channel and must never block the caller (the hub). On the pre-fix code
+// the first event blocked forever on the unbuffered wsClientChan send, the hub
+// stopped draining respChan, and transportDataSession logged "server hub: Event
+// dropped".
+func TestRemoveRoutingForwardResponse_NoHubWedgeOnMonitoringStream(t *testing.T) {
+	const events = 50
+	saved := clientBackendChan[0]
+	clientBackendChan[0] = make(chan string, events)
+	defer func() { clientBackendChan[0] = saved }()
+
+	// Intentionally NO reader on wsClientChan[0].
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < events; i++ {
+			resp := `{"RouterId":"0?0","action":"monitoring","path":"VehicleService.Seating.Row1.DriverSide.MoveSeat","serviceId":"860818","status":"ONGOING","ts":"2026-06-17T14:29:37Z"}`
+			RemoveRoutingForwardResponse(resp, nil)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("hub wedged: RemoveRoutingForwardResponse blocked delivering a monitoring event")
+	}
+
+	if got := len(clientBackendChan[0]); got != events {
+		t.Fatalf("delivered %d/%d monitoring events to the async channel", got, events)
+	}
+}
+
+// Sanity check that the routing predicate stays correct for the messages that
+// must keep using each path.
+func TestIsAsyncServerPush(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{"monitoring event", `{"action":"monitoring","status":"ONGOING"}`, true},
+		{"subscription notification", `{"action":"subscribe","subscription":"246","data":{}}`, true},
+		{"invoke ACK (solicited)", `{"action":"invoke","status":"ONGOING","requestId":"8756"}`, false},
+		{"monitor ACK (solicited)", `{"action":"monitor","status":"ONGOING","requestId":"8756"}`, false},
+		{"subscribe ACK (solicited)", `{"action":"subscribe","subscriptionId":"246","requestId":"1"}`, false},
+		{"get response", `{"action":"get","data":{"path":"Vehicle.Speed","dp":{"value":"5"}}}`, false},
+	}
+	for _, c := range cases {
+		if got := isAsyncServerPush(c.msg); got != c.want {
+			t.Errorf("%s: isAsyncServerPush=%v; want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem (reported by Ulf, after #187)

#187 fixed the loopback — the tree search ("Matches=…") on events is gone, and
monitoring events now reach the WS hub. But the client still receives nothing,
and the log fills with:

```
wsMgr.go: WS mgr hub: Response from server core:{...,"action":"monitoring",...}
vissv2server.go: server hub: Event dropped   (repeats, starting ~8s in)
```

## Root cause (the final delivery hop)

Each WS app-client talks to the hub over two per-client channels:

- **`wsClientChan`** — a *synchronous* request/response rendezvous. The frontend
  goroutine reads it only in the window between sending a request and receiving
  that request's response (`forwardWsRequest`: `clientChannel <- payload;
  response := <-clientChannel`).
- **`clientBackendChan`** — the *asynchronous* write-pump that
  `backendWSAppSession` drains continuously and writes to the socket.

`RemoveRoutingForwardResponse` routed a message to `clientBackendChan` only when
it contained `"subscription"`; everything else took a **blocking** send to
`wsClientChan`.

A service `monitoring` event (`{"action":"monitoring",...}`) is an unsolicited
push that arrives long after the invoke handshake completed — when the frontend
is parked on `conn.ReadMessage()` and is **not** reading `wsClientChan`. The
blocking send wedged the hub; it stopped draining `respChan`; `respChan`
(buffer 32) filled at ~4 events/s and after ~8 s `transportDataSession` started
dropping. Exactly Ulf's timeline.

## Fix

Treat monitoring events as async server pushes, like subscription
notifications, and route them to `clientBackendChan`. Added `isAsyncServerPush`
in **wsMgr** and **udsMgr** (both had the same `"subscription"`-only routing;
udsMgr degraded via a 5 s send-timeout per event rather than wedging). Invoke /
monitor / subscribe ACKs and get/set responses stay on the synchronous channel.

## Why CI was green while Ulf's client broke — and how we test it now

#187's tests stopped at `respChan` (mock reader). Nothing exercised the final
hop: routing through `RemoveRoutingForwardResponse` to the correct per-client
channel with a frontend that has stopped reading the synchronous channel. The
new tests reproduce that condition deterministically (they hang / time out on
the pre-fix code):

- **wsMgr**: a monitoring event routes to `clientBackendChan`, never
  `wsClientChan`; a 50-event stream with **no reader on the synchronous
  channel** must not block the hub; `isAsyncServerPush` predicate table.
- **udsMgr**: a monitoring event routes to `clientBackendChan` without stalling.

`go build ./...`, `go vet`, and `go test -race -count=1 ./server/vissv2server/...`
all pass.

Signed-off-by: Matt Jones <matt@jellybaby.com>