### PR TITLE
test: maximise coverage across tools, clients, feeders (tier-1 + tier-2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ vsspathlist.json
 vss_vissv2.binary
 certificate.pem
 config.json
-feeder
 feeder/feeder-rl/config.json
 
 

--- a/client/client-1.0/compress_client/transportSec_coverage_test.go
+++ b/client/client-1.0/compress_client/transportSec_coverage_test.go
@@ -1,0 +1,45 @@
+/**
+* (C) 2026 Matt Jones
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE file in this repository.
+**/
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// readTransportSecConfig reads transport_sec/transportSec.json (relative to the
+// overridable trSecConfigPath). prepareTransportSecConfig is integration-only:
+// it loads real X.509 cert/key files and os.Exit(1)s on failure.
+func TestReadTransportSecConfig_Coverage(t *testing.T) {
+	dir := t.TempDir() + "/"
+	old := trSecConfigPath
+	defer func() { trSecConfigPath = old }()
+	trSecConfigPath = dir
+
+	// Missing file -> defaults to "no".
+	secConfig = SecConfig{}
+	readTransportSecConfig()
+	if secConfig.TransportSec != "no" {
+		t.Errorf("missing file: TransportSec=%q; want no", secConfig.TransportSec)
+	}
+
+	// Valid config.
+	os.WriteFile(dir+"transportSec.json", []byte(`{"transportSec":"yes"}`), 0644)
+	secConfig = SecConfig{}
+	readTransportSecConfig()
+	if secConfig.TransportSec != "yes" {
+		t.Errorf("valid file: TransportSec=%q; want yes", secConfig.TransportSec)
+	}
+
+	// Malformed JSON -> defaults to "no".
+	os.WriteFile(dir+"transportSec.json", []byte(`not json`), 0644)
+	secConfig = SecConfig{}
+	readTransportSecConfig()
+	if secConfig.TransportSec != "no" {
+		t.Errorf("bad json: TransportSec=%q; want no", secConfig.TransportSec)
+	}
+}

--- a/client/client-1.0/csv_client/transportSec_coverage_test.go
+++ b/client/client-1.0/csv_client/transportSec_coverage_test.go
@@ -1,0 +1,45 @@
+/**
+* (C) 2026 Matt Jones
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE file in this repository.
+**/
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// readTransportSecConfig reads transport_sec/transportSec.json (relative to the
+// overridable trSecConfigPath). prepareTransportSecConfig is integration-only:
+// it loads real X.509 cert/key files and os.Exit(1)s on failure.
+func TestReadTransportSecConfig_Coverage(t *testing.T) {
+	dir := t.TempDir() + "/"
+	old := trSecConfigPath
+	defer func() { trSecConfigPath = old }()
+	trSecConfigPath = dir
+
+	// Missing file -> defaults to "no".
+	secConfig = SecConfig{}
+	readTransportSecConfig()
+	if secConfig.TransportSec != "no" {
+		t.Errorf("missing file: TransportSec=%q; want no", secConfig.TransportSec)
+	}
+
+	// Valid config.
+	os.WriteFile(dir+"transportSec.json", []byte(`{"transportSec":"yes"}`), 0644)
+	secConfig = SecConfig{}
+	readTransportSecConfig()
+	if secConfig.TransportSec != "yes" {
+		t.Errorf("valid file: TransportSec=%q; want yes", secConfig.TransportSec)
+	}
+
+	// Malformed JSON -> defaults to "no".
+	os.WriteFile(dir+"transportSec.json", []byte(`not json`), 0644)
+	secConfig = SecConfig{}
+	readTransportSecConfig()
+	if secConfig.TransportSec != "no" {
+		t.Errorf("bad json: TransportSec=%q; want no", secConfig.TransportSec)
+	}
+}

--- a/client/client-1.0/filetransfer_client/transportSec_coverage_test.go
+++ b/client/client-1.0/filetransfer_client/transportSec_coverage_test.go
@@ -1,0 +1,45 @@
+/**
+* (C) 2026 Matt Jones
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE file in this repository.
+**/
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// readTransportSecConfig reads transport_sec/transportSec.json (relative to the
+// overridable trSecConfigPath). prepareTransportSecConfig is integration-only:
+// it loads real X.509 cert/key files and os.Exit(1)s on failure.
+func TestReadTransportSecConfig_Coverage(t *testing.T) {
+	dir := t.TempDir() + "/"
+	old := trSecConfigPath
+	defer func() { trSecConfigPath = old }()
+	trSecConfigPath = dir
+
+	// Missing file -> defaults to "no".
+	secConfig = SecConfig{}
+	readTransportSecConfig()
+	if secConfig.TransportSec != "no" {
+		t.Errorf("missing file: TransportSec=%q; want no", secConfig.TransportSec)
+	}
+
+	// Valid config.
+	os.WriteFile(dir+"transportSec.json", []byte(`{"transportSec":"yes"}`), 0644)
+	secConfig = SecConfig{}
+	readTransportSecConfig()
+	if secConfig.TransportSec != "yes" {
+		t.Errorf("valid file: TransportSec=%q; want yes", secConfig.TransportSec)
+	}
+
+	// Malformed JSON -> defaults to "no".
+	os.WriteFile(dir+"transportSec.json", []byte(`not json`), 0644)
+	secConfig = SecConfig{}
+	readTransportSecConfig()
+	if secConfig.TransportSec != "no" {
+		t.Errorf("bad json: TransportSec=%q; want no", secConfig.TransportSec)
+	}
+}

--- a/client/client-1.0/transportSec_coverage_test.go
+++ b/client/client-1.0/transportSec_coverage_test.go
@@ -1,0 +1,45 @@
+/**
+* (C) 2026 Matt Jones
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE file in this repository.
+**/
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// readTransportSecConfig reads transport_sec/transportSec.json (relative to the
+// overridable trSecConfigPath). prepareTransportSecConfig is integration-only:
+// it loads real X.509 cert/key files and os.Exit(1)s on failure.
+func TestReadTransportSecConfig_Coverage(t *testing.T) {
+	dir := t.TempDir() + "/"
+	old := trSecConfigPath
+	defer func() { trSecConfigPath = old }()
+	trSecConfigPath = dir
+
+	// Missing file -> defaults to "no".
+	secConfig = SecConfig{}
+	readTransportSecConfig()
+	if secConfig.TransportSec != "no" {
+		t.Errorf("missing file: TransportSec=%q; want no", secConfig.TransportSec)
+	}
+
+	// Valid config.
+	os.WriteFile(dir+"transportSec.json", []byte(`{"transportSec":"yes"}`), 0644)
+	secConfig = SecConfig{}
+	readTransportSecConfig()
+	if secConfig.TransportSec != "yes" {
+		t.Errorf("valid file: TransportSec=%q; want yes", secConfig.TransportSec)
+	}
+
+	// Malformed JSON -> defaults to "no".
+	os.WriteFile(dir+"transportSec.json", []byte(`not json`), 0644)
+	secConfig = SecConfig{}
+	readTransportSecConfig()
+	if secConfig.TransportSec != "no" {
+		t.Errorf("bad json: TransportSec=%q; want no", secConfig.TransportSec)
+	}
+}

--- a/feeder/feeder-evic/evicFeeder_conv_test.go
+++ b/feeder/feeder-evic/evicFeeder_conv_test.go
@@ -1,0 +1,194 @@
+/**
+* (C) 2026 Matt Jones
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE file in this repository.
+*
+* Unit tests for the EVIC feeder's pure conversion logic, message
+* (de)composition, and the binary domain-conversion file readers. The socket /
+* UDS / CAN / redis plumbing and main() remain integration-only.
+**/
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// cvtElement encodes one FeederMap entry in the exact byte layout the Domain
+// Conversion Tool's writeElement emits (and readElement expects).
+func cvtElement(mapIndex uint16, name string, typ, datatype uint8, convIdx uint16) []byte {
+	b := []byte{byte(mapIndex & 0xff), byte(mapIndex >> 8)}
+	b = append(b, byte(len(name)))
+	b = append(b, []byte(name)...)
+	b = append(b, typ, datatype)
+	b = append(b, byte(convIdx&0xff), byte(convIdx>>8))
+	return b
+}
+
+// ── mapString ─────────────────────────────────────────────────────────────────
+
+func TestMapString(t *testing.T) {
+	m := map[string]interface{}{"s": "v", "n": nil, "i": 7}
+	if v, ok := mapString(m, "s"); !ok || v != "v" {
+		t.Errorf("mapString(s) = %q,%v; want v,true", v, ok)
+	}
+	if _, ok := mapString(m, "absent"); ok {
+		t.Error("mapString(absent) ok=true; want false")
+	}
+	if _, ok := mapString(m, "n"); ok {
+		t.Error("mapString(nil) ok=true; want false")
+	}
+	if _, ok := mapString(m, "i"); ok {
+		t.Error("mapString(int) ok=true; want false")
+	}
+}
+
+// ── convertValue / enum / linear ──────────────────────────────────────────────
+
+func TestConvertValue_NoConversion(t *testing.T) {
+	if got := convertValue("42", 0, 0, 0, true); got != "42" {
+		t.Errorf("no-conversion got %q; want 42", got)
+	}
+}
+
+func TestConvertValue_Enum(t *testing.T) {
+	scalingDataList = []string{`{"LOW":"0","HIGH":"1"}`}
+	defer func() { scalingDataList = nil }()
+	if got := convertValue("LOW", 1, 0, 0, true); got != "0" {
+		t.Errorf("north2south enum got %q; want 0", got)
+	}
+	if got := convertValue("1", 1, 0, 0, false); got != "HIGH" {
+		t.Errorf("south2north enum got %q; want HIGH", got)
+	}
+	if got := convertValue("NOPE", 1, 0, 0, true); got != "" {
+		t.Errorf("enum out-of-range got %q; want empty", got)
+	}
+}
+
+func TestConvertValue_Linear(t *testing.T) {
+	scalingDataList = []string{`[2, 1]`} // y = 2x + 1
+	defer func() { scalingDataList = nil }()
+	if got := convertValue("3", 1, 0, 0, true); got != "7" {
+		t.Errorf("north2south linear got %q; want 7", got)
+	}
+	if got := convertValue("7", 1, 0, 0, false); got != "3" {
+		t.Errorf("south2north linear got %q; want 3", got)
+	}
+}
+
+func TestConvertValue_Errors(t *testing.T) {
+	scalingDataList = []string{`not json`, `[0, 5]`}
+	defer func() { scalingDataList = nil }()
+	if got := convertValue("1", 99, 0, 0, true); got != "" {
+		t.Errorf("out-of-range index got %q; want empty", got)
+	}
+	if got := convertValue("1", 1, 0, 0, true); got != "" { // bad json entry
+		t.Errorf("bad json got %q; want empty", got)
+	}
+	if got := convertValue("1", 2, 0, 0, false); got != "" { // A=0, south2north divide-by-zero
+		t.Errorf("divide-by-zero got %q; want empty", got)
+	}
+}
+
+func TestLinearConversion_BadInputs(t *testing.T) {
+	if got := linearConversion([]interface{}{1.0}, true, "5"); got != "" {
+		t.Errorf("short coeff array got %q; want empty", got)
+	}
+	if got := linearConversion([]interface{}{2.0, 1.0}, true, "notnum"); got != "" {
+		t.Errorf("non-numeric input got %q; want empty", got)
+	}
+	if got := linearConversion([]interface{}{"x", "y"}, true, "5"); got != "" {
+		t.Errorf("non-numeric coeffs got %q; want empty", got)
+	}
+}
+
+// ── lookupFeederMap / convertDomainData ───────────────────────────────────────
+
+func TestLookupFeederMap(t *testing.T) {
+	if _, ok := lookupFeederMap("x", nil); ok {
+		t.Error("empty map should miss")
+	}
+	fm := []FeederMap{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+	if i, ok := lookupFeederMap("b", fm); !ok || i != 1 {
+		t.Errorf("lookup b = %d,%v; want 1,true", i, ok)
+	}
+	if _, ok := lookupFeederMap("z", fm); ok {
+		t.Error("lookup z should miss")
+	}
+}
+
+func TestConvertDomainData(t *testing.T) {
+	// a -> b (MapIndex 1 points at entry "b"); no conversion (ConvertIndex 0).
+	fm := []FeederMap{
+		{Name: "a", MapIndex: 1, ConvertIndex: 0, Datatype: 0},
+		{Name: "b", MapIndex: 0, ConvertIndex: 0, Datatype: 0},
+	}
+	out := convertDomainData(true, DomainData{Name: "a", Value: "5"}, fm)
+	if out.Name != "b" || out.Value != "5" {
+		t.Errorf("convertDomainData = %+v; want b/5", out)
+	}
+	// name not in map.
+	if out := convertDomainData(true, DomainData{Name: "zzz"}, fm); out.Name != "" {
+		t.Errorf("missing name = %+v; want empty", out)
+	}
+	// MapIndex out of range.
+	bad := []FeederMap{{Name: "a", MapIndex: 99}}
+	if out := convertDomainData(true, DomainData{Name: "a"}, bad); out.Name != "" {
+		t.Errorf("bad MapIndex = %+v; want empty", out)
+	}
+}
+
+// ── binary file readers ───────────────────────────────────────────────────────
+
+func TestReadFeederMap(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "map.cvt")
+	var data []byte
+	data = append(data, cvtElement(1, "Vehicle.Speed", 0, 1, 0)...)
+	data = append(data, cvtElement(0, "Can.Spd", 0, 1, 0)...)
+	if err := os.WriteFile(p, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	fm := readFeederMap(p)
+	if len(fm) != 2 {
+		t.Fatalf("readFeederMap len=%d; want 2", len(fm))
+	}
+	// sorted by Name: Can.Spd before Vehicle.Speed.
+	if fm[0].Name != "Can.Spd" || fm[1].Name != "Vehicle.Speed" {
+		t.Fatalf("readFeederMap names = %q,%q; want sorted", fm[0].Name, fm[1].Name)
+	}
+	if fm[1].MapIndex != 1 || fm[1].Datatype != 1 {
+		t.Errorf("Vehicle.Speed entry = %+v; want MapIndex 1, Datatype 1", fm[1])
+	}
+
+	if readFeederMap(filepath.Join(dir, "missing.cvt")) != nil {
+		t.Error("missing map file should return nil")
+	}
+
+	// Truncated element (only a partial header) -> readElement stops cleanly.
+	tp := filepath.Join(dir, "trunc.cvt")
+	os.WriteFile(tp, []byte{0x01}, 0644)
+	if got := readFeederMap(tp); len(got) != 0 {
+		t.Errorf("truncated file = %+v; want empty", got)
+	}
+}
+
+func TestReadscalingDataList(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "scl.json")
+	os.WriteFile(p, []byte(`["{\"LOW\":\"0\"}","[2, 1]"]`), 0644)
+	got := readscalingDataList(p)
+	if len(got) != 2 {
+		t.Fatalf("readscalingDataList len=%d; want 2", len(got))
+	}
+	if readscalingDataList(filepath.Join(dir, "missing.json")) != nil {
+		t.Error("missing scaling file should return nil")
+	}
+	bad := filepath.Join(dir, "bad.json")
+	os.WriteFile(bad, []byte(`not json`), 0644)
+	if readscalingDataList(bad) != nil {
+		t.Error("bad json scaling file should return nil")
+	}
+}

--- a/feeder/feeder-evic/evicSim/evicSim_readbytes_test.go
+++ b/feeder/feeder-evic/evicSim/evicSim_readbytes_test.go
@@ -1,0 +1,33 @@
+/**
+* (C) 2026 Matt Jones
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE file in this repository.
+**/
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadBytes_EvicSim(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "b.bin")
+	if err := os.WriteFile(p, []byte{0x01, 0x02, 0x03, 0x04}, 0644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	got := readBytes(2, f)
+	if len(got) != 2 || got[0] != 0x01 || got[1] != 0x02 {
+		t.Errorf("readBytes(2) = %v; want [1 2]", got)
+	}
+	if readBytes(0, f) != nil {
+		t.Error("readBytes(0) should return nil")
+	}
+}

--- a/feeder/feeder-rl/feeder-rl_conv_test.go
+++ b/feeder/feeder-rl/feeder-rl_conv_test.go
@@ -1,0 +1,160 @@
+/**
+* (C) 2026 Matt Jones
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE file in this repository.
+*
+* Unit tests for the RemotiveLabs feeder's pure helpers: message
+* (de)composition, the feeder-map reader, domain mapping/conversion, the
+* simulation value helpers, and channel-data formatting. The redis / UDS /
+* RemotiveLabs-broker / interface-manager goroutines and main() are
+* integration-only.
+**/
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/covesa/vissr/utils"
+)
+
+func TestMain(m *testing.M) {
+	utils.InitLog("feeder-rl-test.log", os.TempDir(), false, "error")
+	os.Exit(m.Run())
+}
+
+func TestMapString(t *testing.T) {
+	m := map[string]interface{}{"s": "v", "n": nil, "i": 7}
+	if v, ok := mapString(m, "s"); !ok || v != "v" {
+		t.Errorf("mapString(s) = %q,%v; want v,true", v, ok)
+	}
+	for _, k := range []string{"absent", "n", "i"} {
+		if _, ok := mapString(m, k); ok {
+			t.Errorf("mapString(%s) ok=true; want false", k)
+		}
+	}
+}
+
+func TestMarshalDatapointJSON(t *testing.T) {
+	got, err := marshalDatapointJSON(`5"6`, "T")
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	// encoding/json escapes the embedded quote so the result stays valid JSON.
+	if !strings.Contains(got, `\"`) || !strings.Contains(got, `"ts":"T"`) {
+		t.Errorf("marshalDatapointJSON = %q; want escaped value + ts", got)
+	}
+}
+
+func TestReadFeederMap(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "map.json")
+	os.WriteFile(p, []byte(`[{"vssdata":"Vehicle.Speed","vehicledata":"Spd"}]`), 0644)
+	fm := readFeederMap(p)
+	if len(fm) != 1 || fm[0].VssName != "Vehicle.Speed" || fm[0].VehicleName != "Spd" {
+		t.Fatalf("readFeederMap = %+v; want one Vehicle.Speed/Spd entry", fm)
+	}
+
+	empty := filepath.Join(dir, "empty.json")
+	os.WriteFile(empty, []byte(`[]`), 0644)
+	if got := readFeederMap(empty); len(got) != 0 {
+		t.Errorf("empty map = %+v; want 0 entries (no panic)", got)
+	}
+	if readFeederMap(filepath.Join(dir, "missing.json")) != nil {
+		t.Error("missing file should return nil")
+	}
+	bad := filepath.Join(dir, "bad.json")
+	os.WriteFile(bad, []byte(`not json`), 0644)
+	if readFeederMap(bad) != nil {
+		t.Error("bad json should return nil")
+	}
+}
+
+func TestSplitToDomainDataAndTs(t *testing.T) {
+	d, ts, ok := splitToDomainDataAndTs(`{"path":"X","dp":{"value":"5","ts":"T"}}`)
+	if !ok || d.Name != "X" || d.Value != "5" || ts != "T" {
+		t.Fatalf("got %+v,%q,%v; want X/5,T,true", d, ts, ok)
+	}
+	for _, bad := range []string{
+		`not json`,
+		`{"dp":{"value":"5","ts":"T"}}`,   // missing path
+		`{"path":"X"}`,                    // missing dp
+		`{"path":"X","dp":{"ts":"T"}}`,    // missing value
+		`{"path":"X","dp":{"value":"5"}}`, // missing ts
+	} {
+		if _, _, ok := splitToDomainDataAndTs(bad); ok {
+			t.Errorf("splitToDomainDataAndTs(%s) ok=true; want false", bad)
+		}
+	}
+}
+
+func TestCalcInputValue(t *testing.T) {
+	if got := calcInputValue(0, "100"); got != "90" { // 100 - 10 + 0
+		t.Errorf("calcInputValue(0,100) = %q; want 90", got)
+	}
+	if got := calcInputValue(5, "100"); got != "95" { // 100 - 10 + 5
+		t.Errorf("calcInputValue(5,100) = %q; want 95", got)
+	}
+	// Non-integer setValue logs an error and treats setVal as 0.
+	if got := calcInputValue(0, "xx"); got != "-10" {
+		t.Errorf("calcInputValue(0,xx) = %q; want -10", got)
+	}
+}
+
+func TestSelectRandomInput(t *testing.T) {
+	if d := selectRandomInput(nil); d.Name != "" {
+		t.Errorf("selectRandomInput(nil) = %+v; want empty (no rand.Intn(0) panic)", d)
+	}
+	fm := []FeederMap{{VssName: "Vehicle.Speed", VehicleName: "Spd"}}
+	d := selectRandomInput(fm)
+	if d.Name != "Spd" {
+		t.Errorf("selectRandomInput = %+v; want VehicleName Spd", d)
+	}
+}
+
+func TestSearchMapAndConvert(t *testing.T) {
+	fm := []FeederMap{{VssName: "Vehicle.Speed", VehicleName: "Spd"}}
+	if got := searchMap(fm, "VSS", "Vehicle.Speed"); got != "Spd" {
+		t.Errorf("searchMap VSS = %q; want Spd", got)
+	}
+	if got := searchMap(fm, "Vehicle", "Spd"); got != "Vehicle.Speed" {
+		t.Errorf("searchMap Vehicle = %q; want Vehicle.Speed", got)
+	}
+	if got := searchMap(fm, "VSS", "nope"); got != "" {
+		t.Errorf("searchMap miss = %q; want empty", got)
+	}
+
+	out := convertDomainData("VSS", DomainData{Name: "Vehicle.Speed", Value: "5"}, fm)
+	if out.Name != "Spd" || out.Value != "5" {
+		t.Errorf("convertDomainData = %+v; want Spd/5", out)
+	}
+	// Unmapped name returns the input unchanged (not an empty-name datapoint).
+	in := DomainData{Name: "Unmapped", Value: "9"}
+	if out := convertDomainData("VSS", in, fm); out != in {
+		t.Errorf("convertDomainData(unmapped) = %+v; want the input unchanged", out)
+	}
+	if got := convertValue("passthru"); got != "passthru" {
+		t.Errorf("convertValue = %q; want passthru", got)
+	}
+}
+
+func TestCovertChannelDataToString(t *testing.T) {
+	cases := []struct {
+		in   any
+		want string
+	}{
+		{float64(3.5), "3.5"},
+		{int64(42), "42"},
+		{true, "true"},
+		{[]byte("bytes"), "bytes"},
+		{struct{}{}, ""}, // unknown type
+	}
+	for _, c := range cases {
+		if got := covertChannelDataToString(c.in); got != c.want {
+			t.Errorf("covertChannelDataToString(%v) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/feeder/feeder-template/feederv4/feederv4_coverage_test.go
+++ b/feeder/feeder-template/feederv4/feederv4_coverage_test.go
@@ -1,0 +1,225 @@
+/**
+* (C) 2026 Matt Jones
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE file in this repository.
+*
+* Coverage for feederv4's file readers (scaling list, config, binary feeder
+* map), the simulation helpers, notification-list mutation, and the
+* domain-conversion logic. The redis/memcache/sqlite state-storage, the UDS and
+* websocket plumbing, and main() remain integration-only.
+**/
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// feederCvtElement encodes one FeederMap entry in the byte layout readElement
+// expects (matching the Domain Conversion Tool's writeElement).
+func feederCvtElement(mapIndex uint16, name string, typ, datatype uint8, convIdx uint16) []byte {
+	b := []byte{byte(mapIndex & 0xff), byte(mapIndex >> 8)}
+	b = append(b, byte(len(name)))
+	b = append(b, []byte(name)...)
+	b = append(b, typ, datatype)
+	b = append(b, byte(convIdx&0xff), byte(convIdx>>8))
+	return b
+}
+
+func TestReadscalingDataListV4(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "scl.json")
+	os.WriteFile(p, []byte(`["{\"LOW\":\"0\"}","[2, 1]"]`), 0644)
+	if got := readscalingDataList(p); len(got) != 2 {
+		t.Fatalf("readscalingDataList len=%d; want 2", len(got))
+	}
+	if readscalingDataList(filepath.Join(dir, "missing.json")) != nil {
+		t.Error("missing file should return nil")
+	}
+	bad := filepath.Join(dir, "bad.json")
+	os.WriteFile(bad, []byte(`nope`), 0644)
+	if readscalingDataList(bad) != nil {
+		t.Error("bad json should return nil")
+	}
+}
+
+func TestReadFeederConfig(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "cfg.json")
+	os.WriteFile(p, []byte(`{"name":"Vehicle","scope":["Vehicle.Speed"]}`), 0644)
+	cfg := readFeederConfig(p)
+	if cfg.Name != "Vehicle" || cfg.InfoType != "Data" || len(cfg.Scope) != 1 {
+		t.Fatalf("readFeederConfig = %+v; want Name Vehicle, InfoType Data, 1 scope", cfg)
+	}
+	if cfg := readFeederConfig(filepath.Join(dir, "missing.json")); cfg.InfoType != "error" {
+		t.Errorf("missing config InfoType=%q; want error", cfg.InfoType)
+	}
+	bad := filepath.Join(dir, "bad.json")
+	os.WriteFile(bad, []byte(`nope`), 0644)
+	if cfg := readFeederConfig(bad); cfg.InfoType != "error" {
+		t.Errorf("bad config InfoType=%q; want error", cfg.InfoType)
+	}
+}
+
+func TestReadFeederMapV4(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "map.cvt")
+	var data []byte
+	data = append(data, feederCvtElement(1, "Vehicle.Speed", 0, 1, 0)...)
+	data = append(data, feederCvtElement(0, "Can.Spd", 0, 1, 0)...)
+	os.WriteFile(p, data, 0644)
+	fm := readFeederMap(p)
+	if len(fm) != 2 || fm[0].Name != "Can.Spd" || fm[1].Name != "Vehicle.Speed" {
+		t.Fatalf("readFeederMap = %+v; want two sorted entries", fm)
+	}
+	if readFeederMap(filepath.Join(dir, "missing.cvt")) != nil {
+		t.Error("missing map file should return nil")
+	}
+	tp := filepath.Join(dir, "trunc.cvt")
+	os.WriteFile(tp, []byte{0x01}, 0644)
+	if got := readFeederMap(tp); len(got) != 0 {
+		t.Errorf("truncated file = %+v; want empty", got)
+	}
+}
+
+func TestMarshalDatapointJSONV4(t *testing.T) {
+	got, err := marshalDatapointJSON(`5"6`, "T")
+	if err != nil || !strings.Contains(got, `"ts":"T"`) {
+		t.Fatalf("marshalDatapointJSON = %q, err=%v", got, err)
+	}
+}
+
+func TestRemoveNotifications(t *testing.T) {
+	notificationList = nil
+	defer func() { notificationList = nil }()
+	addNotifications([]interface{}{"A", "B", "C", 7 /*non-string skipped*/})
+	if len(notificationList) != 3 {
+		t.Fatalf("addNotifications -> %v; want [A B C]", notificationList)
+	}
+	removeNotifications([]interface{}{"B", "missing", 9})
+	if onNotificationList("B") != -1 || onNotificationList("A") == -1 || onNotificationList("C") == -1 {
+		t.Fatalf("removeNotifications result=%v; want B gone, A and C kept", notificationList)
+	}
+}
+
+func TestGetSimulatorContainer(t *testing.T) {
+	ctx := []ActuatorSimCtx{{Path: "a", RemainingSteps: 3}, {RemainingSteps: 0}}
+	if i := getSimulatorContainer(ctx, "a"); i != 0 {
+		t.Errorf("existing path -> %d; want 0", i)
+	}
+	if i := getSimulatorContainer(ctx, "new"); i != 1 {
+		t.Errorf("free slot -> %d; want 1", i)
+	}
+	full := []ActuatorSimCtx{{Path: "a", RemainingSteps: 3}}
+	if i := getSimulatorContainer(full, "new"); i != -1 {
+		t.Errorf("full -> %d; want -1", i)
+	}
+}
+
+func TestCalculateSimValue(t *testing.T) {
+	intCtx := &ActuatorSimCtx{RemainingSteps: 2, CurrVal: "0", EndVal: "10"}
+	if got := calculateSimValue(intCtx); got != "5" { // step (10-0)/2
+		t.Errorf("int step = %q; want 5", got)
+	}
+	floatCtx := &ActuatorSimCtx{RemainingSteps: 2, CurrVal: "0", EndVal: "10.5"}
+	if got := calculateSimValue(floatCtx); got == "" {
+		t.Errorf("float step returned empty")
+	}
+	badCtx := &ActuatorSimCtx{RemainingSteps: 2, CurrVal: "0", EndVal: "abc"}
+	if got := calculateSimValue(badCtx); got != "abc" || badCtx.RemainingSteps != 0 {
+		t.Errorf("bad endval = %q, steps=%d; want abc/0", got, badCtx.RemainingSteps)
+	}
+}
+
+func TestSelectRandomInputAndIndex(t *testing.T) {
+	if i := getRandomVssfMapIndex(nil); i != -1 {
+		t.Errorf("empty map index = %d; want -1", i)
+	}
+	if i := getRandomVssfMapIndex([]FeederMap{{Name: "a.b"}}); i != -1 {
+		t.Errorf("all-dotted index = %d; want -1", i)
+	}
+	leaf := []FeederMap{{Name: "Speed", Datatype: 0}}
+	if i := getRandomVssfMapIndex(leaf); i != 0 {
+		t.Errorf("leaf index = %d; want 0", i)
+	}
+	if d := selectRandomInput(nil); d.Name != "" {
+		t.Errorf("selectRandomInput(nil) = %+v; want empty", d)
+	}
+	if d := selectRandomInput(leaf); d.Name != "Speed" {
+		t.Errorf("selectRandomInput = %+v; want Name Speed", d)
+	}
+}
+
+func TestSimulatedDataLifecycle(t *testing.T) {
+	tripData = nil
+	defer func() { tripData = nil }()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "trip.json")
+	os.WriteFile(p, []byte(`[{"path":"X","dp":[{"ts":"t1","value":"1"},{"ts":"t2","value":"2"}]}]`), 0644)
+
+	if got := readSimulatedData(p); len(got) != 1 {
+		t.Fatalf("readSimulatedData len=%d; want 1", len(got))
+	}
+	if dps := getSimulatedDataPoints(0); len(dps) != 1 || dps[0].Value != "1" {
+		t.Fatalf("getSimulatedDataPoints(0) = %+v; want X/1", dps)
+	}
+	if dps := getSimulatedDataPoints(5); len(dps) != 0 { // out of range -> skipped
+		t.Errorf("getSimulatedDataPoints(5) = %+v; want empty", dps)
+	}
+	if incDpIndex(0) != 1 || incDpIndex(1) != 0 { // wraps at len 2
+		t.Errorf("incDpIndex wrap incorrect")
+	}
+
+	if readSimulatedData(filepath.Join(dir, "missing.json")) != nil {
+		t.Error("missing trip file should return nil")
+	}
+}
+
+func TestConvertDomainDataV4(t *testing.T) {
+	scalingDataList = nil
+	defer func() { scalingDataList = nil }()
+	fm := []FeederMap{
+		{Name: "a", MapIndex: 1, ConvertIndex: 0, Datatype: 0},
+		{Name: "b", MapIndex: 0, ConvertIndex: 0, Datatype: 0},
+	}
+	if out := convertDomainData(true, DomainData{Name: "a", Value: "5"}, fm); out.Name != "b" || out.Value != "5" {
+		t.Errorf("convertDomainData = %+v; want b/5", out)
+	}
+	// Unmapped name -> input returned unchanged.
+	in := DomainData{Name: "zzz", Value: "1"}
+	if out := convertDomainData(true, in, fm); out != in {
+		t.Errorf("unmapped = %+v; want input unchanged", out)
+	}
+	// Empty map -> input.
+	if out := convertDomainData(true, in, nil); out != in {
+		t.Errorf("empty map = %+v; want input", out)
+	}
+	// MapIndex out of range -> input.
+	oob := []FeederMap{{Name: "a", MapIndex: 99}}
+	if out := convertDomainData(true, DomainData{Name: "a"}, oob); out.Name != "a" {
+		t.Errorf("oob MapIndex = %+v; want input", out)
+	}
+}
+
+func TestConvertValueV4(t *testing.T) {
+	if got := convertValue("9", 0, 0, 0, true); got != "9" {
+		t.Errorf("no-conv = %q; want 9", got)
+	}
+	scalingDataList = []string{`{"LOW":"0"}`, `[2, 1]`, `bad`}
+	defer func() { scalingDataList = nil }()
+	if got := convertValue("LOW", 1, 0, 0, true); got != "0" {
+		t.Errorf("enum = %q; want 0", got)
+	}
+	if got := convertValue("3", 2, 0, 0, true); got != "7" { // 2*3+1
+		t.Errorf("linear = %q; want 7", got)
+	}
+	if got := convertValue("1", 99, 0, 0, true); got != "" {
+		t.Errorf("oob index = %q; want empty", got)
+	}
+	if got := convertValue("1", 3, 0, 0, true); got != "" { // bad json entry
+		t.Errorf("bad json = %q; want empty", got)
+	}
+}

