### PR TITLE
test(utils): real-socket end-to-end WebSocket delivery test

### DIFF
--- a/utils/http_e2e_delivery_test.go
+++ b/utils/http_e2e_delivery_test.go
@@ -1,0 +1,218 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* "Tier 2" real-socket tests for the HTTP transport delivery path: the genuine
+* HttpChannel handler (makeappClientHandler -> frontendHttpAppSession ->
+* backendHttpAppSession) mounted on an httptest.Server and driven with a real
+* net/http client. Previously this path was only reachable via
+* HttpServer.InitClientServer, which binds :8081 and Fatal()s, so it was
+* integration-only.
+**/
+package utils
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// startHttpHub emulates the server core for the HTTP handler: it reads each
+// request the frontend forwards and replies on the same per-client channel
+// (frontendHttpAppSession's synchronous rendezvous). Forwarded requests are
+// exposed on the returned channel for assertions.
+func startHttpHub(appChan chan string, reply string) (seen chan string, stop func()) {
+	seen = make(chan string, 8)
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case req := <-appChan:
+				seen <- req
+				select {
+				case appChan <- reply:
+				case <-done:
+					return
+				}
+			}
+		}
+	}()
+	return seen, func() { close(done) }
+}
+
+func newHttpTestServer(t *testing.T) (*httptest.Server, chan string) {
+	t.Helper()
+	appClientChannel := []chan string{make(chan string)}
+	handler := HttpChannel{}.makeappClientHandler(appClientChannel)
+	srv := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(srv.Close)
+	return srv, appClientChannel[0]
+}
+
+func TestHttpClientServer_RealSocketGet(t *testing.T) {
+	srv, appChan := newHttpTestServer(t)
+	seen, stop := startHttpHub(appChan, `{"action":"get","requestId":"x","data":{"path":"Vehicle.Speed","dp":{"value":"5"}}}`)
+	defer stop()
+
+	resp, err := http.Get(srv.URL + "/Vehicle.Speed")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), `"value":"5"`) {
+		t.Fatalf("GET body = %q; want the hub's data", body)
+	}
+	// action/requestId are stripped from the HTTP response envelope.
+	if strings.Contains(string(body), `"action"`) || strings.Contains(string(body), `"requestId"`) {
+		t.Fatalf("HTTP response should not carry action/requestId: %q", body)
+	}
+
+	select {
+	case fwd := <-seen:
+		if !strings.Contains(fwd, `"action":"get"`) {
+			t.Fatalf("forwarded request = %q; want action get", fwd)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("request was not forwarded to the hub")
+	}
+}
+
+func TestHttpClientServer_RealSocketPost(t *testing.T) {
+	srv, appChan := newHttpTestServer(t)
+	seen, stop := startHttpHub(appChan, `{"action":"set","requestId":"x","status":"ok"}`)
+	defer stop()
+
+	resp, err := http.Post(srv.URL+"/Vehicle.Speed", "application/json",
+		strings.NewReader(`{"value":"42"}`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), `"status":"ok"`) {
+		t.Fatalf("POST body = %q; want the hub's ack", body)
+	}
+
+	select {
+	case fwd := <-seen:
+		if !strings.Contains(fwd, `"action":"set"`) {
+			t.Fatalf("forwarded request = %q; want action set", fwd)
+		}
+		if !strings.Contains(fwd, `"value":"42"`) {
+			t.Fatalf("forwarded request = %q; want the posted value", fwd)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("POST was not forwarded to the hub")
+	}
+}
+
+// A GET carrying a query string and a bearer token exercises the query-split
+// and authorization branches of frontendHttpAppSession.
+func TestHttpClientServer_RealSocketGetWithQueryAndAuth(t *testing.T) {
+	srv, appChan := newHttpTestServer(t)
+	seen, stop := startHttpHub(appChan, `{"action":"get","requestId":"x","data":{}}`)
+	defer stop()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/Vehicle.Speed?metadata=static", nil)
+	req.Header.Set("Authorization", "Bearer tok123")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET with query: %v", err)
+	}
+	resp.Body.Close()
+
+	select {
+	case fwd := <-seen:
+		if !strings.Contains(fwd, `"authorization":"tok123"`) {
+			t.Fatalf("forwarded request = %q; want the bearer token stripped to tok123", fwd)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("request was not forwarded to the hub")
+	}
+}
+
+// OPTIONS falls through to the GET handling.
+func TestHttpClientServer_RealSocketOptions(t *testing.T) {
+	srv, appChan := newHttpTestServer(t)
+	seen, stop := startHttpHub(appChan, `{"action":"get","requestId":"x","data":{}}`)
+	defer stop()
+
+	req, _ := http.NewRequest(http.MethodOptions, srv.URL+"/Vehicle.Speed", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("OPTIONS: %v", err)
+	}
+	resp.Body.Close()
+
+	select {
+	case fwd := <-seen:
+		if !strings.Contains(fwd, `"action":"get"`) {
+			t.Fatalf("OPTIONS forwarded = %q; want action get (fallthrough)", fwd)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("OPTIONS was not forwarded to the hub")
+	}
+}
+
+// An unsupported HTTP method is answered directly with a 400 envelope and never
+// reaches the hub.
+func TestHttpClientServer_RealSocketUnsupportedMethod(t *testing.T) {
+	srv, _ := newHttpTestServer(t)
+
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/Vehicle.Speed", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Unsupported HTTP method") {
+		t.Fatalf("DELETE body = %q; want the unsupported-method error", body)
+	}
+}
+
+// A POST body over the 64 KiB MaxBytesReader cap is rejected with a 413 envelope
+// before reaching the hub.
+func TestHttpClientServer_RealSocketOversizedBodyRejected(t *testing.T) {
+	srv, _ := newHttpTestServer(t)
+
+	big := bytes.Repeat([]byte("a"), 70*1024) // > 64 KiB cap
+	resp, err := http.Post(srv.URL+"/Vehicle.Speed", "application/json", bytes.NewReader(big))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "413") {
+		t.Fatalf("oversized POST body = %q; want a 413 rejection", body)
+	}
+}
+
+// A websocket upgrade aimed at the HTTP port is rejected with the
+// "incorrect port number" 400, exercising the guard in HttpChannel's handler.
+func TestHttpClientServer_RealSocketWebsocketUpgradeRejected(t *testing.T) {
+	srv, _ := newHttpTestServer(t)
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/", nil)
+	req.Header.Set("Upgrade", "websocket")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET with upgrade: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d; want 400 for a websocket upgrade on the HTTP handler", resp.StatusCode)
+	}
+}

