### PR TITLE
fix(vissServiceMgr): cancel/error replies dropped, server hang

### DIFF
--- a/server/vissv2server/vissServiceMgr/vissServiceMgr.go
+++ b/server/vissv2server/vissServiceMgr/vissServiceMgr.go
@@ -261,13 +261,13 @@ func HandleInvoke(requestMap map[string]interface{}, backendChans []chan map[str
 	node := resolveServiceNode(path)
 	if node == nil || utils.VSSgetType(node) != utils.PROCEDURE {
 		sendServiceError(bc, "invoke", requestId, "", StatusFailed,
-			"400", "bad_request", "path must address a procedure node")
+			"400", "bad_request", "path must address a procedure node", requestMap)
 		return
 	}
 
 	inputParams, _ := requestMap["input"].(map[string]interface{})
 	if ok, missingFields := validateInputSignature(node, inputParams); !ok {
-		sendValidationError(bc, "invoke", requestId, missingFields)
+		sendValidationError(bc, "invoke", requestId, missingFields, requestMap)
 		return
 	}
 
@@ -345,7 +345,7 @@ func HandleMonitor(requestMap map[string]interface{}, backendChans []chan map[st
 	node := resolveServiceNode(path)
 	if node == nil || utils.VSSgetType(node) != utils.PROCEDURE {
 		sendServiceError(bc, "monitor", requestId, "", StatusFailed,
-			"400", "bad_request", "path must address a procedure node")
+			"400", "bad_request", "path must address a procedure node", requestMap)
 		return
 	}
 
@@ -415,7 +415,7 @@ func HandleCancel(requestMap map[string]interface{}, backendChan chan map[string
 	serviceId, _ := requestMap["serviceId"].(string)
 	if serviceId == "" {
 		sendServiceError(backendChan, "cancel", "", serviceId, StatusFailed,
-			"400", "bad_request", "serviceId is required for cancel")
+			"400", "bad_request", "serviceId is required for cancel", requestMap)
 		return
 	}
 
@@ -424,7 +424,7 @@ func HandleCancel(requestMap map[string]interface{}, backendChan chan map[string
 	if !ok {
 		mu.Unlock()
 		sendServiceError(backendChan, "cancel", "", serviceId, StatusFailed,
-			"400", "bad_request", "serviceId not found")
+			"400", "bad_request", "serviceId not found", requestMap)
 		return
 	}
 
@@ -488,14 +488,14 @@ func HandleDiscover(requestMap map[string]interface{}, backendChan chan map[stri
 	node := resolveServiceNode(path)
 	if node == nil {
 		sendServiceError(backendChan, "discover", requestId, "", StatusUnknown,
-			"400", "bad_request", "path not found in service tree")
+			"400", "bad_request", "path not found in service tree", requestMap)
 		return
 	}
 
 	nodeType := utils.VSSgetType(node)
 	if nodeType != utils.BRANCH && nodeType != utils.PROCEDURE {
 		sendServiceError(backendChan, "discover", requestId, "", StatusUnknown,
-			"400", "bad_request", "path must address a branch or procedure node")
+			"400", "bad_request", "path must address a branch or procedure node", requestMap)
 		return
 	}
 
@@ -949,8 +949,14 @@ func copyMap(src map[string]interface{}) map[string]interface{} {
 
 // sendValidationError sends a 400 error that lists the missing input field
 // names, providing callers with actionable detail (VISSv3.3 §29).
+//
+// requestMap is the originating request: its RouterId is copied onto the error
+// so the transport manager can route the reply back to the requesting client.
+// Without it the WS/UDS managers recover clientId=-1 and drop the response,
+// wedging the client's synchronous request/response channel.
 func sendValidationError(backendChan chan map[string]interface{},
-	action, requestId string, missingFields []string) {
+	action, requestId string, missingFields []string,
+	requestMap map[string]interface{}) {
 
 	errMap := map[string]interface{}{
 		"action": action,
@@ -966,12 +972,17 @@ func sendValidationError(backendChan chan map[string]interface{},
 	if requestId != "" {
 		errMap["requestId"] = requestId
 	}
+	copyRouteFields(requestMap, errMap)
 	backendChan <- errMap
 }
 
+// sendServiceError sends a structured error response. As with
+// sendValidationError, requestMap supplies the RouterId so the reply can be
+// addressed back to the originating client rather than dropped.
 func sendServiceError(backendChan chan map[string]interface{},
 	action, requestId, serviceId string,
-	status ServiceStatus, errNum, errReason, errDesc string) {
+	status ServiceStatus, errNum, errReason, errDesc string,
+	requestMap map[string]interface{}) {
 
 	errMap := map[string]interface{}{
 		"action": action,
@@ -989,5 +1000,6 @@ func sendServiceError(backendChan chan map[string]interface{},
 	if serviceId != "" {
 		errMap["serviceId"] = serviceId
 	}
+	copyRouteFields(requestMap, errMap)
 	backendChan <- errMap
 }

--- a/server/vissv2server/vissServiceMgr/vissServiceMgr_test.go
+++ b/server/vissv2server/vissServiceMgr/vissServiceMgr_test.go
@@ -254,7 +254,8 @@ func TestHandleInvoke_ResponseHasNoRouterIndex(t *testing.T) {
 
 func TestSendServiceError_RequiredFields(t *testing.T) {
 	ch := make(chan map[string]interface{}, 4)
-	sendServiceError(ch, "invoke", "req-1", "", StatusFailed, "400", "bad_request", "oops")
+	req := map[string]interface{}{"RouterId": "1?0"}
+	sendServiceError(ch, "invoke", "req-1", "", StatusFailed, "400", "bad_request", "oops", req)
 	select {
 	case m := <-ch:
 		if m["action"] != "invoke" {
@@ -272,6 +273,36 @@ func TestSendServiceError_RequiredFields(t *testing.T) {
 		}
 		if m["ts"] == nil {
 			t.Error("ts missing")
+		}
+		// Regression (Issue C): the RouterId must be copied onto the error so the
+		// transport manager can route the reply back; otherwise clientId=-1 and
+		// the response is dropped, wedging the client's synchronous channel.
+		if m["RouterId"] != "1?0" {
+			t.Errorf("RouterId not copied onto error response: %v", m["RouterId"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+// TestSendValidationError_CopiesRouterId is the validation-path half of the
+// Issue C regression: a SET/invoke that fails input validation must still
+// address its error reply back to the originating client.
+func TestSendValidationError_CopiesRouterId(t *testing.T) {
+	ch := make(chan map[string]interface{}, 4)
+	req := map[string]interface{}{"routerId": "2?7"}
+	sendValidationError(ch, "invoke", "req-9", []string{"Position"}, req)
+	select {
+	case m := <-ch:
+		if m["routerId"] != "2?7" {
+			t.Errorf("routerId not copied onto validation error: %v", m["routerId"])
+		}
+		errObj, ok := m["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("missing error object: %v", m)
+		}
+		if fields, ok := errObj["fields"].([]string); !ok || len(fields) != 1 || fields[0] != "Position" {
+			t.Errorf("missing/incorrect fields: %v", errObj["fields"])
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout")
@@ -302,6 +333,63 @@ func TestHandleCancel_UnknownServiceId(t *testing.T) {
 	case m := <-ch:
 		if _, ok := m["error"]; !ok {
 			t.Error("expected error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+// TestHandleCancel_UnknownServiceId_PreservesRouterId reproduces Ulf's hang:
+// a cancel arriving after the invocation has already terminated (timeout) hits
+// the "serviceId not found" error path. Before the fix that error reply carried
+// no RouterId, so wsMgr resolved clientId=-1 and dropped it; because cancel
+// replies ride the synchronous request/response channel, the client blocked
+// forever and the next Get got no answer. The reply must carry the RouterId.
+func TestHandleCancel_UnknownServiceId_PreservesRouterId(t *testing.T) {
+	resetState()
+	ch := make(chan map[string]interface{}, 4)
+	HandleCancel(map[string]interface{}{"serviceId": "608688", "RouterId": "1?0"}, ch)
+	select {
+	case m := <-ch:
+		if m["status"] != string(StatusFailed) {
+			t.Errorf("want FAILED, got %v", m["status"])
+		}
+		if m["RouterId"] != "1?0" {
+			t.Errorf("cancel error dropped RouterId (Issue C): %v", m)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+// TestHandleInvoke_ErrorPathPreservesRouterId guards the invoke/monitor/discover
+// error returns that also go through sendServiceError/sendValidationError.
+func TestHandleInvoke_ErrorPathPreservesRouterId(t *testing.T) {
+	resetState()
+	loadVehicleServiceTree(t)
+	t.Cleanup(stopServiceGoroutines)
+
+	bc := make(chan map[string]interface{}, 4)
+	bcs := []chan map[string]interface{}{bc}
+	// Address a non-procedure node so HandleInvoke takes the error return.
+	req := map[string]interface{}{
+		"action":      "invoke",
+		"path":        "VehicleService.Seating",
+		"requestId":   "8756",
+		"routerIndex": 0,
+		"RouterId":    "1?0",
+	}
+	HandleInvoke(req, bcs)
+	select {
+	case m := <-bc:
+		if _, ok := m["error"]; !ok {
+			t.Fatalf("expected error response, got %v", m)
+		}
+		if m["RouterId"] != "1?0" {
+			t.Errorf("invoke error dropped RouterId (Issue C): %v", m)
+		}
+		if _, leaked := m["routerIndex"]; leaked {
+			t.Errorf("invoke error leaked internal routerIndex: %v", m)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout")
@@ -789,7 +877,7 @@ func TestHandleMonitor_BadRouterIndex_DoesNotPanic(t *testing.T) {
 
 func TestSendValidationError_IncludesFields(t *testing.T) {
 	ch := make(chan map[string]interface{}, 4)
-	sendValidationError(ch, "invoke", "req-v", []string{"SeatId", "Position"})
+	sendValidationError(ch, "invoke", "req-v", []string{"SeatId", "Position"}, nil)
 	select {
 	case m := <-ch:
 		if m["action"] != "invoke" {
@@ -831,7 +919,7 @@ func TestSendValidationError_IncludesFields(t *testing.T) {
 
 func TestSendValidationError_NilFields(t *testing.T) {
 	ch := make(chan map[string]interface{}, 4)
-	sendValidationError(ch, "invoke", "req-nil", nil)
+	sendValidationError(ch, "invoke", "req-nil", nil, nil)
 	select {
 	case m := <-ch:
 		errObj, ok := m["error"].(map[string]interface{})


### PR DESCRIPTION
## Problem (reported by Ulf)

After PR #188 events flow to the client, but issuing a **cancel** after an invoke produced **no response**, and a subsequent **Get never returned** — the server appeared hung.

Server log showed:

```
wsMgr:RemoveRoutingForwardResponse: invalid clientId=-1 (response="{...cancel...serviceId not found...}"); dropping
```

## Root cause

Error and cancel-error responses are forwarded to the client over the **synchronous** request/response transport channel (`wsClientChan` / UDS equivalent). `sendServiceError` and `sendValidationError` built the reply **without copying the request's `RouterId`**, so the WS/UDS managers recovered `clientId=-1` and dropped the response. The client's `forwardWsRequest` then blocked forever on its rendezvous channel, wedging that session — hence the missing cancel reply *and* the hung Get that followed.

This affected every early error return in `HandleInvoke` / `HandleMonitor` / `HandleCancel` / `HandleDiscover`. The success paths already called `copyRouteFields`; the error paths did not. In Ulf's trace the invocation had already terminated on its timeout watchdog, so the late cancel hit the `serviceId not found` branch.

## Fix

Thread the originating `requestMap` into both error senders and copy the `RouterId` onto the error reply. `routerIndex` is still never copied, so the internal channel index is not leaked to clients (the existing `TestHandleInvoke_ResponseHasNoRouterIndex` guard still holds).

## Tests

- `TestSendServiceError_RequiredFields` / `TestSendValidationError_CopiesRouterId` — assert `RouterId` propagation through both senders.
- `TestHandleCancel_UnknownServiceId_PreservesRouterId` — Ulf's exact cancel-after-timeout case.
- `TestHandleInvoke_ErrorPathPreservesRouterId` — invoke error return carries `RouterId`, still no `routerIndex` leak.

`go build ./...`, `go vet`, and `go test -race -count=1 ./server/vissv2server/vissServiceMgr/` all green.