--- a/server/vissv2server/atServer/ecfSim/ecfSim_dispatch_test.go
+++ b/server/vissv2server/atServer/ecfSim/ecfSim_dispatch_test.go
@@ -1,0 +1,56 @@
+/**
+* (C) 2026 Matt Jones
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE file in this repository.
+*
+* Tests for the stdin-driven prepareCancelRequest and the dispatchResponse
+* channel writer. The websocket client/receiver goroutines, the interactive
+* uiDialogue loop, and main() are integration-only.
+**/
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// withStdin feeds input to os.Stdin while fn runs (for fmt.Scanf prompts).
+func withStdin(t *testing.T, input string, fn func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = old }()
+	go func() { w.WriteString(input); w.Close() }()
+	fn()
+}
+
+func TestPrepareCancelRequest(t *testing.T) {
+	var got bool
+	withStdin(t, "yes\n", func() { got = prepareCancelRequest(`{"action":"x"}`) })
+	if !got {
+		t.Error(`prepareCancelRequest with "yes" = false; want true`)
+	}
+	withStdin(t, "no\n", func() { got = prepareCancelRequest(`{"action":"x"}`) })
+	if got {
+		t.Error(`prepareCancelRequest with "no" = true; want false`)
+	}
+}
+
+func TestDispatchResponse(t *testing.T) {
+	sendChan := make(chan string, 1)
+	dispatchResponse(`{"action":"get","messageId":"7"}`, sendChan)
+	select {
+	case resp := <-sendChan:
+		if !strings.Contains(resp, `"action":"get"`) {
+			t.Errorf("dispatchResponse sent %q; want it to echo action get", resp)
+		}
+	default:
+		t.Fatal("dispatchResponse did not send a response")
+	}
+}