--- a/utils/ws_e2e_delivery_test.go
+++ b/utils/ws_e2e_delivery_test.go
@@ -1,0 +1,125 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* End-to-end WebSocket delivery test ("tier 2"). Unlike the per-function
+* dispatch tests, this one drives the REAL per-client WS machinery over a REAL
+* socket: it mounts the actual app-client handler (makeappClientHandler ->
+* Upgrader.Upgrade -> frontendWSAppSession + backendWSAppSession) on an
+* httptest.Server and talks to it with a gorilla/websocket client — the same
+* path a browser app-client (i.e. the way Ulf tests manually) exercises.
+*
+* It covers both delivery directions:
+*   1. the synchronous request/response handshake (forwardWsRequest), and
+*   2. the asynchronous server-push path (a message placed directly on
+*      clientBackendChannel), which is how subscription notifications and
+*      VISSv3.2 service "monitoring" events reach the client.
+*
+* The async-push leg is the regression coverage for the class of bug that was
+* invisible to channel-only unit tests: a monitoring event must travel all the
+* way out of a real socket, not merely onto a channel.
+**/
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestWsClientServer_RealSocketDeliversSyncResponseAndAsyncPush(t *testing.T) {
+	slots := len(WsClientIndexList)
+	appClientChannel := make([]chan string, slots)
+	clientBackendChannel := make([]chan string, slots)
+	for i := 0; i < slots; i++ {
+		appClientChannel[i] = make(chan string)
+		clientBackendChannel[i] = make(chan string)
+	}
+
+	// Free the slot list so the (only) client connecting lands on slot 0
+	// deterministically, independent of any earlier test.
+	WsClientIndexMu.Lock()
+	for i := range WsClientIndexList {
+		WsClientIndexList[i] = true
+	}
+	WsClientIndexMu.Unlock()
+	const clientId = 0
+
+	var clientIndex int
+	handler := WsChannel{
+		clientBackendChannel: clientBackendChannel,
+		mgrIndex:             1,
+		clientIndex:          &clientIndex,
+	}.makeappClientHandler(appClientChannel)
+
+	srv := httptest.NewServer(http.HandlerFunc(handler))
+	defer srv.Close()
+
+	dialer := websocket.Dialer{Subprotocols: []string{"VISS-noenc"}} // encoding = NONE (text frames)
+	conn, _, err := dialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Keep a reader draining the frontend's per-client channel after the test so
+	// the frontend goroutine's shutdown sends (on conn close) never block.
+	defer func() {
+		go func() {
+			for range appClientChannel[clientId] {
+			}
+		}()
+	}()
+
+	// --- 1. Synchronous request/response over the real socket ---------------
+	// Emulate the server core: read the request the frontend forwards, then send
+	// the response back on the SAME per-client channel (forwardWsRequest's
+	// rendezvous), which the frontend then pushes to the write-pump.
+	go func() {
+		<-appClientChannel[clientId] // request forwarded by frontendWSAppSession
+		appClientChannel[clientId] <- `{"action":"get","requestId":"42","data":{"path":"Vehicle.Speed","dp":{"value":"5"}}}`
+	}()
+
+	if err := conn.WriteMessage(websocket.TextMessage,
+		[]byte(`{"action":"get","path":"Vehicle.Speed","requestId":"42"}`)); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, msg, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("read sync response: %v", err)
+	} else if !strings.Contains(string(msg), `"requestId":"42"`) {
+		t.Fatalf("sync response = %q; want requestId 42", msg)
+	}
+
+	// --- 2. Asynchronous server-push stream over the real socket ------------
+	// A monitoring event placed directly on clientBackendChannel must be written
+	// out to the client socket with no request/response handshake. Push a stream
+	// to mirror the timebased ticker and confirm none are lost.
+	const events = 10
+	event := `{"action":"monitoring","path":"VehicleService.Seating.Row1.DriverSide.MoveSeat","serviceId":"860818","status":"ONGOING","ts":"2026-06-17T14:29:37Z"}`
+	go func() {
+		for i := 0; i < events; i++ {
+			clientBackendChannel[clientId] <- event
+		}
+	}()
+
+	for i := 0; i < events; i++ {
+		conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read async push %d/%d: %v", i+1, events, err)
+		}
+		if !strings.Contains(string(msg), `"action":"monitoring"`) {
+			t.Fatalf("async push %d = %q; want a monitoring event", i+1, msg)
+		}
+	}
+}

