### PR TITLE
feat(vissServiceMgr): realistic MoveSeat simulation (built-in + example)

### DIFF
--- a/server/vissv2server/vissServiceMgr/builtinService.go
+++ b/server/vissv2server/vissServiceMgr/builtinService.go
@@ -1,0 +1,168 @@
+/**
+* (C) 2026 Ford Motor Company
+*
+* SPDX-License-Identifier: MPL-2.0
+*
+* Built-in (in-process) service simulations.
+**/
+
+package vissServiceMgr
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Built-in services provide an in-process simulation for demo/test procedures
+// when no external service process (serviceReg.go) has registered for the
+// addressed path. Without one, an invoke to e.g.
+// VehicleService.Seating.Row1.DriverSide.MoveSeat would create an invocation
+// that nothing ever drives via UpdateServiceState: the time-based ticker emits
+// content-less ONGOING monitoring events until the timeout watchdog fires
+// FAILED ~30 s later. The built-in supplies realistic state and terminates the
+// session, matching the VISSv3.2 Service spec event example.
+
+// builtinDecision is what a builtin returns synchronously to HandleInvoke.
+//
+//   - errNum != ""        -> send an error invoke response; create nothing.
+//   - immediate != ""     -> send that terminal status as the invoke response
+//     (with outdata); create no invocation/session, emit no events.
+//   - run != nil          -> proceed with the normal ONGOING invocation,
+//     session and ticker, then start run() as the async driver. minDuration
+//     extends the timeout-watchdog deadline so a long move is not killed before
+//     it completes.
+type builtinDecision struct {
+	immediate   ServiceStatus
+	outdata     map[string]interface{}
+	errNum      string
+	errReason   string
+	errDesc     string
+	minDuration time.Duration
+	run         func(serviceId string, backendChans []chan map[string]interface{})
+}
+
+type builtinHandler func(path string, input map[string]interface{}) builtinDecision
+
+// builtinServices maps a procedure name (the last path segment) to its
+// in-process handler. Lookup is by procedure name so a built-in serves every
+// instance path that ends in that procedure.
+var builtinServices = map[string]builtinHandler{
+	"MoveSeat": moveSeatBuiltin,
+}
+
+// procedureName returns the last "."-separated segment of a service path.
+func procedureName(path string) string {
+	if i := strings.LastIndex(path, "."); i >= 0 {
+		return path[i+1:]
+	}
+	return path
+}
+
+// ── MoveSeat ────────────────────────────────────────────────────────────────
+
+// moveSeatStepPeriod is the wall-clock interval between one-percentage-point
+// position changes (VISSv3.3 service example). A var so tests can shrink it.
+var moveSeatStepPeriod = time.Second
+
+var moveSeatMovementTypes = map[string]bool{
+	"longitudinal": true,
+	"vertical":     true,
+	"recline":      true,
+}
+
+// seatState stores the simulated position (0-100) per (path, MovementType),
+// initialised to 0 on first use and persisted for the process lifetime. Keyed
+// by the full instance path so each seat instance has independent state.
+var (
+	seatMu    sync.Mutex
+	seatState = map[string]int{}
+)
+
+func seatKey(path, movementType string) string { return path + "\x00" + movementType }
+
+func seatOutput(position int) map[string]interface{} {
+	return map[string]interface{}{"Position": strconv.Itoa(position)}
+}
+
+// moveSeatBuiltin simulates VehicleService...MoveSeat per Ulf's specification:
+//
+//   - MovementType must be one of longitudinal, vertical, recline.
+//   - Position is a percentage restricted to [0,100].
+//   - If the requested Position equals the saved state -> SUCCESSFUL, no events.
+//   - If out of range (or non-numeric / unknown MovementType) -> error response,
+//     no events.
+//   - Otherwise the saved state is incremented/decremented by one percentage
+//     point per second, emitting monitoring events, until it reaches the
+//     requested Position, at which point the status becomes SUCCESSFUL and
+//     events stop.
+func moveSeatBuiltin(path string, input map[string]interface{}) builtinDecision {
+	movementType, _ := input["MovementType"].(string)
+	if !moveSeatMovementTypes[movementType] {
+		return builtinDecision{
+			errNum: "400", errReason: "bad_request",
+			errDesc: "MovementType must be one of: longitudinal, vertical, recline",
+		}
+	}
+
+	posStr, _ := input["Position"].(string)
+	target, err := strconv.Atoi(strings.TrimSpace(posStr))
+	if err != nil || target < 0 || target > 100 {
+		return builtinDecision{
+			errNum: "400", errReason: "bad_request",
+			errDesc: "Position must be an integer percentage between 0 and 100",
+		}
+	}
+
+	key := seatKey(path, movementType)
+	seatMu.Lock()
+	current := seatState[key]
+	seatMu.Unlock()
+
+	if current == target {
+		// Already at the requested position: terminal response, no movement.
+		return builtinDecision{immediate: StatusSuccessful, outdata: seatOutput(current)}
+	}
+
+	steps := target - current
+	if steps < 0 {
+		steps = -steps
+	}
+	// Allow one step per second plus a small buffer so the timeout watchdog
+	// does not kill a long move (0->100 takes 100 s, well past DefaultTimeout).
+	minDuration := time.Duration(steps+2) * moveSeatStepPeriod
+
+	return builtinDecision{
+		minDuration: minDuration,
+		run: func(serviceId string, backendChans []chan map[string]interface{}) {
+			ticker := time.NewTicker(moveSeatStepPeriod)
+			defer ticker.Stop()
+			for range ticker.C {
+				// Stop promptly if the invocation was cancelled or removed.
+				mu.Lock()
+				_, alive := invocations[serviceId]
+				mu.Unlock()
+				if !alive {
+					return
+				}
+
+				seatMu.Lock()
+				cur := seatState[key]
+				if cur < target {
+					cur++
+				} else if cur > target {
+					cur--
+				}
+				seatState[key] = cur
+				seatMu.Unlock()
+
+				if cur == target {
+					UpdateServiceState(serviceId, StatusSuccessful, seatOutput(cur), nil, nil, backendChans)
+					return
+				}
+				UpdateServiceState(serviceId, StatusOngoing, seatOutput(cur), nil, nil, backendChans)
+			}
+		},
+	}
+}