--- a/tools/DomainConversionTool/DomainConversionTool.go
+++ b/tools/DomainConversionTool/DomainConversionTool.go
@@ -192,6 +192,10 @@ func getInternalToolNbdTableNames() (string, string) {
 		fmt.Printf("getInternalToolNbdTableNames: SQL query error=%s\n", err)
 		return "", ""
 	}
+	// defer Close so the connection is released on every path; the previous
+	// code leaked rows on the scan-error return, which held a read lock and
+	// could block a following write (SQLITE_BUSY).
+	defer rows.Close()
 	var nbdTableName string
 	var sbdTableName string
 
@@ -201,7 +205,6 @@ func getInternalToolNbdTableNames() (string, string) {
 		fmt.Printf("getInternalToolNbdTableNames: SQL result scan error=%s\n", err)
 		return "", ""
 	}
-	rows.Close()
 	return nbdTableName, sbdTableName
 }
 
@@ -573,6 +576,7 @@ func getDomainData(tbl string, signalName string) ToolConversionData {
 		fmt.Printf("getDomainData: SQL query error=%s\n", err)
 		return data
 	}
+	defer rows.Close() // release the connection on every path (was leaked on scan error)
 
 	rows.Next()
 	err = rows.Scan(&(data.Name), &(data.Type), &(data.Datatype), &(data.Unit), &(data.EnumValues))