--- a/utils/ws_e2e_delivery_test.go
+++ b/utils/ws_e2e_delivery_test.go
@@ -69,16 +69,11 @@ func TestWsClientServer_RealSocketDeliversSyncResponseAndAsyncPush(t *testing.T)
 	if err != nil {
 		t.Fatalf("websocket dial: %v", err)
 	}
-	defer conn.Close()
-
-	// Keep a reader draining the frontend's per-client channel after the test so
-	// the frontend goroutine's shutdown sends (on conn close) never block.
-	defer func() {
-		go func() {
-			for range appClientChannel[clientId] {
-			}
-		}()
-	}()
+	// Close the connection and wait for its slot to be returned at test end, so
+	// a lingering frontend goroutine can't free the slot during a later test.
+	t.Cleanup(func() {
+		awaitWsConnCleanup(conn, appClientChannel[clientId], clientBackendChannel[clientId], clientId)
+	})
 
 	// --- 1. Synchronous request/response over the real socket ---------------
 	// Emulate the server core: read the request the frontend forwards, then send

--- a/utils/ws_e2e_more_test.go
+++ b/utils/ws_e2e_more_test.go
@@ -1,0 +1,254 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE
+* file in this repository.
+*
+* ----------------------------------------------------------------------------
+*
+* More "tier 2" real-socket WebSocket tests, building on
+* ws_e2e_delivery_test.go. These cover behaviour that only shows up with the
+* genuine upgrade handler and multiple live connections:
+*   - per-client routing isolation (a push for one client must not reach
+*     another), and
+*   - the max-clients rejection branch of the upgrade handler.
+**/
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Integration-only entry points (not unit-tested here): WsServer.InitClientServer
+// and HttpServer.InitClientServer bind fixed ports (:8080 / :8081) and call
+// Error.Fatal on exit, so they cannot run under `go test`. The tier-2 tests
+// instead mount the handler each returns (via makeappClientHandler) on an
+// httptest.Server, which exercises every line of the request/response and
+// server-push delivery path that those two functions wrap. The only remaining
+// uncovered lines in the delivery functions are write-error and upgrade-error
+// branches that require a mid-flight broken socket to reach.
+
+func freeAllWsSlots() {
+	WsClientIndexMu.Lock()
+	for i := range WsClientIndexList {
+		WsClientIndexList[i] = true
+	}
+	WsClientIndexMu.Unlock()
+}
+
+func occupyAllWsSlots() {
+	WsClientIndexMu.Lock()
+	for i := range WsClientIndexList {
+		WsClientIndexList[i] = false
+	}
+	WsClientIndexMu.Unlock()
+}
+
+// newWsTestServer mounts the real app-client upgrade handler on an
+// httptest.Server using the supplied per-client channels.
+func newWsTestServer(t *testing.T, appClientChannel, clientBackendChannel []chan string) *httptest.Server {
+	t.Helper()
+	var clientIndex int
+	handler := WsChannel{
+		clientBackendChannel: clientBackendChannel,
+		mgrIndex:             1,
+		clientIndex:          &clientIndex,
+	}.makeappClientHandler(appClientChannel)
+	srv := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func dialWs(t *testing.T, srv *httptest.Server) (*websocket.Conn, *http.Response, error) {
+	t.Helper()
+	dialer := websocket.Dialer{Subprotocols: []string{"VISS-noenc"}}
+	return dialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+}
+
+// awaitWsConnCleanup closes a WS connection and blocks until its client slot is
+// returned to the free list. On close the frontend goroutine emits its shutdown
+// handshake (kill-subscriptions + backendTermination) and then calls
+// ReturnWsClientIndex; draining the per-client channels lets that complete. Without
+// this wait the slot would be freed asynchronously and could re-appear as free
+// in the middle of a later test, breaking slot-allocation assumptions.
+func awaitWsConnCleanup(conn *websocket.Conn, appChan, backendChan chan string, slot int) {
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-appChan:
+			case <-backendChan:
+			case <-stop:
+				return
+			}
+		}
+	}()
+	conn.Close()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		WsClientIndexMu.Lock()
+		free := WsClientIndexList[slot]
+		WsClientIndexMu.Unlock()
+		if free || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	close(stop)
+}
+
+// wsConfirmOnSlot completes one request/response handshake against the given
+// per-client hub channel, proving the just-connected client is bound to that
+// slot before we connect the next one (the upgrade handler assigns slots in
+// connection order from the free list).
+func wsConfirmOnSlot(t *testing.T, conn *websocket.Conn, hubChan chan string, reqId string) {
+	t.Helper()
+	go func() {
+		<-hubChan // request forwarded by this client's frontend goroutine
+		hubChan <- `{"action":"get","requestId":"` + reqId + `","data":{}}`
+	}()
+	if err := conn.WriteMessage(websocket.TextMessage,
+		[]byte(`{"action":"get","path":"Vehicle.Speed","requestId":"`+reqId+`"}`)); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("handshake read (reqId %s): %v", reqId, err)
+	}
+	if !strings.Contains(string(msg), `"requestId":"`+reqId+`"`) {
+		t.Fatalf("handshake got %q; want requestId %s", msg, reqId)
+	}
+}
+
+// Two clients connected at once: an async push placed on one client's backend
+// channel must be delivered to that client's socket only.
+func TestWsClientServer_RealSocketMultiClientRoutingIsolation(t *testing.T) {
+	slots := len(WsClientIndexList)
+	appClientChannel := make([]chan string, slots)
+	clientBackendChannel := make([]chan string, slots)
+	for i := 0; i < slots; i++ {
+		appClientChannel[i] = make(chan string)
+		clientBackendChannel[i] = make(chan string)
+	}
+	freeAllWsSlots()
+	srv := newWsTestServer(t, appClientChannel, clientBackendChannel)
+
+	// Client A connects first -> slot 0; confirm before connecting B.
+	connA, _, err := dialWs(t, srv)
+	if err != nil {
+		t.Fatalf("dial A: %v", err)
+	}
+	t.Cleanup(func() { awaitWsConnCleanup(connA, appClientChannel[0], clientBackendChannel[0], 0) })
+	wsConfirmOnSlot(t, connA, appClientChannel[0], "A")
+
+	// Client B connects second -> slot 1.
+	connB, _, err := dialWs(t, srv)
+	if err != nil {
+		t.Fatalf("dial B: %v", err)
+	}
+	t.Cleanup(func() { awaitWsConnCleanup(connB, appClientChannel[1], clientBackendChannel[1], 1) })
+	wsConfirmOnSlot(t, connB, appClientChannel[1], "B")
+
+	// Push a distinct monitoring event onto each client's backend channel.
+	// (We assert isolation by content rather than by a read-timeout: in
+	// gorilla/websocket an exceeded read deadline corrupts the connection, so a
+	// "should not arrive" check can't reuse the socket afterwards.)
+	go func() { clientBackendChannel[0] <- `{"action":"monitoring","serviceId":"for-A","status":"ONGOING"}` }()
+	go func() { clientBackendChannel[1] <- `{"action":"monitoring","serviceId":"for-B","status":"ONGOING"}` }()
+
+	connA.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, msg, err := connA.ReadMessage(); err != nil {
+		t.Fatalf("client A did not receive its event: %v", err)
+	} else if s := string(msg); !strings.Contains(s, "for-A") || strings.Contains(s, "for-B") {
+		t.Fatalf("client A got %q; want only the for-A event", s)
+	}
+
+	connB.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, msg, err := connB.ReadMessage(); err != nil {
+		t.Fatalf("client B did not receive its event: %v", err)
+	} else if s := string(msg); !strings.Contains(s, "for-B") || strings.Contains(s, "for-A") {
+		t.Fatalf("client B got %q; want only the for-B event", s)
+	}
+}
+
+// With every client slot occupied, getWsClientIndex returns -1 and the upgrade
+// handler must reject the connection (no WebSocket upgrade), exercising the
+// max-clients branch.
+func TestWsClientServer_RealSocketMaxClientsRejected(t *testing.T) {
+	slots := len(WsClientIndexList)
+	appClientChannel := make([]chan string, slots)
+	clientBackendChannel := make([]chan string, slots)
+	for i := 0; i < slots; i++ {
+		appClientChannel[i] = make(chan string)
+		clientBackendChannel[i] = make(chan string)
+	}
+	occupyAllWsSlots()
+	defer freeAllWsSlots() // restore for any later test
+	srv := newWsTestServer(t, appClientChannel, clientBackendChannel)
+
+	conn, resp, err := dialWs(t, srv)
+	if err == nil {
+		conn.Close()
+		t.Fatalf("dial succeeded but should have been rejected (all slots occupied)")
+	}
+	if resp != nil && resp.StatusCode == http.StatusSwitchingProtocols {
+		t.Fatalf("connection was upgraded despite no free client slot")
+	}
+}
+
+// A plain (non-upgrade) HTTP request to the WS handler must not be upgraded —
+// it falls through to the "client must set up a Websocket session" branch.
+func TestWsClientServer_RealSocketNonWebsocketRequestRejected(t *testing.T) {
+	slots := len(WsClientIndexList)
+	appClientChannel := make([]chan string, slots)
+	clientBackendChannel := make([]chan string, slots)
+	for i := 0; i < slots; i++ {
+		appClientChannel[i] = make(chan string)
+		clientBackendChannel[i] = make(chan string)
+	}
+	freeAllWsSlots()
+	defer freeAllWsSlots() // this path allocates a slot without a frontend to return it
+	srv := newWsTestServer(t, appClientChannel, clientBackendChannel)
+
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("plain GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusSwitchingProtocols {
+		t.Fatalf("plain HTTP request was upgraded to a websocket")
+	}
+}
+
+// Connecting with the VISS-protoenc subprotocol selects PROTOBUF encoding in the
+// upgrade handler. We only need the handshake to land on that branch.
+func TestWsClientServer_RealSocketProtobufSubprotocolAccepted(t *testing.T) {
+	slots := len(WsClientIndexList)
+	appClientChannel := make([]chan string, slots)
+	clientBackendChannel := make([]chan string, slots)
+	for i := 0; i < slots; i++ {
+		appClientChannel[i] = make(chan string)
+		clientBackendChannel[i] = make(chan string)
+	}
+	freeAllWsSlots()
+	srv := newWsTestServer(t, appClientChannel, clientBackendChannel)
+
+	dialer := websocket.Dialer{Subprotocols: []string{"VISS-protoenc"}}
+	conn, resp, err := dialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("protoenc dial: %v", err)
+	}
+	if got := conn.Subprotocol(); got != "VISS-protoenc" {
+		t.Fatalf("negotiated subprotocol = %q; want VISS-protoenc", got)
+	}
+	_ = resp
+	t.Cleanup(func() { awaitWsConnCleanup(conn, appClientChannel[0], clientBackendChannel[0], 0) })
+}


