### PR TITLE
Service discover: reuse the Data profile's HIM-tree metadata pattern

### DIFF
--- a/client/client-1.0/Javascript/appclient_service_commands.txt
+++ b/client/client-1.0/Javascript/appclient_service_commands.txt
@@ -21,6 +21,7 @@
 {
     "action": "discover",
     "path": "VehicleService.Seating",
+    "depth": "0",
     "requestId": "8758"
 }
 

--- a/client/client-1.0/testClient/testRequests-service.json
+++ b/client/client-1.0/testClient/testRequests-service.json
@@ -3,14 +3,14 @@
         {
             "action": "discover",
             "path": "VehicleService",
-            "depth": "1",
+            "depth": "0",
             "requestId": "8757"
         }
     ],
     "ws": [
         {
             "action": "discover",
-            "depth": "1",
+            "depth": "0",
             "path": "VehicleService.Seating",
             "requestId": "8758"
         },
@@ -32,7 +32,7 @@
         {
             "action": "discover",
             "path": "VehicleService.Seating",
-            "depth": "1",
+            "depth": "0",
             "requestId": "8764"
         },
         {

--- a/client/client-1.0/testClient/testRequests-service.json
+++ b/client/client-1.0/testClient/testRequests-service.json
@@ -32,7 +32,7 @@
         {
             "action": "discover",
             "path": "VehicleService.Seating",
-            "depth": "0",
+            "depth": "2",
             "requestId": "8764"
         },
         {

--- a/server/vissv2server/vissv2server.go
+++ b/server/vissv2server/vissv2server.go
@@ -559,6 +559,9 @@ func isServiceTree(requestMap map[string]interface{}) bool {
 // dispatchServiceAction routes VISSv3.2/3.3 service actions to vissServiceMgr.
 // HandleInvoke and HandleMonitor receive the full backendChan slice so they
 // can fan out monitoring events to any transport channel.
+//
+// "discover" is handled locally (handleServiceDiscover) rather than by
+// vissServiceMgr.HandleDiscover - see that function's doc comment for why.
 func dispatchServiceAction(requestMap map[string]interface{}, tDChanIndex int) {
 	action, _ := requestMap["action"].(string)
 	switch action {
@@ -567,10 +570,102 @@ func dispatchServiceAction(requestMap map[string]interface{}, tDChanIndex int) {
 	case "monitor":
 		vissServiceMgr.HandleMonitor(requestMap, backendChan)
 	case "discover":
-		vissServiceMgr.HandleDiscover(requestMap, backendChan[tDChanIndex])
+		handleServiceDiscover(requestMap, tDChanIndex)
 	default:
 		utils.Error.Printf("dispatchServiceAction: unexpected action %q", action)
 	}
+}
+
+// handleServiceDiscover processes a VISSv3.2 "discover" action (§6.4) by
+// reusing the Data profile's HIM-tree metadata-generation machinery
+// (synthesizeJsonTree/jsonifyTreeNode) instead of a bespoke Service-profile
+// tree walk. This keeps "metadata describing the addressed subtree" the
+// same shape/behaviour on both profiles: the response is a JSON object
+// keyed by the addressed node's own name, with descendants nested under a
+// "children" key exactly like the signal-tree metadata filter
+// (action=get, filter.variant=metadata) - jsonifyTreeNode is agnostic to
+// node type, so it walks branch/procedure/iostruct/property nodes
+// generically with no Service-profile-specific logic required.
+//
+// "depth" is mandatory: a non-negative integer string ("0" means
+// unlimited/all generations, matching synthesizeJsonTree's existing
+// convention - see the JSON schema for the exact required shape). Per the
+// current Discover spec revision, no "filter" is accepted any more:
+// resource-instance narrowing was removed, so metadata for every instance
+// of a multiplexed procedure is always included (the generic tree walk has
+// no notion of "resource instance" to narrow by in the first place).
+//
+// Adopting synthesizeJsonTree also gets the ATS-based (access-token)
+// authorization pruning of out-of-scope branches "for free" - the previous
+// vissServiceMgr.HandleDiscover implementation had no such pruning.
+//
+// vissServiceMgr.HandleDiscover and its buildServiceMetadata/
+// buildProcedureMetadata*/buildResourceInstanceMetadata/buildIoStructMetadata
+// helpers are intentionally left in place, unused by this dispatch path, in
+// case the live-status enrichment they compute (serviceStatus,
+// activeInvocations, version, serviceHealth, totalInvocations,
+// successRate, avgDurationMs - VISSv3.3 §24/25/27/30/31) is wanted again,
+// e.g. as a future post-processing step layered on top of this tree walk.
+func handleServiceDiscover(requestMap map[string]interface{}, tDChanIndex int) {
+	path, _ := requestMap["path"].(string)
+	requestId, _ := requestMap["requestId"].(string)
+
+	depthStr, ok := requestMap["depth"].(string)
+	if !ok {
+		setErrorAndForward(requestMap, tDChanIndex, 0, "missing/invalid depth") //bad_request
+		return
+	}
+	depth, err := strconv.Atoi(depthStr)
+	if err != nil || depth < 0 {
+		setErrorAndForward(requestMap, tDChanIndex, 0, "depth must be a non-negative integer") //bad_request
+		return
+	}
+
+	VSSTreeRoot := utils.SetRootNodePointer(path)
+	if VSSTreeRoot == nil {
+		setErrorAndForward(requestMap, tDChanIndex, 6, "path not found in service tree") //unavailable_data
+		return
+	}
+
+	tokenContext := getTokenContext(requestMap)
+	if len(tokenContext) == 0 {
+		tokenContext = "Undefined+Undefined+Undefined"
+	}
+	metadataJson := synthesizeJsonTree(path, depth, tokenContext, VSSTreeRoot)
+	if len(metadataJson) == 0 {
+		setErrorAndForward(requestMap, tDChanIndex, 6, "path not found in service tree") //unavailable_data
+		return
+	}
+	// synthesizeJsonTree returns a hand-built JSON string; parse it back
+	// into a map so "metadata" serializes as a native nested JSON object
+	// (matching the discover-message schema's "metadata":"object") rather
+	// than a JSON string containing escaped JSON text.
+	var metadata map[string]interface{}
+	if err := json.Unmarshal([]byte(metadataJson), &metadata); err != nil {
+		utils.Error.Printf("handleServiceDiscover: failed to parse synthesized metadata for path=%q: %s", path, err)
+		setErrorAndForward(requestMap, tDChanIndex, 0, "internal metadata generation error") //bad_request
+		return
+	}
+
+	response := map[string]interface{}{
+		"action":    "discover",
+		"metadata":  metadata,
+		"requestId": requestId,
+		"ts":        utils.GetRfcTime(),
+	}
+	// Copy the client-addressing RouterId so the transport manager can route
+	// the reply back and then strip it (mirrors vissServiceMgr.go's
+	// copyRouteFields). Deliberately not copying "routerIndex" - that is a
+	// server-internal transport-channel index serveRequest injected into
+	// requestMap purely for invoke/monitor's async event fan-out; discover
+	// has no async events, and leaking routerIndex onto the wire would
+	// expose an internal implementation detail to the client.
+	for _, k := range []string{"RouterId", "routerId"} {
+		if v, ok := requestMap[k]; ok {
+			response[k] = v
+		}
+	}
+	backendChan[tDChanIndex] <- response
 }
 
 func issueServiceRequest(requestMap map[string]interface{}, tDChanIndex int, sDChanIndex int) {

--- a/server/vissv2server/vissv2server_coverage_test.go
+++ b/server/vissv2server/vissv2server_coverage_test.go
@@ -777,7 +777,11 @@ func registerServiceDomainTree(t *testing.T, rootName string) func() {
 	return func() { utils.DeregisterServiceTree(rootName) }
 }
 
-func TestDispatchServiceAction_Discover(t *testing.T) {
+// TestDispatchServiceAction_Discover_MissingDepthReturnsError: discover is
+// now handled by handleServiceDiscover (not vissServiceMgr.HandleDiscover),
+// which requires a "depth" field. A request without one gets a synchronous
+// error response, not a block/panic.
+func TestDispatchServiceAction_Discover_MissingDepthReturnsError(t *testing.T) {
 	initChannels()
 	defer registerServiceDomainTree(t, "SvcD")()
 	req := map[string]interface{}{
@@ -785,14 +789,14 @@ func TestDispatchServiceAction_Discover(t *testing.T) {
 		"path":      "SvcD.Invoke",
 		"requestId": "42",
 	}
-	// HandleDiscover writes to backendChan[tDChanIndex] (may return error since
-	// there's no registered procedure, but it must not block).
 	dispatchServiceAction(req, 0)
 	select {
 	case got := <-backendChan[0]:
-		_ = got // error or metadata response — both acceptable
+		if got["error"] == nil {
+			t.Errorf("discover without depth: expected error; got %+v", got)
+		}
 	case <-time.After(500 * time.Millisecond):
-		t.Log("dispatchServiceAction discover: no response to backendChan (acceptable for discover)")
+		t.Fatal("dispatchServiceAction discover: no response to backendChan")
 	}
 }
 
@@ -940,6 +944,290 @@ func TestIssueServiceRequest_HIMMetadataFilter_CallsHimJsonify(t *testing.T) {
 	default:
 		t.Log("no response to backendChan (himJsonify may have returned \"\")")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// handleServiceDiscover — VISSv3.2 "discover" reusing synthesizeJsonTree
+// ---------------------------------------------------------------------------
+
+// registerVehicleServiceTree registers a service-domain tree ("<rootName>.Service")
+// containing a branch with a procedure (with Input/Output iostructs) and a
+// nested sub-branch, mirroring the shape exercised by
+// vissServiceMgr_e2e_test.go's TestHandleDiscover_BranchPath_ReturnsMetadata,
+// so handleServiceDiscover's behaviour can be compared against the same
+// fixture shape.
+func registerVehicleServiceTree(t *testing.T, rootName string) func() {
+	t.Helper()
+	input := utils.NewIoStructNode("Input",
+		utils.NewPropertyNode("MovementType", "string", "Type of movement."),
+		utils.NewPropertyNode("Position", "uint8", "Target position."))
+	output := utils.NewIoStructNode("Output",
+		utils.NewPropertyNode("Position", "uint8", "Current position."))
+	moveSeat := utils.NewProcedureNode("MoveSeat", "Performs seat movements.", input, output)
+	subBranch := utils.NewBranchNode("SubBranch")
+	seating := utils.NewBranchNode("Seating", moveSeat, subBranch)
+	root := utils.NewBranchNode(rootName, seating)
+	utils.RegisterServiceTree(rootName, rootName+".Service", "1.0", root)
+	return func() { utils.DeregisterServiceTree(rootName) }
+}
+
+// stubAtsNoScope replies to exactly one getNoScopeList round-trip on
+// atsChannel[0] with an empty noscope list (nothing pruned).
+func stubAtsNoScope(t *testing.T) {
+	t.Helper()
+	go func() {
+		<-atsChannel[0]
+		atsChannel[0] <- `{"paths":[]}`
+	}()
+}
+
+func TestHandleServiceDiscover_MissingDepth_ReturnsBadRequest(t *testing.T) {
+	initChannels()
+	defer registerVehicleServiceTree(t, "SvcDisc1")()
+	req := map[string]interface{}{
+		"action":    "discover",
+		"path":      "SvcDisc1.Seating",
+		"requestId": "1",
+	}
+	handleServiceDiscover(req, 0)
+	got := <-backendChan[0]
+	errObj, ok := got["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected an error response; got %+v", got)
+	}
+	if errObj["number"] != "400" {
+		t.Errorf("error.number = %v; want 400", errObj["number"])
+	}
+}
+
+func TestHandleServiceDiscover_InvalidDepth_ReturnsBadRequest(t *testing.T) {
+	initChannels()
+	defer registerVehicleServiceTree(t, "SvcDisc2")()
+	cases := []string{"abc", "-1", ""}
+	for _, d := range cases {
+		req := map[string]interface{}{
+			"action":    "discover",
+			"path":      "SvcDisc2.Seating",
+			"depth":     d,
+			"requestId": "1",
+		}
+		handleServiceDiscover(req, 0)
+		got := <-backendChan[0]
+		if got["error"] == nil {
+			t.Errorf("depth=%q: expected error response; got %+v", d, got)
+		}
+	}
+}
+
+func TestHandleServiceDiscover_UnknownPath_ReturnsUnavailableData(t *testing.T) {
+	initChannels()
+	req := map[string]interface{}{
+		"action":    "discover",
+		"path":      "NoSuchServiceRoot.Whatever",
+		"depth":     "0",
+		"requestId": "1",
+	}
+	handleServiceDiscover(req, 0)
+	got := <-backendChan[0]
+	errObj, ok := got["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected an error response; got %+v", got)
+	}
+	if errObj["number"] != "404" {
+		t.Errorf("error.number = %v; want 404", errObj["number"])
+	}
+}
+
+// TestHandleServiceDiscover_BranchPath_ReturnsNestedTreeMetadata pins the new
+// shape: metadata is keyed by the addressed node's own name, with
+// descendants nested under a "children" key (jsonifyTreeNode's shape),
+// unlike the old flat vissServiceMgr.HandleDiscover response.
+func TestHandleServiceDiscover_BranchPath_ReturnsNestedTreeMetadata(t *testing.T) {
+	initChannels()
+	defer registerVehicleServiceTree(t, "SvcDisc3")()
+	stubAtsNoScope(t)
+	req := map[string]interface{}{
+		"action":    "discover",
+		"path":      "SvcDisc3.Seating",
+		"depth":     "0", // unlimited
+		"requestId": "d1",
+	}
+	handleServiceDiscover(req, 0)
+	got := <-backendChan[0]
+	if got["error"] != nil {
+		t.Fatalf("unexpected error: %+v", got["error"])
+	}
+	if got["action"] != "discover" || got["requestId"] != "d1" || got["ts"] == nil {
+		t.Fatalf("response envelope: got %+v", got)
+	}
+	metadata, ok := got["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("metadata missing/!map: %T", got["metadata"])
+	}
+	seating, ok := metadata["Seating"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected top-level \"Seating\" wrapper key; got keys=%v", metaKeysCoverage(metadata))
+	}
+	if seating["type"] != "branch" {
+		t.Errorf("Seating.type = %v; want \"branch\"", seating["type"])
+	}
+	children, ok := seating["children"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected Seating.children map; got %T", seating["children"])
+	}
+	moveSeat, ok := children["MoveSeat"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected children.MoveSeat; got keys=%v", metaKeysCoverage(children))
+	}
+	if moveSeat["type"] != "procedure" {
+		t.Errorf("MoveSeat.type = %v; want \"procedure\"", moveSeat["type"])
+	}
+	moveSeatChildren, ok := moveSeat["children"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected MoveSeat.children (Input/Output); got %T", moveSeat["children"])
+	}
+	if _, ok := moveSeatChildren["Input"]; !ok {
+		t.Errorf("expected MoveSeat.children.Input; got keys=%v", metaKeysCoverage(moveSeatChildren))
+	}
+	if _, ok := moveSeatChildren["Output"]; !ok {
+		t.Errorf("expected MoveSeat.children.Output; got keys=%v", metaKeysCoverage(moveSeatChildren))
+	}
+	// The live-status enrichment fields (serviceStatus/activeInvocations/...)
+	// that vissServiceMgr.HandleDiscover used to add are intentionally not
+	// produced by this tree-walk-only implementation.
+	for _, k := range []string{"serviceStatus", "activeInvocations", "version", "serviceHealth", "totalInvocations", "successRate", "avgDurationMs"} {
+		if _, present := moveSeat[k]; present {
+			t.Errorf("unexpected live-enrichment field %q present in tree-walk metadata", k)
+		}
+	}
+}
+
+// TestHandleServiceDiscover_ProcedurePath_ReturnsInputOutput confirms
+// addressing a procedure node directly also works, and that its own
+// Input/Output iostructs are nested one level down (matching depth
+// semantics: depth=0 unlimited).
+func TestHandleServiceDiscover_ProcedurePath_ReturnsInputOutput(t *testing.T) {
+	initChannels()
+	defer registerVehicleServiceTree(t, "SvcDisc4")()
+	stubAtsNoScope(t)
+	req := map[string]interface{}{
+		"action":    "discover",
+		"path":      "SvcDisc4.Seating.MoveSeat",
+		"depth":     "0",
+		"requestId": "d2",
+	}
+	handleServiceDiscover(req, 0)
+	got := <-backendChan[0]
+	if got["error"] != nil {
+		t.Fatalf("unexpected error: %+v", got["error"])
+	}
+	metadata := got["metadata"].(map[string]interface{})
+	moveSeat, ok := metadata["MoveSeat"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected top-level \"MoveSeat\" wrapper key; got keys=%v", metaKeysCoverage(metadata))
+	}
+	if moveSeat["type"] != "procedure" {
+		t.Errorf("MoveSeat.type = %v; want \"procedure\"", moveSeat["type"])
+	}
+	children, ok := moveSeat["children"].(map[string]interface{})
+	if !ok || children["Input"] == nil || children["Output"] == nil {
+		t.Fatalf("expected children.Input and children.Output; got %+v", moveSeat["children"])
+	}
+}
+
+// TestHandleServiceDiscover_DepthOne_OnlyAddressedNode pins the off-by-one
+// depth semantics inherited from synthesizeJsonTree/jsonifyTreeNode:
+// depth=1 returns only the addressed node's own metadata, with no
+// "children" key at all, even though it has children.
+func TestHandleServiceDiscover_DepthOne_OnlyAddressedNode(t *testing.T) {
+	initChannels()
+	defer registerVehicleServiceTree(t, "SvcDisc5")()
+	stubAtsNoScope(t)
+	req := map[string]interface{}{
+		"action":    "discover",
+		"path":      "SvcDisc5.Seating",
+		"depth":     "1",
+		"requestId": "d3",
+	}
+	handleServiceDiscover(req, 0)
+	got := <-backendChan[0]
+	if got["error"] != nil {
+		t.Fatalf("unexpected error: %+v", got["error"])
+	}
+	metadata := got["metadata"].(map[string]interface{})
+	seating, ok := metadata["Seating"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected top-level \"Seating\" wrapper key; got keys=%v", metaKeysCoverage(metadata))
+	}
+	if _, present := seating["children"]; present {
+		t.Errorf("depth=1: expected no \"children\" key; got %+v", seating["children"])
+	}
+}
+
+// TestHandleServiceDiscover_DepthTwo_DirectChildrenOnly confirms depth=2
+// includes direct children (MoveSeat, SubBranch) but not MoveSeat's own
+// grandchildren (Input/Output).
+func TestHandleServiceDiscover_DepthTwo_DirectChildrenOnly(t *testing.T) {
+	initChannels()
+	defer registerVehicleServiceTree(t, "SvcDisc6")()
+	stubAtsNoScope(t)
+	req := map[string]interface{}{
+		"action":    "discover",
+		"path":      "SvcDisc6.Seating",
+		"depth":     "2",
+		"requestId": "d4",
+	}
+	handleServiceDiscover(req, 0)
+	got := <-backendChan[0]
+	if got["error"] != nil {
+		t.Fatalf("unexpected error: %+v", got["error"])
+	}
+	metadata := got["metadata"].(map[string]interface{})
+	seating := metadata["Seating"].(map[string]interface{})
+	children, ok := seating["children"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("depth=2: expected Seating.children; got %+v", seating["children"])
+	}
+	moveSeat, ok := children["MoveSeat"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("depth=2: expected children.MoveSeat; got keys=%v", metaKeysCoverage(children))
+	}
+	if _, present := moveSeat["children"]; present {
+		t.Errorf("depth=2: MoveSeat should have no \"children\" (grandchildren excluded); got %+v", moveSeat["children"])
+	}
+}
+
+// TestHandleServiceDiscover_RouterIdPreserved confirms the client-addressing
+// RouterId is copied onto the response (so the transport manager can route
+// the reply back), mirroring vissServiceMgr.go's copyRouteFields.
+func TestHandleServiceDiscover_RouterIdPreserved(t *testing.T) {
+	initChannels()
+	defer registerVehicleServiceTree(t, "SvcDisc7")()
+	stubAtsNoScope(t)
+	req := map[string]interface{}{
+		"action":    "discover",
+		"path":      "SvcDisc7.Seating",
+		"depth":     "0",
+		"requestId": "d5",
+		"RouterId":  "1?0",
+	}
+	handleServiceDiscover(req, 0)
+	got := <-backendChan[0]
+	if got["RouterId"] != "1?0" {
+		t.Errorf("RouterId = %v; want \"1?0\"", got["RouterId"])
+	}
+	if _, present := got["routerIndex"]; present {
+		t.Errorf("routerIndex must never be copied onto the response; got %v", got["routerIndex"])
+	}
+}
+
+// metaKeysCoverage returns the keys of m for diagnostic test-failure output.
+func metaKeysCoverage(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 // ---------------------------------------------------------------------------

--- a/server/vissv2server/vissv3.2-service-schema.json
+++ b/server/vissv2server/vissv3.2-service-schema.json
@@ -309,10 +309,11 @@
                     "properties": {
                         "action": { "const": "discover" },
                         "path": { "description": "The service path (branch or procedure node)", "type": "string" },
+                        "depth": { "description": "The max number of descendant generations to return. \"0\" means all generations.", "type": "string" },
                         "authorization": { "description": "The access token", "type": "string" },
                         "requestId": { "description": "The request id", "type": "string" }
                     },
-                    "required": ["action", "path", "requestId"]
+                    "required": ["action", "path", "depth", "requestId"]
                 },
                 {
                     "description": "discoverySuccessResponse",

--- a/spec/VISSRv3.3_Service.html
+++ b/spec/VISSRv3.3_Service.html
@@ -120,13 +120,13 @@ normative text remains in force unless explicitly overridden below.</p>
 <tr><td>§22</td><td>TLS on Service Registration Port</td><td>Optional TLS wrapping for the registration protocol.</td></tr>
 <tr><td>§23</td><td>Server-Sent Events Binding</td><td>SSE frame format for HTTP monitoring event streaming.</td></tr>
 <tr><td>§24</td><td>Service SDK: Auto-Reconnect</td><td><code>WithReconnect</code> builder method with exponential backoff.</td></tr>
-<tr><td>§25</td><td>Discover Response Enrichment</td><td>Live <code>serviceStatus</code> and <code>activeInvocations</code> per procedure in discover response.</td></tr>
+<tr><td>§25</td><td>Discover Response Enrichment <em>(superseded, see note in §25)</em></td><td>Live <code>serviceStatus</code> and <code>activeInvocations</code> per procedure; no longer surfaced by discover.</td></tr>
 <tr><td>§26</td><td>Cancel Propagation to Service Process</td><td>Server forwards <code>cancel</code> to service process; SDK exposes <code>ctx.Done()</code> channel.</td></tr>
-<tr><td>§27</td><td>Service Versioning</td><td>Optional <code>version</code> field in registration; surfaced in discover response.</td></tr>
+<tr><td>§27</td><td>Service Versioning <em>(discover surfacing superseded)</em></td><td>Optional <code>version</code> field in registration; no longer surfaced by discover.</td></tr>
 <tr><td>§28</td><td>Progress Percentage Field</td><td>Optional 0-100 <code>progress</code> integer in ONGOING updates; fanned out in monitoring events.</td></tr>
 <tr><td>§29</td><td>Structured Input Validation Errors</td><td>Validation failures include a <code>fields</code> array naming each missing Input parameter.</td></tr>
-<tr><td>§30</td><td>Service Health Reporting</td><td>Service sends health status; server exposes <code>serviceHealth</code> in discover response; SDK auto-sends on register.</td></tr>
-<tr><td>§31</td><td>Observability Metrics in Discover</td><td>Per-path counters: <code>totalInvocations</code>, <code>successRate</code>, <code>avgDurationMs</code> in discover response.</td></tr>
+<tr><td>§30</td><td>Service Health Reporting <em>(discover surfacing superseded)</em></td><td>Service sends health status; no longer surfaced by discover; SDK auto-sends on register.</td></tr>
+<tr><td>§31</td><td>Observability Metrics <em>(discover surfacing superseded)</em></td><td>Per-path counters: <code>totalInvocations</code>, <code>successRate</code>, <code>avgDurationMs</code>; no longer surfaced by discover.</td></tr>
 </tbody>
 </table>
 
@@ -711,9 +711,20 @@ svc.Run() // reconnects automatically on disconnect</pre>
 <p>If <code>WithReconnect</code> is not called (the default), <code>Run()</code> exits
 immediately when the connection closes.</p>
 
-<h2 id="discover-enrichment">§25. Discover Response Enrichment <span class="new">[NEW in 3.3]</span></h2>
+<h2 id="discover-enrichment">§25. Discover Response Enrichment <span class="new">[NEW in 3.3, superseded]</span></h2>
 
-<p>In addition to the HIM tree structure, the discover response in VISSv3.3 includes two
+<p class="note"><strong>Note:</strong> as of the reference implementation's adoption of the Data
+profile's HIM-tree metadata-generation pattern for discover (see §6.4), the discover response's
+<code>metadata</code> is produced by a generic tree walk and no longer includes the live-status
+fields <code>serviceStatus</code>/<code>activeInvocations</code> described in this section, nor
+the <code>version</code>/<code>serviceHealth</code>/<code>totalInvocations</code>/
+<code>successRate</code>/<code>avgDurationMs</code> fields described in §27/§30/§31 below. The
+server-side code that computes these fields (<code>vissServiceMgr.HandleDiscover</code> and its
+helpers) is retained, unused, for potential reuse as a future post-processing step layered on top
+of the tree walk. This section is kept for historical/design-intent reference; the fields it
+describes are not currently present on the wire.</p>
+
+<p>Previously, in addition to the HIM tree structure, the discover response included two
 live-status fields for each procedure node:</p>
 
 <table>
@@ -725,7 +736,7 @@ live-status fields for each procedure node:</p>
 </table>
 
 <p>Example discover response for a procedure with a connected service and two active
-invocations:</p>
+invocations (previous, superseded shape):</p>
 
 <pre>{
   "action": "discover",
@@ -783,24 +794,22 @@ server sends a cancel:</p>
     ctx.ReportProgress("SUCCESSFUL", result)
 })</pre>
 
-<h2 id="service-versioning">§27. Service Versioning <span class="new">[NEW in 3.3]</span></h2>
+<h2 id="service-versioning">§27. Service Versioning <span class="new">[NEW in 3.3, discover surfacing superseded]</span></h2>
 
 <p>A service process MAY declare a version string during registration:</p>
 
 <pre>{"action":"register","path":"Root.Proc","version":"1.2.0","signature":{...}}</pre>
 
-<p>The server stores this version and includes it in the discover response:</p>
+<p>The server stores this version.</p>
 
-<pre>"MoveSeat": {
-  "type": "procedure",
-  "version": "1.2.0",
-  ...
-}</pre>
+<p class="note"><strong>Note:</strong> the server previously included this version in the
+discover response (<code>"MoveSeat":{"type":"procedure","version":"1.2.0",...}</code>). As
+described in §25's note, discover's <code>metadata</code> is now produced by a generic HIM-tree
+walk that does not surface it; the stored version is retained server-side, unused by discover, for
+potential future reuse.</p>
 
-<p>The version string is opaque to the server; it is copied verbatim into discover
-responses. The RECOMMENDED format is <a href="https://semver.org/">Semantic Versioning</a>
-(<em>MAJOR.MINOR.PATCH</em>). If the field is absent the server MUST NOT include
-<code>"version"</code> in the discover response.</p>
+<p>The version string is opaque to the server. The RECOMMENDED format is
+<a href="https://semver.org/">Semantic Versioning</a> (<em>MAJOR.MINOR.PATCH</em>).</p>
 
 <p>SDK usage:</p>
 
@@ -865,7 +874,7 @@ the invoke request. This is a strict superset of the v3.2 error response, which
 carried only the <code>description</code> string. Clients SHOULD inspect <code>fields</code> to provide
 actionable feedback to users or to retry with corrected input.</p>
 
-<h2 id="service-health">§30. Service Health Reporting <span class="new">[NEW in 3.3]</span></h2>
+<h2 id="service-health">§30. Service Health Reporting <span class="new">[NEW in 3.3, discover surfacing superseded]</span></h2>
 
 <p>A service process MAY send a health status message to the server at any time:</p>
 
@@ -874,19 +883,12 @@ actionable feedback to users or to retry with corrected input.</p>
 <p>The <code>healthy</code> field (boolean, required) indicates operational status. The <code>detail</code>
 field (string, optional) provides a human-readable description of the current state.</p>
 
-<p>The server stores the latest health report per connection and includes it in discover
-responses when at least one health report has been received:</p>
+<p>The server stores the latest health report per connection.</p>
 
-<pre>"MoveSeat": {
-  "type": "procedure",
-  "serviceStatus": "registered",
-  "serviceHealth": {
-    "healthy": true,
-    "detail": "running normally",
-    "updatedAt": "2026-01-15T10:00:01Z"
-  },
-  ...
-}</pre>
+<p class="note"><strong>Note:</strong> the server previously included this in discover responses
+as a <code>serviceHealth</code> object. As described in §25's note, discover's
+<code>metadata</code> is now produced by a generic HIM-tree walk that does not surface it; the
+stored health report is retained server-side, unused by discover, for potential future reuse.</p>
 
 <p>The SDK automatically sends <code>{"action":"health","healthy":true,"detail":"running"}</code>
 immediately after successful registration. Services MAY call <code>ReportHealth</code> at any
@@ -894,14 +896,10 @@ time to update the server's view:</p>
 
 <pre>svc.ReportHealth(false, "seat motor overheated")</pre>
 
-<p>If no health report has been received, <code>serviceHealth</code> is absent from the discover
-response (rather than <code>null</code>). Clients SHOULD treat absence as "unknown" rather
-than "unhealthy".</p>
+<h2 id="observability-metrics">§31. Observability Metrics <span class="new">[NEW in 3.3, discover surfacing superseded]</span></h2>
 
-<h2 id="observability-metrics">§31. Observability Metrics in Discover <span class="new">[NEW in 3.3]</span></h2>
-
-<p>The server accumulates per-path invocation counters and exposes them in the discover
-response. Counters are maintained in memory and reset when the server restarts.</p>
+<p>The server accumulates per-path invocation counters. Counters are maintained in memory and
+reset when the server restarts.</p>
 
 <table>
 <thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>
@@ -912,32 +910,11 @@ response. Counters are maintained in memory and reset when the server restarts.<
 </tbody>
 </table>
 
-<p>Example discover response with observability metrics:</p>
-
-<pre>{
-  "action": "discover",
-  "metadata": {
-    "MoveSeat": {
-      "type": "procedure",
-      "version": "1.2.0",
-      "serviceStatus": "registered",
-      "serviceHealth": {"healthy": true, "detail": "running", "updatedAt": "2026-01-15T10:00:01Z"},
-      "activeInvocations": 1,
-      "totalInvocations": 124,
-      "successRate": 0.98,
-      "avgDurationMs": 1240,
-      "Input": {...},
-      "Output": {...}
-    }
-  },
-  "requestId": "disc-2",
-  "ts": "2026-01-15T10:05:00Z"
-}</pre>
-
-<p>Client-side behaviour: <code>totalInvocations == 0</code> indicates the procedure has never
-been invoked since the server started (or since the path was last registered). In
-this case <code>successRate</code> and <code>avgDurationMs</code> are absent and clients MUST NOT
-interpret their absence as failure.</p>
+<p class="note"><strong>Note:</strong> these counters were previously exposed in the discover
+response alongside <code>serviceStatus</code>/<code>activeInvocations</code>/<code>version</code>/
+<code>serviceHealth</code> (see §25's note). As described there, discover's <code>metadata</code>
+is now produced by a generic HIM-tree walk that does not surface them; the counters are retained
+server-side, unused by discover, for potential future reuse.</p>
 
 <hr>
 <p><em>This document is the VISSv3.3-Services alpha specification.

--- a/spec/VISSv3.2_Service.html
+++ b/spec/VISSv3.2_Service.html
@@ -551,16 +551,21 @@ mandatory in case the service signature specifies it:</p>
 
 <p class="req-star">(*) : If it is not specified in the service signature then the parameter shall be omitted.</p>
 
-<h3 id="discover">6.4 Service Discovery</h3>
+<h3 id="discover">6.4 Discover</h3>
 
 <p>Purpose: Retrieve metadata describing one or more services.<br>
 The metadata describes a service and declares its signature.<br>
-Request arguments, of which path is mandatory:</p>
+Request arguments, of which path and depth are mandatory:</p>
 
 <ul>
   <li><strong>path</strong>: The path to a node with the node type branch or procedure.</li>
+  <li><strong>depth</strong>: The max number of descendant generations that are returned.</li>
   <li><strong>authorization</strong>: The authorization token.</li>
 </ul>
+
+<p>The path must either address a procedure node or a branch node that is not a descendant node to a procedure node.<br>
+Depth must be an integer greater than or equal to zero. Zero returns all generations.<br>
+Metadata for all instances of a multiplexed service are returned.</p>
 
 <p>Success response arguments of which metadata and timestamp are mandatory:</p>
 
@@ -572,8 +577,9 @@ Request arguments, of which path is mandatory:</p>
 <table>
 <thead><tr><th>Object Name</th><th>Attribute</th><th>Type</th><th>Required</th></tr></thead>
 <tbody>
-<tr><td rowspan="4"><strong>discoveryRequest</strong></td><td>action</td><td>Action</td><td>Yes</td></tr>
+<tr><td rowspan="5"><strong>discoveryRequest</strong></td><td>action</td><td>Action</td><td>Yes</td></tr>
 <tr><td>path</td><td>string</td><td>Yes</td></tr>
+<tr><td>depth</td><td>string</td><td>Yes</td></tr>
 <tr><td>authorization</td><td>string</td><td>Optional</td></tr>
 <tr><td>requestId</td><td>string</td><td>Yes</td></tr>
 </tbody>
@@ -760,14 +766,18 @@ lead to that a monitoring session is started. This session can be canceled by th
     "ts":"2025-04-15T13:37:05Z"
 }</pre>
 
-<h3 id="example-discover">9.4 Service Discovery Example</h3>
+<h3 id="example-discover">9.4 Discover Example</h3>
 
-<p>The service discovery request returns metadata describing one or more services.</p>
+<p>The discover request returns metadata describing one or more services. The metadata is a JSON
+representation of the addressed subtree, using the same node-name-keyed/nested-<code>children</code>
+tree shape as the VSS Data profile's metadata filter (<code>action:"get"</code>,
+<code>filter.variant:"metadata"</code>) - see the VISSv3.2 [[CORE]] specification.</p>
 
 <p><strong>Request:</strong></p>
 <pre>{
     "action": "discover",
     "path": "VehicleService.Seating",
+    "depth": "0",
     "requestId": "5687"
 }</pre>
 
@@ -775,29 +785,53 @@ lead to that a monitoring session is started. This session can be canceled by th
 <pre>{
     "action": "discover",
     "metadata": {
-        "MoveSeat": {
-          "type": "procedure",
-          "description": "Performs all supported seat movements."
-        },
-        "MoveSeat.Input": {
-          "type": "iostruct",
-          "description": "Input parameters= (MovementType, Position, Credentials)."
-        },
-        "MoveSeat.Input.MovementType": {
-          "type": "property",
-          "datatype": "string",
-          "description": "Type of movement. Supported types are retrieved via Seating.GetProperties()."
-        },
-        "MoveSeat.Input.Position": {
-          "type": "property",
-          "datatype": "Types.Common.Percentage",
-          "description": "Final position of the movement, expressed as a percentage."
-        },
-......
+        "Seating": {
+            "type": "branch",
+            "description": "Seating related services.",
+            "children": {
+                "MoveSeat": {
+                    "type": "procedure",
+                    "description": "Performs all supported seat movements.",
+                    "children": {
+                        "Input": {
+                            "type": "iostruct",
+                            "children": {
+                                "MovementType": {
+                                    "type": "property",
+                                    "datatype": "string",
+                                    "description": "Type of movement. Supported types are retrieved via Seating.GetProperties()."
+                                },
+                                "Position": {
+                                    "type": "property",
+                                    "datatype": "Types.Common.Percentage",
+                                    "description": "Final position of the movement, expressed as a percentage."
+                                }
+                            }
+                        },
+                        "Output": {
+                            "type": "iostruct",
+                            "children": {
+                                "Position": {
+                                    "type": "property",
+                                    "datatype": "Types.Common.Percentage",
+                                    "description": "Current position of the seat, expressed as a percentage."
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     },
     "requestId": "5687",
     "ts":"2025-04-15T13:37:05Z"
 }</pre>
+
+<p>Depth limits how many generations below the addressed node are included: <code>depth:"1"</code> would
+return only <code>Seating</code>'s own metadata (no <code>children</code> key at all);
+<code>depth:"2"</code> would additionally include <code>MoveSeat</code> but not its own
+<code>Input</code>/<code>Output children</code>; <code>depth:"0"</code> (used above) returns every
+generation.</p>
 
 <h3 id="example-error">9.5 Error Response Example</h3>
 

--- a/spec/VISSv3.2_Service_Quickstart.md
+++ b/spec/VISSv3.2_Service_Quickstart.md
@@ -181,10 +181,17 @@ execution itself. Cancelling a **monitor session** only stops updates to that cl
 
 ## Step 7: Discover the service tree
 
+`depth` is mandatory. `"0"` returns every generation below the addressed node;
+`"1"` returns only the addressed node's own metadata (no `children` key at
+all); `"2"` additionally includes its direct children, and so on. The
+`metadata` shape mirrors the VSS Data profile's metadata filter: keyed by the
+addressed node's own name, with descendants nested under a `children` key.
+
 ```json
 {
   "action": "discover",
   "path": "SeatingService.Car.Service",
+  "depth": "0",
   "requestId": "disc-1"
 }
 ```
@@ -195,10 +202,28 @@ Response:
 {
   "action": "discover",
   "metadata": {
-    "MoveSeat": {
-      "type": "procedure",
-      "Input": {"MovementType": {"type": 4, "datatype": "string"}, "Position": {"type": 4, "datatype": "uint8"}},
-      "Output": {"Position": {"type": 4, "datatype": "uint8"}}
+    "Service": {
+      "type": "branch",
+      "children": {
+        "MoveSeat": {
+          "type": "procedure",
+          "children": {
+            "Input": {
+              "type": "iostruct",
+              "children": {
+                "MovementType": {"type": "property", "datatype": "string"},
+                "Position": {"type": "property", "datatype": "uint8"}
+              }
+            },
+            "Output": {
+              "type": "iostruct",
+              "children": {
+                "Position": {"type": "property", "datatype": "uint8"}
+              }
+            }
+          }
+        }
+      }
     }
   },
   "requestId": "disc-1",

--- a/spec/VISSv3.3_Service_Quickstart.md
+++ b/spec/VISSv3.3_Service_Quickstart.md
@@ -23,13 +23,20 @@ unchanged. This guide focuses on the v3.3 additions.
 | **TLS on port 8300** | Optional mutual TLS for the service registration channel |
 | **SSE helper** | HTTP monitoring can use Server-Sent Events |
 | **Auto-reconnect SDK** | SDK reconnects on connection loss with exponential backoff |
-| **Discover enrichment** | Discover responses include live `serviceStatus` and `activeInvocations` |
+| **Discover enrichment**<sup>†</sup> | Discover responses include live `serviceStatus` and `activeInvocations` |
 | **Cancel propagation** | Server forwards cancel to service process; SDK exposes `ctx.Done()` |
-| **Service versioning** | Services declare a `version` string; appears in discover responses |
+| **Service versioning**<sup>†</sup> | Services declare a `version` string; appears in discover responses |
 | **Progress percentage** | ONGOING updates carry optional `progress` 0-100 field |
 | **Structured validation errors** | Missing Input fields listed by name on invoke failure |
-| **Service health reporting** | Services report health status; shown in discover responses |
-| **Observability metrics** | Per-path counters (`totalInvocations`, `successRate`, `avgDurationMs`) in discover |
+| **Service health reporting**<sup>†</sup> | Services report health status; shown in discover responses |
+| **Observability metrics**<sup>†</sup> | Per-path counters (`totalInvocations`, `successRate`, `avgDurationMs`) in discover |
+
+<sup>†</sup> **Superseded:** discover's `metadata` is now produced by the same generic HIM-tree walk
+used by the Data profile's metadata filter (`action:"get"`, `filter.variant:"metadata"`), which has
+no notion of these live-status fields. The server-side code that computes them is retained,
+unused, for potential future reuse as a post-processing step. `depth` (mandatory) replaces the
+resource filter for narrowing discover's response - see the updated "Discover the service tree"
+section in `VISSv3.2_Service_Quickstart.md`.
 
 ---
 
@@ -158,9 +165,15 @@ and independent state machine. Monitoring sessions attach to a specific invocati
 `timeout` is milliseconds. Omitting it uses the server default (30s). Setting it to `0`
 disables the timeout for this invocation.
 
-### 2.3 Discover enrichment (§25)
+### 2.3 Discover enrichment (§25) — superseded
 
-The `discover` response now includes live fields per procedure:
+> **Superseded:** the fields described in this subsection are no longer present in discover
+> responses; see the note under "What's new in v3.3?" above. `discover` now requires a mandatory
+> `depth` field and returns the addressed subtree in the same nested/`children`-keyed shape as the
+> Data profile's metadata filter - see `VISSv3.2_Service_Quickstart.md`'s "Discover the service
+> tree" section for the current shape.
+
+The `discover` response previously included live fields per procedure:
 
 ```json
 {
@@ -285,18 +298,21 @@ Each SSE frame is `data: <json>\n\n`.
 | Service implementation | In-process | Separate process via TCP |
 | Concurrent invocations | One per path | Unlimited per path |
 | Timeout | None | 30s default, per-request override |
-| Service status in discover | No | Yes (`serviceStatus`, `activeInvocations`) |
+| Service status in discover<sup>†</sup> | No | (was: `serviceStatus`, `activeInvocations`) |
 | Structured errors | No | Yes (`error.code` + `error.message`) |
 | Auth forwarding | Not specified | Client token forwarded to service |
 | TLS on service channel | No | Yes (port 8300 TLS) |
 | Heartbeat | No | Ping every 15s, pong within 5s |
 | Auto-reconnect | No | SDK built-in with backoff |
 | Cancel propagation | No | Server forwards cancel; `ctx.Done()` in SDK |
-| Service versioning | No | `WithVersion()` + shows in discover |
+| Service versioning<sup>†</sup> | No | `WithVersion()` (was: shown in discover) |
 | Progress percentage | No | `ReportProgressPct()` + `progress` 0-100 field |
 | Validation error details | Generic string | `fields` array with missing field names |
-| Health reporting | No | `ReportHealth()` + `serviceHealth` in discover |
-| Observability metrics | No | `totalInvocations`, `successRate`, `avgDurationMs` in discover |
+| Health reporting<sup>†</sup> | No | `ReportHealth()` (was: `serviceHealth` in discover) |
+| Observability metrics<sup>†</sup> | No | (was: `totalInvocations`, `successRate`, `avgDurationMs` in discover) |
+| Discover depth limiting | No | `depth` mandatory; replaces the old resource filter |
+
+<sup>†</sup> Superseded - see the note under "What's new in v3.3?" above.
 
 ---
 
@@ -324,7 +340,7 @@ OnInvoke(func(ctx *vissServiceSDK.InvokeContext) {
 
 ### 6.2 Service versioning (§27)
 
-Declare a version to make upgrades visible in discover responses:
+Declare a version during registration:
 
 ```go
 vissServiceSDK.NewService(serverAddr, "Root.Proc").
@@ -333,8 +349,8 @@ vissServiceSDK.NewService(serverAddr, "Root.Proc").
     Register()
 ```
 
-Clients see `"version":"2.1.0"` in the discover response alongside
-`serviceStatus`, allowing them to validate compatibility before invoking.
+> **Superseded:** the server stores this version but no longer surfaces it in the discover
+> response - see the note under "What's new in v3.3?" above.
 
 ### 6.3 Progress percentage (§28)
 
@@ -376,28 +392,16 @@ status at any time:
 svc.ReportHealth(false, "seat motor overheated — maintenance required")
 ```
 
-Clients see this in discover:
-
-```json
-"serviceHealth": {
-  "healthy": false,
-  "detail": "seat motor overheated — maintenance required",
-  "updatedAt": "2026-01-15T10:03:00Z"
-}
-```
+> **Superseded:** the server stores the latest health report but no longer surfaces it in the
+> discover response as `serviceHealth` - see the note under "What's new in v3.3?" above.
 
 ### 6.6 Observability metrics (§31)
 
-After the service has processed some requests, discover shows cumulative stats:
+The server accumulates per-path stats (`totalInvocations`, `successRate`, `avgDurationMs`) as
+requests are processed; these reset when the server restarts.
 
-```json
-"totalInvocations": 124,
-"successRate": 0.98,
-"avgDurationMs": 1240
-```
-
-These reset when the server restarts. Use them to surface dashboards or
-orchestration health checks without a separate metrics endpoint.
+> **Superseded:** these counters are no longer surfaced in the discover response - see the note
+> under "What's new in v3.3?" above.
 
 ---
 

--- a/utils/service_schema_test.go
+++ b/utils/service_schema_test.go
@@ -147,8 +147,21 @@ func TestJsonSchemaValidate_DiscoverRoutedToServiceSchema(t *testing.T) {
 	loadBaseSchema(t)
 	loadServiceSchema(t)
 
-	if got := JsonSchemaValidate(`{"action":"discover","path":"Vehicle","requestId":"2"}`); got != "" {
+	if got := JsonSchemaValidate(`{"action":"discover","path":"Vehicle","depth":"0","requestId":"2"}`); got != "" {
 		t.Errorf("valid discover rejected = %q; want \"\"", got)
+	}
+}
+
+// TestJsonSchemaValidate_DiscoverMissingDepth_Rejected confirms "depth" is
+// now a required discoveryRequest field (per the Discover spec revision:
+// depth replaces the resource filter, and metadata for all instances of a
+// multiplexed service is always returned).
+func TestJsonSchemaValidate_DiscoverMissingDepth_Rejected(t *testing.T) {
+	loadBaseSchema(t)
+	loadServiceSchema(t)
+
+	if got := JsonSchemaValidate(`{"action":"discover","path":"Vehicle","requestId":"2"}`); got == "" {
+		t.Error("discover without depth was accepted; want rejection")
 	}
 }
 
@@ -244,26 +257,26 @@ func TestJsonSchemaValidate_ResourceFilterArray_MonitorFirst(t *testing.T) {
 	}
 }
 
-// TestJsonSchemaValidate_ResourceFilterStandalone confirms a bare
-// {"variant":"resource",...} single-object filter (no array) validates, per
-// the merged spec text allowing a resource filter alone.
-func TestJsonSchemaValidate_ResourceFilterStandalone(t *testing.T) {
+// TestJsonSchemaValidate_DiscoverIgnoresLeftoverFilterProperty confirms a
+// discover request carrying a leftover "filter" property (from the older,
+// now-removed resource-filter-based narrowing) still validates as long as
+// "depth" is present — discover-message doesn't reference "filter" in its
+// $defs at all any more, and additionalProperties is unset (defaults to
+// allowed) throughout this schema, so an extra unrecognised property is not
+// itself a validation error.
+func TestJsonSchemaValidate_DiscoverIgnoresLeftoverFilterProperty(t *testing.T) {
 	loadBaseSchema(t)
 	loadServiceSchema(t)
 
 	req := `{
 		"action": "discover",
 		"path": "VehicleService.Seating.MoveSeat",
+		"depth": "0",
 		"filter": {"variant": "resource", "parameter": ["Row1.DriverSide"]},
 		"requestId": "d1"
 	}`
-	// discover-message doesn't reference "filter" in its $defs (HandleDiscover
-	// parses it directly from the request map), so this only exercises that
-	// the base object schema doesn't reject the extra "filter" property —
-	// additionalProperties is unset (defaults to allowed) throughout this
-	// schema, so this must still pass.
 	if got := JsonSchemaValidate(req); got != "" {
-		t.Errorf("discover with a standalone resource filter rejected = %q; want \"\"", got)
+		t.Errorf("discover with depth and a leftover filter property rejected = %q; want \"\"", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the VISSv3.2 Service profile's `discover` action so it returns proper HIM-tree metadata, following the same pattern already used for the Data profile's metadata filter (`action:"get"`, `filter.variant:"metadata"` -> `vissv2server.go`'s `synthesizeJsonTree`/`jsonifyTreeNode`).

Previously, `discover` built its own bespoke, flat metadata shape (`vissServiceMgr.HandleDiscover` / `buildServiceMetadata` / `buildProcedureMetadata*`) that was structurally inconsistent with the Data profile's equivalent feature and produced a somewhat "strange" result relative to what the spec text ("A JSON representation of the content of the addressed subtree") implies.

## What changed

- `dispatchServiceAction`'s `"discover"` case is now handled by a new `handleServiceDiscover` (`vissv2server.go`) that calls `synthesizeJsonTree` directly, instead of `vissServiceMgr.HandleDiscover`. `jsonifyTreeNode` is fully agnostic to node type - it just walks `utils.Node_t.Child[]` generically - so it correctly recurses through `branch`/`procedure`/`iostruct`/`property` nodes with zero Service-profile-specific logic required.
- **`depth` is now mandatory** on every discover request (a non-negative integer string; `"0"` = all generations), matching `synthesizeJsonTree`'s existing convention and the gRPC `DiscoverRequestMessage.Depth` field already added in #202. The `"resource"` filter variant is no longer accepted - metadata for every instance of a multiplexed procedure is always returned, since the generic tree walk has no notion of "resource instance" to narrow by in the first place.
- **Breaking response shape change**: `metadata` is now keyed by the addressed node's own name, with descendants nested under a `"children"` key - the same shape the Data profile's metadata filter already produces - instead of the previous flat shape (no top-level wrapper; a procedure's `Input`/`Output`/live-status fields as direct sibling keys).
- The response's `metadata` is parsed back from `synthesizeJsonTree`'s JSON string into a native map before being placed on the response, so it serializes as a proper nested JSON object (matching the schema's `"metadata":"object"`) rather than double-encoded JSON text.
- **Bonus**: ATS-based (access-token) authorization pruning of out-of-scope branches, which `synthesizeJsonTree` already performs via `getNoScopeList`, now applies to discover for free - the previous implementation had none.
- `vissv3.2-service-schema.json`'s `discoveryRequest` now requires `"depth"`.

## What's intentionally NOT changed

Per explicit direction, the VISSv3.3 §24/25/27/30/31 live-status enrichment fields (`serviceStatus`, `activeInvocations`, `version`, `serviceHealth`, `totalInvocations`, `successRate`, `avgDurationMs`) are **dropped from the discover response**, since they have no equivalent in the static HIM tree that `synthesizeJsonTree` walks (they come from `vissServiceMgr`'s live registration/invocation/metrics maps). The server-side code that computes them (`vissServiceMgr.HandleDiscover` and its `buildServiceMetadata`/`buildProcedureMetadata*`/`buildResourceInstanceMetadata`/`buildIoStructMetadata` helpers) is **left in place, unused**, in case this enrichment is wanted again later - e.g. as a future post-processing step layered on top of the tree walk.

`vissServiceMgr.HandleDiscover`'s own existing unit/e2e tests (`vissServiceMgr_test.go`, `vissServiceMgr_e2e_test.go`, `resource_multiplex_e2e_test.go`, `appclient_commands_e2e_test.go`) are unaffected since they call `HandleDiscover` directly - they continue to pass, now exercising code unreachable from `dispatchServiceAction`.

## Docs updated

The repo's own copies of the Service spec/quickstart docs are updated to match:
- `spec/VISSv3.2_Service.html` §6.4/§9.4: mandatory `depth`, new nested example.
- `spec/VISSv3.2_Service_Quickstart.md`: "Discover the service tree" step updated.
- `spec/VISSRv3.3_Service.html` and `spec/VISSv3.3_Service_Quickstart.md`: §25/§27/§30/§31 sections annotated as superseded (discover-surfacing only; registration/health/metrics tracking itself is unaffected), with historical examples kept for reference.

## Testing

- New tests in `server/vissv2server/vissv2server_coverage_test.go`: missing/invalid depth, unknown path, branch vs. procedure addressing, the depth=1/depth=2 off-by-one semantics inherited from `jsonifyTreeNode`, and RouterId preservation.
- `utils/service_schema_test.go`: added a depth-required-rejection test; updated the now-obsolete standalone-resource-filter test to reflect that discover no longer references `"filter"` for anything.
- `go build ./...` and `go vet ./...` clean repo-wide.
- `go test ./...`: no new failures - the same pre-existing, environment-specific failures (Windows file-permission-mode assertions, a temp-file-cleanup race, and a local-MQTT-broker-dependent test) reproduce identically on `v3.2.5` before this change.
- `go test ./server/vissv2server/... -race`: clean.
- Fixture files (`client/client-1.0/testClient/testRequests-service.json`, `client/client-1.0/Javascript/appclient_service_commands.txt`) updated with the now-mandatory `depth` field.