@@ -580,7 +584,6 @@ func getDomainData(tbl string, signalName string) ToolConversionData {
 		fmt.Printf("getDomainData: SQL result scan error=%s\n", err)
 		return data
 	}
-	rows.Close()
 	return data
 }
 
@@ -938,6 +941,7 @@ func readMapElementDatamodel(nbd string, mapSignalName string) DomainData {
 		fmt.Printf("readMapElementDatamodel: SQL query error=%s\n", err)
 		return (DomainData{})
 	}
+	defer rows.Close() // release the connection on every path (was leaked on scan error)
 
 	rows.Next()
 	var node DomainData
@@ -947,7 +951,6 @@ func readMapElementDatamodel(nbd string, mapSignalName string) DomainData {
 		fmt.Printf("readMapElementDatamodel: SQL result scan error=%s\n", err)
 		return (DomainData{})
 	}
-	rows.Close()
 	return node
 }
 
@@ -958,6 +961,7 @@ func readDomainDatamodel(nbd string) []DomainData {
 		fmt.Printf("readDomainDatamodel: SQL query error=%s\n", err)
 		return nil
 	}
+	defer rows.Close() // release the connection on every path (was leaked on scan error)
 	var nodeArray []DomainData
 
 	for rows.Next() {
@@ -970,7 +974,6 @@ func readDomainDatamodel(nbd string) []DomainData {
 		}
 		nodeArray = append(nodeArray, node)
 	}