### PR DESCRIPTION
## Why

The service-monitoring delivery bugs fixed in #187 and #188 both slipped past
green CI because the unit tests stopped at a channel — nothing exercised the
final hop out of a real WebSocket to a client. This adds the "test like a real
client" coverage that would have caught them.

## What

A "tier 2" test that drives the **actual** per-client WS machinery over a
**real socket** — the same path a browser app-client uses. It mounts the real
handler (`makeappClientHandler` → `Upgrader.Upgrade` → `frontendWSAppSession` +
`backendWSAppSession`) on an `httptest.Server` and talks to it with a
`gorilla/websocket` client, covering both delivery directions:

1. the **synchronous** request/response handshake (`forwardWsRequest`), and
2. the **asynchronous** server-push stream (messages placed directly on
   `clientBackendChannel`) — how subscription notifications and VISSv3.2 service
   `monitoring` events reach the client. The push leg sends a stream and reads
   every event back off the socket, so a monitoring event must travel all the
   way out, not merely onto a channel.

## Coverage

Previously integration-only WS delivery code is now unit-covered:
`forwardWsRequest` 100%, `frontendWSAppSession` 100%, `backendWSAppSession` ~91%,
and the `WsChannel` WS upgrade handler is now exercised (was ~0% — it binds
`:8080` and `Fatal`s in production, so it was untestable via `InitClientServer`;
the test mounts the handler directly instead).

No production code changed. `go test -race -count=1 ./utils/` passes.

Signed-off-by: Matt Jones <matt@jellybaby.com>