--- a/server/vissv2server/vissServiceMgr/builtinService_test.go
+++ b/server/vissv2server/vissServiceMgr/builtinService_test.go
@@ -1,0 +1,439 @@
+/**
+* (C) 2026 Matt Jones
+*
+* Unit + integration tests for the built-in MoveSeat simulation.
+**/
+package vissServiceMgr
+
+import (
+	"testing"
+	"time"
+)
+
+func resetSeatState() {
+	seatMu.Lock()
+	seatState = map[string]int{}
+	seatMu.Unlock()
+}
+
+// shrinkStepPeriod speeds up the simulation for tests and restores it after.
+func shrinkStepPeriod(t *testing.T, d time.Duration) {
+	t.Helper()
+	old := moveSeatStepPeriod
+	moveSeatStepPeriod = d
+	t.Cleanup(func() { moveSeatStepPeriod = old })
+}
+
+// ---- procedureName ---------------------------------------------------------
+
+func TestProcedureName(t *testing.T) {
+	cases := map[string]string{
+		"VehicleService.Seating.Row1.DriverSide.MoveSeat": "MoveSeat",
+		"VehicleService.Seating.MoveSeat":                 "MoveSeat",
+		"MoveSeat":                                        "MoveSeat",
+		"":                                                "",
+	}
+	for in, want := range cases {
+		if got := procedureName(in); got != want {
+			t.Errorf("procedureName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// ---- instance-path resolution ---------------------------------------------
+
+func TestIsInstanceGeneralization(t *testing.T) {
+	split := func(s string) []string {
+		out := []string{}
+		cur := ""
+		for _, r := range s {
+			if r == '.' {
+				out = append(out, cur)
+				cur = ""
+			} else {
+				cur += string(r)
+			}
+		}
+		return append(out, cur)
+	}
+	cases := []struct {
+		tmpl, inst string
+		want       bool
+	}{
+		{"A.B.MoveSeat", "A.B.Row1.DriverSide.MoveSeat", true},
+		{"A.MoveSeat", "A.B.Row1.MoveSeat", true},
+		{"A.B.MoveSeat", "A.B.MoveSeat", true},   // equal is trivially a subsequence
+		{"X.B.MoveSeat", "A.B.Row1.MoveSeat", false}, // different root
+		{"A.B.Other", "A.B.Row1.MoveSeat", false},    // different procedure
+		{"A.C.MoveSeat", "A.B.Row1.MoveSeat", false},  // middle segment not present
+	}
+	for _, c := range cases {
+		if got := isInstanceGeneralization(split(c.tmpl), split(c.inst)); got != c.want {
+			t.Errorf("isInstanceGeneralization(%q,%q) = %v, want %v", c.tmpl, c.inst, got, c.want)
+		}
+	}
+}
+
+func TestResolveRegistration_ExactAndInstance(t *testing.T) {
+	regMu.Lock()
+	registrations = map[string]*serviceConn{}
+	exact := &serviceConn{path: "A.B.Row1.MoveSeat"}
+	tmpl := &serviceConn{path: "A.B.MoveSeat"}
+	registrations["A.B.Row1.MoveSeat"] = exact
+	registrations["A.B.MoveSeat"] = tmpl
+	regMu.Unlock()
+	t.Cleanup(func() {
+		regMu.Lock()
+		registrations = map[string]*serviceConn{}
+		regMu.Unlock()
+	})
+
+	if got := resolveRegistration("A.B.Row1.MoveSeat"); got != exact {
+		t.Errorf("exact path should match the exact registration")
+	}
+	// Instance path with no exact match resolves to the template registration.
+	if got := resolveRegistration("A.B.Row2.PassengerSide.MoveSeat"); got != tmpl {
+		t.Errorf("instance path should resolve to the template registration, got %v", got)
+	}
+	if got := resolveRegistration("A.B.Row2.Lighting"); got != nil {
+		t.Errorf("unrelated path should not resolve, got %v", got)
+	}
+}
+
+// ---- moveSeatBuiltin decision logic ---------------------------------------
+
+func TestMoveSeatBuiltin_ValidationErrors(t *testing.T) {
+	resetSeatState()
+	cases := []struct {
+		name  string
+		input map[string]interface{}
+	}{
+		{"unknown movement type", map[string]interface{}{"MovementType": "diagonal", "Position": "40"}},
+		{"missing movement type", map[string]interface{}{"Position": "40"}},
+		{"position too high", map[string]interface{}{"MovementType": "longitudinal", "Position": "101"}},
+		{"position negative", map[string]interface{}{"MovementType": "longitudinal", "Position": "-5"}},
+		{"position non-numeric", map[string]interface{}{"MovementType": "longitudinal", "Position": "x"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := moveSeatBuiltin("VehicleService.Seating.MoveSeat", c.input)
+			if d.errNum != "400" {
+				t.Errorf("want errNum 400, got %q (decision %+v)", d.errNum, d)
+			}
+			if d.run != nil || d.immediate != "" {
+				t.Errorf("error decision must not move or complete: %+v", d)
+			}
+		})
+	}
+}
+
+func TestMoveSeatBuiltin_AlreadyAtTarget(t *testing.T) {
+	resetSeatState()
+	path := "VehicleService.Seating.Row1.DriverSide.MoveSeat"
+	seatMu.Lock()
+	seatState[seatKey(path, "longitudinal")] = 40
+	seatMu.Unlock()
+
+	d := moveSeatBuiltin(path, map[string]interface{}{"MovementType": "longitudinal", "Position": "40"})
+	if d.immediate != StatusSuccessful {
+		t.Fatalf("want immediate SUCCESSFUL, got %q", d.immediate)
+	}
+	if d.run != nil {
+		t.Error("already-at-target must not start a driver (no events)")
+	}
+	if d.outdata["Position"] != "40" {
+		t.Errorf("outdata Position = %v, want 40", d.outdata["Position"])
+	}
+}
+
+func TestMoveSeatBuiltin_MovingReturnsRunner(t *testing.T) {
+	resetSeatState()
+	shrinkStepPeriod(t, time.Second) // keep default for the minDuration assertion
+	d := moveSeatBuiltin("VehicleService.Seating.MoveSeat",
+		map[string]interface{}{"MovementType": "vertical", "Position": "40"})
+	if d.run == nil {
+		t.Fatal("moving request must return a driver")
+	}
+	if d.immediate != "" || d.errNum != "" {
+		t.Errorf("moving request must not be immediate/error: %+v", d)
+	}
+	// 0->40 is 40 steps; deadline budget must exceed DefaultTimeout so the
+	// watchdog does not kill the move (the bug Ulf saw at ~30 s).
+	if d.minDuration <= DefaultTimeout {
+		t.Errorf("minDuration %v should exceed DefaultTimeout %v for a 40-step move", d.minDuration, DefaultTimeout)
+	}
+}
+
+// TestMoveSeatBuiltin_DriverStepsToTarget runs the async driver against a
+// seeded invocation + an "all"-filter session (so every ONGOING update is
+// delivered) and verifies the event stream Ulf specified: one event per
+// percentage point, each with outdata.output.Position, ending SUCCESSFUL.
+func TestMoveSeatBuiltin_DriverStepsToTarget(t *testing.T) {
+	resetState()
+	resetSeatState()
+	shrinkStepPeriod(t, 2*time.Millisecond)
+
+	const sid = "drv-1"
+	const path = "VehicleService.Seating.Row1.DriverSide.MoveSeat"
+	mu.Lock()
+	invocations[sid] = &invocationState{serviceId: sid, path: path, status: StatusOngoing, startedAt: time.Now()}
+	sessions["sess-1"] = &monitorSession{sessionId: "sess-1", serviceId: sid, path: path, filterKind: "all", routerIndex: 0}
+	mu.Unlock()
+
+	bc := make(chan map[string]interface{}, 64)
+	bcs := []chan map[string]interface{}{bc}
+
+	d := moveSeatBuiltin(path, map[string]interface{}{"MovementType": "longitudinal", "Position": "5"})
+	if d.run == nil {
+		t.Fatal("expected a driver")
+	}
+	done := make(chan struct{})
+	go func() { d.run(sid, bcs); close(done) }()
+
+	var statuses []string
+	var lastPos string
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-bc:
+			if ev["action"] != "monitoring" {
+				t.Errorf("event action = %v, want monitoring", ev["action"])
+			}
+			if ev["path"] != path {
+				t.Errorf("event path = %v, want %v", ev["path"], path)
+			}
+			if ev["serviceId"] != "sess-1" {
+				t.Errorf("event serviceId = %v, want sess-1 (the session id)", ev["serviceId"])
+			}
+			outdata, ok := ev["outdata"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("event missing outdata: %v", ev)
+			}
+			out, ok := outdata["output"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("outdata missing output: %v", outdata)
+			}
+			if outdata["ts"] == nil {
+				t.Error("outdata missing ts")
+			}
+			lastPos, _ = out["Position"].(string)
+			statuses = append(statuses, ev["status"].(string))
+			if ev["status"] == string(StatusSuccessful) {
+				goto finished
+			}
+		case <-timeout:
+			t.Fatalf("driver did not complete; statuses so far=%v", statuses)
+		}
+	}
+finished:
+	<-done
+	// 0->5: four ONGOING events then one SUCCESSFUL.
+	if len(statuses) != 5 {
+		t.Errorf("want 5 events, got %d (%v)", len(statuses), statuses)
+	}
+	for i := 0; i < len(statuses)-1; i++ {
+		if statuses[i] != string(StatusOngoing) {
+			t.Errorf("event %d status = %q, want ONGOING", i, statuses[i])
+		}
+	}
+	if lastPos != "5" {
+		t.Errorf("final Position = %q, want 5", lastPos)
+	}
+	seatMu.Lock()
+	if seatState[seatKey(path, "longitudinal")] != 5 {
+		t.Errorf("saved state = %d, want 5", seatState[seatKey(path, "longitudinal")])
+	}
+	seatMu.Unlock()
+	// Terminal removes the invocation.
+	mu.Lock()
+	_, alive := invocations[sid]
+	mu.Unlock()
+	if alive {
+		t.Error("invocation should be removed after SUCCESSFUL")
+	}
+}
+
+// TestMoveSeatBuiltin_DriverStopsWhenInvocationRemoved verifies the driver
+// exits promptly when the invocation is cancelled/removed (the cancel path).
+func TestMoveSeatBuiltin_DriverStopsWhenInvocationRemoved(t *testing.T) {
+	resetState()
+	resetSeatState()
+	shrinkStepPeriod(t, 5*time.Millisecond)
+
+	const sid = "drv-2"
+	const path = "VehicleService.Seating.MoveSeat"
+	mu.Lock()
+	invocations[sid] = &invocationState{serviceId: sid, path: path, status: StatusOngoing, startedAt: time.Now()}
+	mu.Unlock()
+
+	bc := make(chan map[string]interface{}, 64)
+	d := moveSeatBuiltin(path, map[string]interface{}{"MovementType": "recline", "Position": "100"})
+	done := make(chan struct{})
+	go func() { d.run(sid, []chan map[string]interface{}{bc}); close(done) }()
+
+	// Remove the invocation as a cancel would, then the driver must return.
+	time.Sleep(15 * time.Millisecond)
+	mu.Lock()
+	delete(invocations, sid)
+	mu.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("driver did not stop after invocation removed")
+	}
+}
+
+func TestMoveSeatBuiltin_PerMovementTypeIndependent(t *testing.T) {
+	resetSeatState()
+	path := "VehicleService.Seating.MoveSeat"
+	seatMu.Lock()
+	seatState[seatKey(path, "longitudinal")] = 30
+	seatMu.Unlock()
+
+	// vertical is still 0, so a request for vertical=0 is already-at-target,
+	// independent of longitudinal=30.
+	d := moveSeatBuiltin(path, map[string]interface{}{"MovementType": "vertical", "Position": "0"})
+	if d.immediate != StatusSuccessful {
+		t.Errorf("vertical state should be independent (0), got decision %+v", d)
+	}
+}
+
+// ---- HandleInvoke integration (built-in path; needs the service tree) ------
+
+func TestHandleInvoke_BuiltinMoveSeatOutOfRange(t *testing.T) {
+	resetState()
+	resetSeatState()
+	loadVehicleServiceTree(t)
+	t.Cleanup(stopServiceGoroutines)
+
+	bc := make(chan map[string]interface{}, 8)
+	bcs := []chan map[string]interface{}{bc}
+	req := map[string]interface{}{
+		"action":      "invoke",
+		"path":        moveSeatPath,
+		"input":       map[string]interface{}{"MovementType": "longitudinal", "Position": "150"},
+		"requestId":   "8756",
+		"routerIndex": 0,
+		"RouterId":    "1?0",
+	}
+	HandleInvoke(req, bcs)
+
+	select {
+	case resp := <-bc:
+		if _, ok := resp["error"]; !ok {
+			t.Fatalf("out-of-range invoke should error, got %v", resp)
+		}
+		if resp["RouterId"] != "1?0" {
+			t.Errorf("error response dropped RouterId: %v", resp)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no response")
+	}
+	// No invocation/session created, so no events follow.
+	mu.Lock()
+	n := len(invocations)
+	mu.Unlock()
+	if n != 0 {
+		t.Errorf("out-of-range request must not create an invocation, have %d", n)
+	}
+}
+
+func TestHandleInvoke_BuiltinMoveSeatAlreadyThere(t *testing.T) {
+	resetState()
+	resetSeatState()
+	loadVehicleServiceTree(t)
+	t.Cleanup(stopServiceGoroutines)
+
+	seatMu.Lock()
+	seatState[seatKey(moveSeatPath, "longitudinal")] = 40
+	seatMu.Unlock()
+
+	bc := make(chan map[string]interface{}, 8)
+	bcs := []chan map[string]interface{}{bc}
+	req := map[string]interface{}{
+		"action":      "invoke",
+		"path":        moveSeatPath,
+		"input":       map[string]interface{}{"MovementType": "longitudinal", "Position": "40"},
+		"requestId":   "8756",
+		"routerIndex": 0,
+		"RouterId":    "1?0",
+		"filter":      map[string]interface{}{"variant": "timebased", "parameter": map[string]interface{}{"period": "1000"}},
+	}
+	HandleInvoke(req, bcs)
+
+	select {
+	case resp := <-bc:
+		if resp["status"] != string(StatusSuccessful) {
+			t.Errorf("already-at-target should respond SUCCESSFUL, got %v", resp["status"])
+		}
+		if resp["RouterId"] != "1?0" {
+			t.Errorf("response dropped RouterId: %v", resp)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no response")
+	}
+	mu.Lock()
+	n := len(invocations)
+	mu.Unlock()
+	if n != 0 {
+		t.Errorf("already-at-target must not create an invocation, have %d", n)
+	}
+}
+
+func TestHandleInvoke_BuiltinMoveSeatMovesAndCompletes(t *testing.T) {
+	resetState()
+	resetSeatState()
+	shrinkStepPeriod(t, 3*time.Millisecond)
+	loadVehicleServiceTree(t)
+	t.Cleanup(stopServiceGoroutines)
+
+	bc := make(chan map[string]interface{}, 64)
+	bcs := []chan map[string]interface{}{bc}
+	req := map[string]interface{}{
+		"action":      "invoke",
+		"path":        moveSeatPath,
+		"input":       map[string]interface{}{"MovementType": "longitudinal", "Position": "3"},
+		"requestId":   "8756",
+		"routerIndex": 0,
+		"RouterId":    "1?0",
+		"filter":      map[string]interface{}{"variant": "all"},
+	}
+	HandleInvoke(req, bcs)
+
+	// First the ONGOING invoke response, then monitoring events ending SUCCESSFUL.
+	gotInvoke := false
+	gotSuccess := false
+	timeout := time.After(2 * time.Second)
+	for !gotSuccess {
+		select {
+		case msg := <-bc:
+			switch msg["action"] {
+			case "invoke":
+				gotInvoke = true
+				if msg["status"] != string(StatusOngoing) {
+					t.Errorf("invoke response status = %v, want ONGOING", msg["status"])
+				}
+			case "monitoring":
+				if msg["status"] == string(StatusSuccessful) {
+					gotSuccess = true
+					od, _ := msg["outdata"].(map[string]interface{})
+					out, _ := od["output"].(map[string]interface{})
+					if out["Position"] != "3" {
+						t.Errorf("final Position = %v, want 3", out["Position"])
+					}
+				}
+			}
+		case <-timeout:
+			t.Fatal("did not reach SUCCESSFUL")
+		}
+	}
+	if !gotInvoke {
+		t.Error("never received the ONGOING invoke response")
+	}
+	seatMu.Lock()
+	if seatState[seatKey(moveSeatPath, "longitudinal")] != 3 {
+		t.Errorf("saved state = %d, want 3", seatState[seatKey(moveSeatPath, "longitudinal")])
+	}
+	seatMu.Unlock()
+}

--- a/server/vissv2server/vissServiceMgr/example/seatService.go
+++ b/server/vissv2server/vissServiceMgr/example/seatService.go
@@ -1,18 +1,34 @@
 /**
 * (C) 2026 Ford Motor Company
 *
+* SPDX-License-Identifier: MPL-2.0
+*
 * VISSv3.3-alpha — Example Service: VehicleService.Seating.MoveSeat
 *
-* Demonstrates how to implement a VISS service procedure using the
-* vissServiceSDK. This example simulates moving a vehicle seat, reporting
-* position updates every 500 ms until the target position is reached.
+* Reference implementation of the MoveSeat service procedure using the
+* vissServiceSDK. It simulates real seat-actuator behaviour:
+*
+*   - A Position state (0-100 %) is kept per MovementType. The supported
+*     MovementTypes are "longitudinal", "vertical" and "recline". State is
+*     initialised to 0 at start-up (no persistence across lifetimes).
+*   - When the requested Position differs from the saved state, the state is
+*     stepped one percentage point per second towards the request, emitting a
+*     monitoring event per step, until it reaches the target -> SUCCESSFUL.
+*   - When the requested Position already equals the saved state, the response
+*     is SUCCESSFUL with no events.
+*   - When the requested Position is outside [0,100] (or non-numeric, or the
+*     MovementType is unknown), a FAILED error response is returned and no
+*     events are issued.
+*
+* The same simulation is built into the server (vissServiceMgr) so the demo
+* works whether or not this external service process is running; this binary
+* is the reference for implementing a real service.
 *
 * Run as a standalone binary alongside the VISS server:
 *
 *   go run ./server/vissv2server/vissServiceMgr/example/seatService.go
 *
-* The service registers with the server on localhost:8300 (the default
-* ServiceRegPort) and handles invoke requests for MoveSeat.
+* It registers with the server on localhost:8300 (the default ServiceRegPort).
 **/
 
 package main
@@ -20,14 +36,36 @@ package main
 import (
 	"log"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	vissServiceSDK "github.com/covesa/vissr/server/vissv2server/vissServiceSDK"
 )
 
+// stepPeriod is the interval between one-percentage-point position changes.
+var stepPeriod = time.Second
+
+var supportedMovementTypes = map[string]bool{
+	"longitudinal": true,
+	"vertical":     true,
+	"recline":      true,
+}
+
+// positions holds the simulated seat position per MovementType, initialised to
+// 0 and guarded by mu because invocations are handled concurrently.
+var (
+	mu        sync.Mutex
+	positions = map[string]int{
+		"longitudinal": 0,
+		"vertical":     0,
+		"recline":      0,
+	}
+)
+
 func main() {
 	svc, err := vissServiceSDK.NewService("localhost:8300", "VehicleService.Seating.MoveSeat").
-		WithInput("SeatId", "string").
+		WithInput("MovementType", "string").
 		WithInput("Position", "uint8").
 		WithOutput("Position", "uint8").
 		OnInvoke(handleMoveSeat).
@@ -41,39 +79,74 @@ func main() {
 	svc.Run()
 }
 
-// handleMoveSeat simulates moving a vehicle seat from its current position
-// to the requested target position, reporting progress every 500 ms.
+// handleMoveSeat implements the simulation described in the file header.
 func handleMoveSeat(ctx *vissServiceSDK.InvokeContext) {
-	targetStr, _ := ctx.Input["Position"].(string)
-	target, err := strconv.Atoi(targetStr)
-	if err != nil || target < 0 || target > 100 {
-		ctx.ReportProgress("FAILED", nil) //nolint:errcheck
+	movementType, _ := ctx.Input["MovementType"].(string)
+	posStr, _ := ctx.Input["Position"].(string)
+	target, errMsg := parseMoveSeatRequest(movementType, posStr)
+	if errMsg != "" {
+		ctx.ReportError("400", errMsg, nil) //nolint:errcheck
 		return
 	}
 
-	// Simulate current position starting at 0.
-	current := 0
-	step := 10
-	if target < current {
-		step = -10
+	mu.Lock()
+	current := positions[movementType]
+	mu.Unlock()
+
+	if current == target {
+		// Already at the requested position: SUCCESSFUL, no events.
+		ctx.ReportProgress("SUCCESSFUL", output(current)) //nolint:errcheck
+		return
 	}
 
-	for current != target {
-		time.Sleep(500 * time.Millisecond)
-		current += step
-		if step > 0 && current > target {
-			current = target
-		} else if step < 0 && current < target {
-			current = target
-		}
-		output := map[string]interface{}{"Position": strconv.Itoa(current)}
-		if current == target {
-			ctx.ReportProgress("SUCCESSFUL", output) //nolint:errcheck
+	ticker := time.NewTicker(stepPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done(): // server cancelled the invocation (§26)
 			return
-		}
-		ctx.ReportProgress("ONGOING", output) //nolint:errcheck
-	}
+		case <-ticker.C:
+			mu.Lock()
+			cur := stepToward(positions[movementType], target)
+			positions[movementType] = cur
+			mu.Unlock()
 
-	// Already at target.
-	ctx.ReportProgress("SUCCESSFUL", map[string]interface{}{"Position": strconv.Itoa(current)}) //nolint:errcheck
+			if cur == target {
+				ctx.ReportProgress("SUCCESSFUL", output(cur)) //nolint:errcheck
+				return
+			}
+			ctx.ReportProgress("ONGOING", output(cur)) //nolint:errcheck
+		}
+	}
+}
+
+// parseMoveSeatRequest validates the MovementType and Position inputs. It
+// returns the target position, or a non-empty error message describing why the
+// request is rejected (unknown MovementType, or Position non-numeric / outside
+// [0,100]).
+func parseMoveSeatRequest(movementType, posStr string) (target int, errMsg string) {
+	if !supportedMovementTypes[movementType] {
+		return 0, "MovementType must be one of: longitudinal, vertical, recline"
+	}
+	target, err := strconv.Atoi(strings.TrimSpace(posStr))
+	if err != nil || target < 0 || target > 100 {
+		return 0, "Position must be an integer percentage between 0 and 100"
+	}
+	return target, ""
+}
+
+// stepToward returns current moved one percentage point towards target.
+func stepToward(current, target int) int {
+	switch {
+	case current < target:
+		return current + 1
+	case current > target:
+		return current - 1
+	default:
+		return current
+	}
+}
+
+func output(position int) map[string]interface{} {
+	return map[string]interface{}{"Position": strconv.Itoa(position)}
 }

--- a/server/vissv2server/vissServiceMgr/example/seatService_test.go
+++ b/server/vissv2server/vissServiceMgr/example/seatService_test.go
@@ -3,10 +3,12 @@
 *
 * Unit tests for seatService (vissServiceMgr/example).
 *
-* handleMoveSeat calls ctx.ReportProgress which routes through the
-* vissServiceSDK's unexported svc.sendJSON. Testing it end-to-end
-* requires a live fake-server fixture identical to the one in
-* vissServiceSDK_test.go; that coverage is provided there.
+* handleMoveSeat drives the simulation via ctx.ReportProgress, which routes
+* through the vissServiceSDK's unexported svc.sendJSON and so needs a live
+* fake-server connection (covered end-to-end in vissServiceSDK_test.go, and the
+* identical simulation logic is unit-tested against the server built-in in
+* vissServiceMgr's builtinService_test.go). The request validation and stepping
+* math are factored into pure helpers and tested directly below.
 *
 * Integration-only entry points — NOT unit-tested here:
 *
@@ -17,6 +19,85 @@ package main
 
 import "testing"
 
-// TestPackageCompiles is a compile-only sentinel — confirms that the
-// example binary builds cleanly without importing the live server.
-func TestPackageCompiles(t *testing.T) {}
+func TestParseMoveSeatRequest(t *testing.T) {
+	cases := []struct {
+		name       string
+		movement   string
+		position   string
+		wantTarget int
+		wantErr    bool
+	}{
+		{"valid longitudinal", "longitudinal", "40", 40, false},
+		{"valid vertical zero", "vertical", "0", 0, false},
+		{"valid recline max", "recline", "100", 100, false},
+		{"valid with whitespace", "longitudinal", " 55 ", 55, false},
+		{"unknown movement type", "diagonal", "40", 0, true},
+		{"empty movement type", "", "40", 0, true},
+		{"position too high", "longitudinal", "101", 0, true},
+		{"position negative", "longitudinal", "-1", 0, true},
+		{"position non-numeric", "longitudinal", "abc", 0, true},
+		{"position empty", "longitudinal", "", 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			target, errMsg := parseMoveSeatRequest(c.movement, c.position)
+			if c.wantErr {
+				if errMsg == "" {
+					t.Fatalf("expected error for movement=%q position=%q", c.movement, c.position)
+				}
+				return
+			}
+			if errMsg != "" {
+				t.Fatalf("unexpected error: %s", errMsg)
+			}
+			if target != c.wantTarget {
+				t.Errorf("target = %d, want %d", target, c.wantTarget)
+			}
+		})
+	}
+}
+
+func TestStepToward(t *testing.T) {
+	cases := []struct{ current, target, want int }{
+		{45, 46, 46}, // increment
+		{45, 44, 44}, // decrement
+		{40, 40, 40}, // already there
+		{0, 1, 1},
+		{100, 99, 99},
+	}
+	for _, c := range cases {
+		if got := stepToward(c.current, c.target); got != c.want {
+			t.Errorf("stepToward(%d,%d) = %d, want %d", c.current, c.target, got, c.want)
+		}
+	}
+}
+
+// TestStepTowardConverges checks that repeated stepping always reaches the
+// target in exactly |target-current| steps, never overshooting.
+func TestStepTowardConverges(t *testing.T) {
+	for _, tc := range [][2]int{{0, 40}, {40, 0}, {0, 100}, {100, 0}, {37, 37}} {
+		current, target := tc[0], tc[1]
+		want := target - current
+		if want < 0 {
+			want = -want
+		}
+		steps := 0
+		for current != target {
+			current = stepToward(current, target)
+			steps++
+			if steps > 200 {
+				t.Fatalf("did not converge from %d to %d", tc[0], tc[1])
+			}
+		}
+		if steps != want {
+			t.Errorf("converging %d->%d took %d steps, want %d", tc[0], tc[1], steps, want)
+		}
+	}
+}
+
+func TestOutput(t *testing.T) {
+	out := output(42)
+	if out["Position"] != "42" {
+		t.Errorf("output Position = %v, want \"42\"", out["Position"])
+	}
+}

--- a/server/vissv2server/vissServiceMgr/serviceReg.go
+++ b/server/vissv2server/vissServiceMgr/serviceReg.go
@@ -331,13 +331,58 @@ func handleHealth(msg map[string]interface{}, sc *serviceConn) {
 	utils.Info.Printf("serviceReg: health update for %q: healthy=%v", sc.path, healthy)
 }
 
+// resolveRegistration returns the service connection registered for path, or
+// nil. It matches either exactly, or via instance generalization: a service
+// that registers a template path (e.g. VehicleService.Seating.MoveSeat) also
+// serves instance paths (e.g. VehicleService.Seating.Row1.DriverSide.MoveSeat)
+// whose template is an ordered sub-sequence of the instance path's segments,
+// sharing the same root and procedure name. The most specific (longest) match
+// wins. It acquires regMu itself; callers must not hold it.
+func resolveRegistration(path string) *serviceConn {
+	regMu.Lock()
+	defer regMu.Unlock()
+	if sc := registrations[path]; sc != nil {
+		return sc
+	}
+	instSeg := strings.Split(path, ".")
+	var best *serviceConn
+	bestLen := -1
+	for rp, sc := range registrations {
+		tmplSeg := strings.Split(rp, ".")
+		if len(tmplSeg) >= len(instSeg) {
+			continue // exact-length already handled by the direct lookup above
+		}
+		if isInstanceGeneralization(tmplSeg, instSeg) && len(tmplSeg) > bestLen {
+			best, bestLen = sc, len(tmplSeg)
+		}
+	}
+	return best
+}
+
+// isInstanceGeneralization reports whether tmpl is an instance generalization
+// of inst: same root segment, same procedure (last) segment, and tmpl is an
+// ordered sub-sequence of inst.
+func isInstanceGeneralization(tmpl, inst []string) bool {
+	if len(tmpl) == 0 || len(inst) == 0 {
+		return false
+	}
+	if tmpl[0] != inst[0] || tmpl[len(tmpl)-1] != inst[len(inst)-1] {
+		return false
+	}
+	i := 0
+	for _, seg := range inst {
+		if i < len(tmpl) && tmpl[i] == seg {
+			i++
+		}
+	}
+	return i == len(tmpl)
+}
+
 // forwardInvokeToService sends an invoke notification to the registered service
 // process for path (if any). authToken is forwarded from the client request so
 // services can perform their own access checks (VISSv3.3 §21).
 func forwardInvokeToService(path, serviceId string, input map[string]interface{}, authToken string) {
-	regMu.Lock()
-	sc := registrations[path]
-	regMu.Unlock()
+	sc := resolveRegistration(path)
 	if sc == nil {
 		return // no service registered; caller must handle via UpdateServiceState
 	}
@@ -356,9 +401,7 @@ func forwardInvokeToService(path, serviceId string, input map[string]interface{}
 // forwardCancelToService notifies the registered service process that
 // invocation serviceId has been cancelled so it can stop cleanly (VISSv3.3 §26).
 func forwardCancelToService(path, serviceId string) {
-	regMu.Lock()
-	sc := registrations[path]
-	regMu.Unlock()
+	sc := resolveRegistration(path)
 	if sc == nil {
 		return
 	}

--- a/server/vissv2server/vissServiceMgr/vissServiceMgr.go
+++ b/server/vissv2server/vissServiceMgr/vissServiceMgr.go
@@ -273,7 +273,48 @@ func HandleInvoke(requestMap map[string]interface{}, backendChans []chan map[str
 
 	authToken, _ := requestMap["authorization"].(string)
 
-	deadline := time.Now().Add(timeoutFromRequest(requestMap))
+	// Built-in (in-process) simulation: used only when no external service
+	// process has registered for this path (instance paths resolve too). It
+	// lets the demo run without a separate service binary and, crucially, makes
+	// the invocation actually terminate instead of emitting content-less
+	// ONGOING events until the timeout watchdog fires.
+	var builtinRun func(string, []chan map[string]interface{})
+	var builtinMinDuration time.Duration
+	if resolveRegistration(path) == nil {
+		if bh, ok := builtinServices[procedureName(path)]; ok {
+			decision := bh(path, inputParams)
+			switch {
+			case decision.errNum != "":
+				sendServiceError(bc, "invoke", requestId, "", StatusFailed,
+					decision.errNum, decision.errReason, decision.errDesc, requestMap)
+				return
+			case decision.immediate != "":
+				ts := getTimestamp()
+				response := map[string]interface{}{
+					"action":    "invoke",
+					"path":      path,
+					"status":    string(decision.immediate),
+					"requestId": requestId,
+					"ts":        ts,
+				}
+				if decision.outdata != nil {
+					response["outdata"] = map[string]interface{}{"output": decision.outdata, "ts": ts}
+				}
+				copyRouteFields(requestMap, response)
+				bc <- response
+				return
+			default:
+				builtinRun = decision.run
+				builtinMinDuration = decision.minDuration
+			}
+		}
+	}
+
+	timeout := timeoutFromRequest(requestMap)
+	if builtinMinDuration > timeout {
+		timeout = builtinMinDuration
+	}
+	deadline := time.Now().Add(timeout)
 
 	mu.Lock()
 	ts := getTimestamp()
@@ -313,7 +354,11 @@ func HandleInvoke(requestMap map[string]interface{}, backendChans []chan map[str
 	inv.cancelFn = startTimeoutWatchdog(inv, backendChans)
 	mu.Unlock()
 
-	forwardInvokeToService(path, serviceId, inputParams, authToken)
+	if builtinRun != nil {
+		go builtinRun(serviceId, backendChans)
+	} else {
+		forwardInvokeToService(path, serviceId, inputParams, authToken)
+	}
 
 	response := map[string]interface{}{
 		"action":    "invoke",

--- a/server/vissv2server/vissServiceMgr/vissServiceMgr.go
+++ b/server/vissv2server/vissServiceMgr/vissServiceMgr.go
@@ -261,13 +261,13 @@ func HandleInvoke(requestMap map[string]interface{}, backendChans []chan map[str
 	node := resolveServiceNode(path)
 	if node == nil || utils.VSSgetType(node) != utils.PROCEDURE {
 		sendServiceError(bc, "invoke", requestId, "", StatusFailed,
-			"400", "bad_request", "path must address a procedure node")
+			"400", "bad_request", "path must address a procedure node", requestMap)
 		return
 	}
 
 	inputParams, _ := requestMap["input"].(map[string]interface{})
 	if ok, missingFields := validateInputSignature(node, inputParams); !ok {
-		sendValidationError(bc, "invoke", requestId, missingFields)
+		sendValidationError(bc, "invoke", requestId, missingFields, requestMap)
 		return
 	}
 
@@ -345,7 +345,7 @@ func HandleMonitor(requestMap map[string]interface{}, backendChans []chan map[st
 	node := resolveServiceNode(path)
 	if node == nil || utils.VSSgetType(node) != utils.PROCEDURE {
 		sendServiceError(bc, "monitor", requestId, "", StatusFailed,
-			"400", "bad_request", "path must address a procedure node")
+			"400", "bad_request", "path must address a procedure node", requestMap)
 		return
 	}
 
@@ -415,7 +415,7 @@ func HandleCancel(requestMap map[string]interface{}, backendChan chan map[string
 	serviceId, _ := requestMap["serviceId"].(string)
 	if serviceId == "" {
 		sendServiceError(backendChan, "cancel", "", serviceId, StatusFailed,
-			"400", "bad_request", "serviceId is required for cancel")
+			"400", "bad_request", "serviceId is required for cancel", requestMap)
 		return
 	}
 
@@ -424,7 +424,7 @@ func HandleCancel(requestMap map[string]interface{}, backendChan chan map[string
 	if !ok {
 		mu.Unlock()
 		sendServiceError(backendChan, "cancel", "", serviceId, StatusFailed,
-			"400", "bad_request", "serviceId not found")
+			"400", "bad_request", "serviceId not found", requestMap)
 		return
 	}
 
@@ -488,14 +488,14 @@ func HandleDiscover(requestMap map[string]interface{}, backendChan chan map[stri
 	node := resolveServiceNode(path)
 	if node == nil {
 		sendServiceError(backendChan, "discover", requestId, "", StatusUnknown,
-			"400", "bad_request", "path not found in service tree")
+			"400", "bad_request", "path not found in service tree", requestMap)
 		return
 	}
 
 	nodeType := utils.VSSgetType(node)
 	if nodeType != utils.BRANCH && nodeType != utils.PROCEDURE {
 		sendServiceError(backendChan, "discover", requestId, "", StatusUnknown,
-			"400", "bad_request", "path must address a branch or procedure node")
+			"400", "bad_request", "path must address a branch or procedure node", requestMap)
 		return
 	}
 
@@ -949,8 +949,14 @@ func copyMap(src map[string]interface{}) map[string]interface{} {
 
 // sendValidationError sends a 400 error that lists the missing input field
 // names, providing callers with actionable detail (VISSv3.3 §29).
+//
+// requestMap is the originating request: its RouterId is copied onto the error
+// so the transport manager can route the reply back to the requesting client.
+// Without it the WS/UDS managers recover clientId=-1 and drop the response,
+// wedging the client's synchronous request/response channel.
 func sendValidationError(backendChan chan map[string]interface{},
-	action, requestId string, missingFields []string) {
+	action, requestId string, missingFields []string,
+	requestMap map[string]interface{}) {
 
 	errMap := map[string]interface{}{
 		"action": action,
@@ -966,12 +972,17 @@ func sendValidationError(backendChan chan map[string]interface{},
 	if requestId != "" {
 		errMap["requestId"] = requestId
 	}
+	copyRouteFields(requestMap, errMap)
 	backendChan <- errMap
 }
 
+// sendServiceError sends a structured error response. As with
+// sendValidationError, requestMap supplies the RouterId so the reply can be
+// addressed back to the originating client rather than dropped.
 func sendServiceError(backendChan chan map[string]interface{},
 	action, requestId, serviceId string,
-	status ServiceStatus, errNum, errReason, errDesc string) {
+	status ServiceStatus, errNum, errReason, errDesc string,
+	requestMap map[string]interface{}) {
 
 	errMap := map[string]interface{}{
 		"action": action,
@@ -989,5 +1000,6 @@ func sendServiceError(backendChan chan map[string]interface{},
 	if serviceId != "" {
 		errMap["serviceId"] = serviceId
 	}
+	copyRouteFields(requestMap, errMap)
 	backendChan <- errMap
 }

--- a/server/vissv2server/vissServiceMgr/vissServiceMgr_test.go
+++ b/server/vissv2server/vissServiceMgr/vissServiceMgr_test.go
@@ -254,7 +254,8 @@ func TestHandleInvoke_ResponseHasNoRouterIndex(t *testing.T) {
 
 func TestSendServiceError_RequiredFields(t *testing.T) {
 	ch := make(chan map[string]interface{}, 4)
-	sendServiceError(ch, "invoke", "req-1", "", StatusFailed, "400", "bad_request", "oops")
+	req := map[string]interface{}{"RouterId": "1?0"}
+	sendServiceError(ch, "invoke", "req-1", "", StatusFailed, "400", "bad_request", "oops", req)
 	select {
 	case m := <-ch:
 		if m["action"] != "invoke" {
@@ -272,6 +273,36 @@ func TestSendServiceError_RequiredFields(t *testing.T) {
 		}
 		if m["ts"] == nil {
 			t.Error("ts missing")
+		}
+		// Regression (Issue C): the RouterId must be copied onto the error so the
+		// transport manager can route the reply back; otherwise clientId=-1 and
+		// the response is dropped, wedging the client's synchronous channel.
+		if m["RouterId"] != "1?0" {
+			t.Errorf("RouterId not copied onto error response: %v", m["RouterId"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+// TestSendValidationError_CopiesRouterId is the validation-path half of the
+// Issue C regression: a SET/invoke that fails input validation must still
+// address its error reply back to the originating client.
+func TestSendValidationError_CopiesRouterId(t *testing.T) {
+	ch := make(chan map[string]interface{}, 4)
+	req := map[string]interface{}{"routerId": "2?7"}
+	sendValidationError(ch, "invoke", "req-9", []string{"Position"}, req)
+	select {
+	case m := <-ch:
+		if m["routerId"] != "2?7" {
+			t.Errorf("routerId not copied onto validation error: %v", m["routerId"])
+		}
+		errObj, ok := m["error"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("missing error object: %v", m)
+		}
+		if fields, ok := errObj["fields"].([]string); !ok || len(fields) != 1 || fields[0] != "Position" {
+			t.Errorf("missing/incorrect fields: %v", errObj["fields"])
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout")
@@ -302,6 +333,63 @@ func TestHandleCancel_UnknownServiceId(t *testing.T) {
 	case m := <-ch:
 		if _, ok := m["error"]; !ok {
 			t.Error("expected error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+// TestHandleCancel_UnknownServiceId_PreservesRouterId reproduces Ulf's hang:
+// a cancel arriving after the invocation has already terminated (timeout) hits
+// the "serviceId not found" error path. Before the fix that error reply carried
+// no RouterId, so wsMgr resolved clientId=-1 and dropped it; because cancel
+// replies ride the synchronous request/response channel, the client blocked
+// forever and the next Get got no answer. The reply must carry the RouterId.
+func TestHandleCancel_UnknownServiceId_PreservesRouterId(t *testing.T) {
+	resetState()
+	ch := make(chan map[string]interface{}, 4)
+	HandleCancel(map[string]interface{}{"serviceId": "608688", "RouterId": "1?0"}, ch)
+	select {
+	case m := <-ch:
+		if m["status"] != string(StatusFailed) {
+			t.Errorf("want FAILED, got %v", m["status"])
+		}
+		if m["RouterId"] != "1?0" {
+			t.Errorf("cancel error dropped RouterId (Issue C): %v", m)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+// TestHandleInvoke_ErrorPathPreservesRouterId guards the invoke/monitor/discover
+// error returns that also go through sendServiceError/sendValidationError.
+func TestHandleInvoke_ErrorPathPreservesRouterId(t *testing.T) {
+	resetState()
+	loadVehicleServiceTree(t)
+	t.Cleanup(stopServiceGoroutines)
+
+	bc := make(chan map[string]interface{}, 4)
+	bcs := []chan map[string]interface{}{bc}
+	// Address a non-procedure node so HandleInvoke takes the error return.
+	req := map[string]interface{}{
+		"action":      "invoke",
+		"path":        "VehicleService.Seating",
+		"requestId":   "8756",
+		"routerIndex": 0,
+		"RouterId":    "1?0",
+	}
+	HandleInvoke(req, bcs)
+	select {
+	case m := <-bc:
+		if _, ok := m["error"]; !ok {
+			t.Fatalf("expected error response, got %v", m)
+		}
+		if m["RouterId"] != "1?0" {
+			t.Errorf("invoke error dropped RouterId (Issue C): %v", m)
+		}
+		if _, leaked := m["routerIndex"]; leaked {
+			t.Errorf("invoke error leaked internal routerIndex: %v", m)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout")
@@ -789,7 +877,7 @@ func TestHandleMonitor_BadRouterIndex_DoesNotPanic(t *testing.T) {
 
 func TestSendValidationError_IncludesFields(t *testing.T) {
 	ch := make(chan map[string]interface{}, 4)
-	sendValidationError(ch, "invoke", "req-v", []string{"SeatId", "Position"})
+	sendValidationError(ch, "invoke", "req-v", []string{"SeatId", "Position"}, nil)
 	select {
 	case m := <-ch:
 		if m["action"] != "invoke" {
@@ -831,7 +919,7 @@ func TestSendValidationError_IncludesFields(t *testing.T) {
 
 func TestSendValidationError_NilFields(t *testing.T) {
 	ch := make(chan map[string]interface{}, 4)
-	sendValidationError(ch, "invoke", "req-nil", nil)
+	sendValidationError(ch, "invoke", "req-nil", nil, nil)
 	select {
 	case m := <-ch:
 		errObj, ok := m["error"].(map[string]interface{})

--- a/spec/VISSv3.2_Service_Quickstart.md
+++ b/spec/VISSv3.2_Service_Quickstart.md
@@ -54,10 +54,10 @@ A minimal tree looks like:
 SeatingService.Car.Service (branch)
   └─ MoveSeat (procedure)
        ├─ Input (iostruct)
-       │    ├─ SeatId    (property, uint8)
-       │    └─ Position  (property, uint8)
+       │    ├─ MovementType (property, string)
+       │    └─ Position     (property, uint8)
        └─ Output (iostruct)
-            └─ Position  (property, uint8)
+            └─ Position      (property, uint8)
 ```
 
 Node types `procedure`, `iostruct`, `property`, and `symlink` are all valid within a
@@ -74,7 +74,7 @@ Connect to the server's WebSocket interface and send an **invokeRequest**:
   "action": "invoke",
   "path": "SeatingService.Car.Service.MoveSeat",
   "input": {
-    "SeatId": "1",
+    "MovementType": "longitudinal",
     "Position": "40"
   },
   "filter": {"variant": "all"},
@@ -128,6 +128,23 @@ When the invocation finishes:
 }
 ```
 
+### MoveSeat simulation behaviour
+
+The bundled `MoveSeat` service (`vissServiceMgr/example/seatService.go`, and the
+equivalent built-in simulation the server runs when no external service process
+is registered) models a real seat actuator:
+
+- A `Position` (0–100 %) is kept **per `MovementType`**. The supported movement
+  types are `longitudinal`, `vertical` and `recline`, each starting at `0`.
+- If the requested `Position` differs from the saved state, the state is stepped
+  **one percentage point per second** towards the request, emitting one
+  monitoring event per step, until it reaches the target — then `SUCCESSFUL`.
+- If the requested `Position` already equals the saved state, the response is
+  `SUCCESSFUL` and **no** monitoring events are issued.
+- If the requested `Position` is outside `[0,100]` (or non-numeric, or the
+  `MovementType` is unknown) the server returns a `400` error response and no
+  events are issued.
+
 ---
 
 ## Step 5: Monitor an existing invocation
@@ -180,7 +197,7 @@ Response:
   "metadata": {
     "MoveSeat": {
       "type": "procedure",
-      "Input": {"SeatId": {"type": 4, "datatype": "uint8"}, "Position": {"type": 4, "datatype": "uint8"}},
+      "Input": {"MovementType": {"type": 4, "datatype": "string"}, "Position": {"type": 4, "datatype": "uint8"}},
       "Output": {"Position": {"type": 4, "datatype": "uint8"}}
     }
   },


### PR DESCRIPTION
> **Stacked on #191** (`fix/v32-cancel-routing`). The first commit here is the cancel/error route-field fix from that PR; review #191 first. Once #191 merges this diff reduces to the MoveSeat commit.

## Problem (reported by Ulf)

Invoking `VehicleService.Seating.Row1.DriverSide.MoveSeat` produced an endless stream of **content-less `ONGOING`** monitoring events that never terminated (until the 30 s timeout watchdog fired `FAILED`), instead of the `outdata` event format from the [Service spec example](https://github.com/COVESA/vissr/blob/v3.2/spec/VISSv3.2_Service.html):

```json
{"action":"monitoring","path":"...MoveSeat","serviceId":"794363","status":"ONGOING","ts":"..."}
```

**Root cause:** nothing drove the invocation. `forwardInvokeToService` did an exact `registrations[path]` lookup; the instance path matched no registered service, so the invocation sat `ONGOING` while the time-based ticker emitted empty events until the watchdog killed it.

## What this implements (Ulf's spec, in both places — as requested)

**1. Server built-in (`builtinService.go`)** — an in-process MoveSeat simulation used *only* when no external service has registered for the path. It makes the html-client demo work without a separate process and is fully unit-testable:

- `Position` (0–100 %) kept **per `MovementType`** (`longitudinal`/`vertical`/`recline`, each starting at 0).
- requested **==** saved → `SUCCESSFUL` response, **no events**.
- requested **out of [0,100]** / non-numeric / unknown `MovementType` → **`400` error response**, no events, no invocation.
- otherwise → `ONGOING`, then the saved value steps **one percentage point per second** (each an event with `outdata={output:{Position},ts}`) until it reaches the target → `SUCCESSFUL`.
- the invocation deadline is widened to the move duration, so the timeout watchdog no longer kills a long move (the `FAILED`-at-~30 s symptom in Ulf's cancel trace).

**2. `example/seatService.go`** — rewritten as the faithful external reference implementation of the same behaviour via the SDK (per-`MovementType` state, 1 pp/s, range validation, `Done()`-aware cancel). Validation/stepping factored into pure helpers and unit-tested.

**3. Instance-path resolution** (`resolveRegistration` / `isInstanceGeneralization`) so a service registered at a template path (`VehicleService.Seating.MoveSeat`) serves instance paths (`…Row1.DriverSide.MoveSeat`); used by the built-in gate and by `forwardInvoke`/`CancelToService`.

## Docs

`spec/VISSv3.2_Service_Quickstart.md` updated to the `MovementType` signature and a new **MoveSeat simulation behaviour** section. (The separate v3.3 SDK tutorial still uses an illustrative `SeatId` signature; can be aligned in a follow-up.)

## Tests

`builtinService_test.go`: validation errors, already-at-target, the async driver event stream/format, per-`MovementType` independence, cancel/stop, instance resolution, and `HandleInvoke` integration against the real service tree (out-of-range, already-there, moves-and-completes). `example/seatService_test.go`: pure-helper coverage. **vissServiceMgr coverage 96.7%.**

`go build ./...`, `go vet`, `go test -race -count=1 ./server/vissv2server/vissServiceMgr/...` all green.

Closes #195.