-	rows.Close()
 	return nodeArray
 }
 

--- a/tools/DomainConversionTool/DomainConversionTool_db_test.go
+++ b/tools/DomainConversionTool/DomainConversionTool_db_test.go
@@ -1,0 +1,362 @@
+/**
+* (C) 2026 Matt Jones
+*
+* All files and artifacts in the repository at https://github.com/covesa/vissr
+* are licensed under the provisions of the license provided by the LICENSE file in this repository.
+*
+* DB-backed and file-IO tests for DomainConversionTool. These drive the
+* functions the original test file documented as "integration-only" by giving
+* them what they actually need: a real (temporary, file-backed) sqlite database
+* assigned to the package global, temp YAML fixtures, redirected stdin for the
+* interactive Scanf prompts, and a temp working directory for the generated
+* artefact files.
+**/
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newToolDB points the package-global db at a fresh temp sqlite file and
+// creates the standard tables (exercises initDb + createTables + the table
+// creators + initializeInternalToolTable).
+func newToolDB(t *testing.T) {
+	t.Helper()
+	dbFile := filepath.Join(t.TempDir(), "dct.db")
+	db = initDb(dbFile, db)
+	// NB: deliberately not capping MaxOpenConns to 1 — several query helpers
+	// leak an open *Rows on their error path (no rows.Close before return), so
+	// a single-connection pool would deadlock the next statement.
+	t.Cleanup(func() {
+		if db != nil {
+			db.Close()
+			db = nil
+		}
+	})
+}
+
+// resetGlobals clears the mutable package globals so tests don't bleed into
+// each other.
+func resetGlobals() {
+	scaleDataList = nil
+	unitScaleList = nil
+	branchPathList = nil
+	domainData = nil
+}
+
+// inTempDir switches into a fresh temp working directory for the duration of a
+// test (the file-writing functions emit artefacts into the cwd).
+func inTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(old) })
+	return dir
+}
+
+// withStdin feeds input to os.Stdin while fn runs (for the fmt.Scanf prompts).
+func withStdin(t *testing.T, input string, fn func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = old }()
+	go func() {
+		w.WriteString(input)
+		w.Close()
+	}()
+	fn()
+}
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+const domainYaml = `Domain: NorthDom
+VehicleA:
+  type: branch
+  description: A branch
+VehicleA.Speed:
+  type: sensor
+  datatype: uint16
+  unit: km/h
+  min: 0
+  max: 300
+  description: Vehicle speed
+VehicleA.Mode:
+  type: actuator
+  datatype: string
+  allowed:
+    - 'LOW'
+    - 'HIGH'
+  description: Drive mode
+`
+
+// ── initDb / createTables / InternalTool round-trip ───────────────────────────
+
+func TestInitDbCreatesTablesAndInternalTool(t *testing.T) {
+	resetGlobals()
+	newToolDB(t)
+
+	// Fresh InternalTool row has NULL nbd/sbd names -> scan-error branch -> "","".
+	if nbd, sbd := getInternalToolNbdTableNames(); nbd != "" || sbd != "" {
+		t.Errorf("fresh InternalTool names = %q/%q; want empty/empty", nbd, sbd)
+	}
+
+	updateInternalToolTableNames("NorthDom", "SouthDom")
+	if nbd, sbd := getInternalToolNbdTableNames(); nbd != "NorthDom" || sbd != "SouthDom" {
+		t.Errorf("after update = %q/%q; want NorthDom/SouthDom", nbd, sbd)
+	}
+}
+
+// ── domain table lifecycle + row read-back ────────────────────────────────────
+
+func TestDomainTableLifecycle(t *testing.T) {
+	resetGlobals()
+	newToolDB(t)
+
+	createDomainTableIfNotExist(db, "NorthDom")
+	createDomainTableIfNotExist(db, "NorthDom") // idempotent (already exists)
+
+	if !checkThisTable(db, "NorthDom") {
+		t.Fatal("checkThisTable: NorthDom should exist after creation")
+	}
+	if checkThisTable(db, "Nope") {
+		t.Error("checkThisTable: nonexistent table should be false")
+	}
+	if names := getDomainTableNames(); !domainTable(names, "NorthDom") {
+		t.Fatalf("getDomainTableNames=%v; want it to include NorthDom", names)
+	}
+
+	row := DomainData{Path: "VehicleA.Speed", Type: "sensor", Datatype: "uint16", Unit: "km/h",
+		Min: "0", Max: "300", Description: "Vehicle speed"}
+	insertTableRow(row, "NorthDom")
+
+	got := getDomainData("NorthDom", "VehicleA.Speed")
+	if got.Name != "VehicleA.Speed" || got.Datatype != "uint16" || got.Unit != "km/h" {
+		t.Fatalf("getDomainData = %+v; want the inserted row", got)
+	}
+	if missing := getDomainData("NorthDom", "Nope"); missing.Name != "" {
+		t.Errorf("getDomainData(missing) = %+v; want empty", missing)
+	}
+
+	if model := readDomainDatamodel("NorthDom"); len(model) != 1 || model[0].Path != "VehicleA.Speed" {
+		t.Fatalf("readDomainDatamodel = %+v; want one VehicleA.Speed node", model)
+	}
+	if node := readMapElementDatamodel("NorthDom", "VehicleA.Speed"); node.Path != "VehicleA.Speed" {
+		t.Fatalf("readMapElementDatamodel = %+v; want VehicleA.Speed", node)
+	}
+}
+
+// ── populateTable (stdin-driven) imports a YAML domain into the DB ─────────────
+
+func TestPopulateTableFromYaml(t *testing.T) {
+	resetGlobals()
+	dir := inTempDir(t)
+	newToolDB(t)
+
+	yamlPath := writeFile(t, dir, "north.yaml", domainYaml)
+	withStdin(t, yamlPath+"\n", func() { populateTable() })
+
+	names := getDomainTableNames()
+	if !domainTable(names, "NorthDom") {
+		t.Fatalf("populateTable did not create NorthDom; tables=%v", names)
+	}
+	speed := getDomainData("NorthDom", "VehicleA.Speed")
+	if speed.Name != "VehicleA.Speed" || speed.Datatype != "uint16" {
+		t.Fatalf("imported VehicleA.Speed = %+v; want datatype uint16", speed)
+	}
+	mode := getDomainData("NorthDom", "VehicleA.Mode")
+	if mode.Name != "VehicleA.Mode" || mode.EnumValues == "" {
+		t.Fatalf("imported VehicleA.Mode = %+v; want non-empty enumValues", mode)
+	}
+
+	// showDomains just prints; call it for coverage (it must not panic).
+	showDomains()
+}
+
+// ── unit-scale + signal-mapping file readers ──────────────────────────────────
+
+func TestReadUnitScaleData(t *testing.T) {
+	resetGlobals()
+	dir := t.TempDir()
+	p := writeFile(t, dir, "UnitScaling.yaml", `coefficients:
+  - unit1: km/h
+    unit2: m/s
+    A: 0.2777
+    B: 0
+  - unit1: celsius
+    unit2: kelvin
+    A: 1
+    B: 273.15
+`)
+	readUnitScaleData(p)
+	if len(unitScaleList) < 2 {
+		t.Fatalf("unitScaleList=%d; want at least 2 entries", len(unitScaleList))
+	}
+	readUnitScaleData(filepath.Join(dir, "missing.yaml")) // missing-file branch (no panic)
+}
+
+func TestReadSignalMappingFile(t *testing.T) {
+	resetGlobals()
+	dir := t.TempDir()
+	p := writeFile(t, dir, "map.yaml", `# a comment
+NorthBoundDomain: NorthDom
+SouthBoundDomain: SouthDom
+Mapping:
+  - North: VehicleA.Speed
+    South: Can.Spd
+  - North: VehicleA.Mode
+    South: Can.Mode
+`)
+	nbd, sbd, list := readSignalMappingFile(p)
+	if nbd != "NorthDom" || sbd != "SouthDom" {
+		t.Fatalf("nbd/sbd = %q/%q; want NorthDom/SouthDom", nbd, sbd)
+	}
+	if len(list) != 2 || list[0].North != "VehicleA.Speed" || list[0].South != "Can.Spd" {
+		t.Fatalf("mapping list = %+v; want two entries", list)
+	}
+	if n, _, _ := readSignalMappingFile(filepath.Join(dir, "missing.yaml")); n != "" {
+		t.Errorf("missing mapping file should yield empty nbd; got %q", n)
+	}
+}
+
+// ── enum + linear conversion type selection ───────────────────────────────────
+
+func TestGetConversionTypeForEnum(t *testing.T) {
+	resetGlobals()
+	// Matched lengths -> new scale entry index 0.
+	if idx := getConversionTypeForEnum(`["LOW","HIGH"]`, `["0","1"]`); idx != 0 {
+		t.Fatalf("first enum mapping index=%d; want 0", idx)
+	}
+	// Same mapping again -> reused index 0.
+	if idx := getConversionTypeForEnum(`["LOW","HIGH"]`, `["0","1"]`); idx != 0 {
+		t.Fatalf("repeat enum mapping index=%d; want reused 0", idx)
+	}
+	// Mismatched lengths -> error sentinel.
+	if idx := getConversionTypeForEnum(`["LOW"]`, `["0","1"]`); idx != 65535-2 {
+		t.Errorf("mismatched enum index=%d; want 65533", idx)
+	}
+}
+
+func TestGetConversionTypeForLinear(t *testing.T) {
+	resetGlobals()
+	unitScaleList = []UnitScaleElem{{Unit1: "km/h", Unit2: "m/s", A: "0.2777", B: "0"}}
+	if idx := getConversionTypeForLinear("km/h", "m/s"); idx != 0 {
+		t.Fatalf("forward linear index=%d; want 0", idx)
+	}
+	// Inverse direction triggers the coefficient-inversion branch and a new entry.
+	if idx := getConversionTypeForLinear("m/s", "km/h"); idx != 1 {
+		t.Fatalf("inverse linear index=%d; want 1", idx)
+	}
+	// Unknown pair -> error sentinel.
+	if idx := getConversionTypeForLinear("foo", "bar"); idx != 65535-2 {
+		t.Errorf("unknown linear index=%d; want 65533", idx)
+	}
+}
+
+// ── full conversion build: createConversionTable + createConversionFiles ───────
+
+func TestConversionBuildEndToEnd(t *testing.T) {
+	resetGlobals()
+	dir := inTempDir(t)
+	newToolDB(t)
+
+	// Two domain tables with one mapped signal pair (differing units -> linear).
+	createDomainTable(db, "NorthDom")
+	createDomainTable(db, "SouthDom")
+	insertTableRow(DomainData{Path: "VehicleA.Speed", Type: "sensor", Datatype: "uint16", Unit: "km/h", Description: "n"}, "NorthDom")
+	insertTableRow(DomainData{Path: "Can.Spd", Type: "sensor", Datatype: "uint16", Unit: "m/s", Description: "s"}, "SouthDom")
+	unitScaleList = []UnitScaleElem{{Unit1: "km/h", Unit2: "m/s", A: "0.2777", B: "0"}}
+
+	mapPath := writeFile(t, dir, "map.yaml", `NorthBoundDomain: NorthDom
+SouthBoundDomain: SouthDom
+Mapping:
+  - North: VehicleA.Speed
+    South: Can.Spd
+`)
+	withStdin(t, mapPath+"\n", func() { createConversionTable() })
+
+	// ConversionPreparation now holds the two feeder rows; build the .cvt + files.
+	createConversionFiles()
+
+	// Artefacts land in the cwd (temp dir).
+	if matches, _ := filepath.Glob(filepath.Join(dir, "*.cvt")); len(matches) == 0 {
+		t.Error("createConversionFiles did not produce a .cvt file")
+	}
+	if matches, _ := filepath.Glob(filepath.Join(dir, "Scaling-*.json")); len(matches) == 0 {
+		t.Error("createConversionTable did not produce a Scaling json file")
+	}
+	if matches, _ := filepath.Glob(filepath.Join(dir, "Datamodel-*.yaml")); len(matches) == 0 {
+		t.Error("createConversionTable did not produce a Datamodel yaml file")
+	}
+}
+
+// ── createDomainDatamodel (stdin-driven) writes a VSS YAML tree ────────────────
+
+func TestCreateDomainDatamodelWritesYaml(t *testing.T) {
+	resetGlobals()
+	dir := inTempDir(t)
+	newToolDB(t)
+
+	createDomainTable(db, "NorthDom")
+	insertTableRow(DomainData{Path: "VehicleA.Speed", Type: "sensor", Datatype: "uint16", Unit: "km/h",
+		Min: "0", Max: "300", Default: "0", Description: "Speed"}, "NorthDom")
+	insertTableRow(DomainData{Path: "VehicleA.Mode", Type: "actuator", Datatype: "string",
+		EnumValues: `["LOW","HIGH"]`, Default: `["LOW"]`, Description: "Mode"}, "NorthDom")
+
+	// domain name, then tree-content selection.
+	withStdin(t, "NorthDom\ncomplete\n", func() { createDomainDatamodel() })
+
+	if matches, _ := filepath.Glob(filepath.Join(dir, "Datamodel-NorthDom.yaml")); len(matches) == 0 {
+		t.Fatal("createDomainDatamodel did not produce Datamodel-NorthDom.yaml")
+	}
+}
+
+// ── low-level writers / serialisers ───────────────────────────────────────────
+
+func TestWriteArrayAndScaleArtefacts(t *testing.T) {
+	resetGlobals()
+	dir := inTempDir(t)
+
+	feederMap := []FeederConversionData{
+		{MapIndex: 0, Name: "a", Type: 0, Datatype: 1, ConvertIndex: 0},
+		{MapIndex: 0, Name: "b", Type: 0, Datatype: 1, ConvertIndex: 0},
+	}
+	reorderMapIndex(feederMap) // pairs index 0<->1
+	printArray(feederMap)      // stdout only; must not panic
+	writeArrayToFile(feederMap, "out.cvt")
+	if !fileExists(filepath.Join(dir, "out.cvt")) {
+		t.Error("writeArrayToFile did not create out.cvt")
+	}
+
+	scaleDataList = []string{`{"LOW":"0", "HIGH":"1"}`, `[0.2777, 0]`}
+	writescaleDataList("NorthDom", "SouthDom")
+	if !fileExists(filepath.Join(dir, "Scaling-NorthDom-SouthDom.json")) {
+		t.Error("writescaleDataList did not create the scaling json")
+	}
+}
+
+func TestGetCorrespondingIndexNotFound(t *testing.T) {
+	resetGlobals()
+	feederMap := []FeederConversionData{{MapIndex: 7, Name: "only"}}
+	if got := getCorrespondingIndex(0, 7, feederMap); got != MAXUINT16 {
+		t.Errorf("getCorrespondingIndex with no partner = %d; want MAXUINT16", got)
+	}
+}

--- a/tools/DomainConversionTool/DomainConversionTool_test.go
+++ b/tools/DomainConversionTool/DomainConversionTool_test.go
@@ -389,27 +389,11 @@ func TestInBranchList_AddAndFind(t *testing.T) {
 	branchPathList = nil // clean up
 }
 
-// Integration-only functions — NOT unit-tested here:
+// The DB-backed, file-IO and stdin-driven functions formerly listed here as
+// "integration-only" are now exercised in DomainConversionTool_db_test.go,
+// which gives them a temporary file-backed sqlite database, temp YAML
+// fixtures, redirected stdin for the Scanf prompts, and a temp working
+// directory for the generated artefacts.
 //
-//   initDb                   — opens a real sqlite3 file
-//   createTables             — requires *sql.DB
-//   createConversionDataTable — requires *sql.DB
-//   createInternalToolTable  — requires *sql.DB
-//   initializeInternalToolTable — requires *sql.DB
-//   checkThisTable           — requires *sql.DB
-//   getDomainTableNames      — requires global db
-//   getInternalToolNbdTableNames — requires global db
-//   updateInternalToolTableNames — requires global db
-//   insertTableRow           — requires global db
-//   insertFeederData         — requires global db
-//   getDomainData            — requires global db
-//   createDomainTable        — requires global db
-//   populateTable            — reads stdin + db
-//   createConversionTable    — reads stdin + db
-//   createDomainDatamodel    — reads stdin + db
-//   showDomains              — requires global db
-//   createConversionFiles    — requires global db
-//   writescaleDataList       — writes to filesystem (output artefact)
-//   readUnitScaleData        — reads an external YAML file
-//   readSignalMappingFile    — reads an external YAML file
-//   main                     — interactive CLI
+// The only remaining untested function is:
+//   main — the interactive argparse command loop (genuine CLI entry point).


### PR DESCRIPTION
Coverage-maximisation pass across packages that were below target, using tier-1
unit tests and tier-2 real-fixture harnesses (temp sqlite DBs, temp files,
redirected stdin, temp working dirs, httptest sockets where applicable).

Packages are added incrementally as commits on this branch. Each commit notes
the before/after coverage and any bug found while testing.

### DomainConversionTool — 17.1% → 80.0%
The DB query/insert helpers, YAML readers, artefact writers and the stdin-driven
flows (populateTable, createConversionTable, createConversionFiles,
createDomainDatamodel) are now driven with a temp file-backed sqlite DB, temp
YAML fixtures, redirected `os.Stdin`, and a temp working dir. Only the
interactive argparse `main` loop remains uncovered.

**Bug fixed while testing:** `getInternalToolNbdTableNames`, `getDomainData`,
`readMapElementDatamodel`, `readDomainDatamodel` returned on a scan error
without closing their `*Rows`; the leaked read lock could block a following
write with SQLITE_BUSY. Each now defers `rows.Close()`.

(more packages to follow on this branch)

Signed-off-by: Matt Jones <matt@jellybaby.com>