### PR TITLE
gRPC: fix broken UnsubscribeRequest kill-routing (and an adjacent crash bug)

### DIFF
--- a/server/vissv2server/grpcMgr/grpcMgr.go
+++ b/server/vissv2server/grpcMgr/grpcMgr.go
@@ -19,7 +19,16 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
+
+// grpcChannelSendTimeout caps how long UnsubscribeRequest will wait when
+// forwarding a kill message to the originally-subscribing SubscribeRequest
+// stream's per-call channel. If that stream's goroutine is gone or stuck
+// (e.g. mid stream.Send on a slow connection), this bounds the wait rather
+// than blocking the unsubscribe caller's own RPC indefinitely. Mirrors
+// udsMgr.go's channelSendTimeout convention.
+const grpcChannelSendTimeout = 5 * time.Second
 
 var grpcCompression utils.Encoding
 var grpcMgrId int
@@ -105,8 +114,28 @@ func updateGrpcRoutingData(clientId int, subscriptionId string) {
 	}
 }
 
-func getSubscribeRoutingData(unsubResp string) (int, chan string) {
-	subscriptionId := getSubscriptionId(unsubResp)
+// getSubscribeRoutingData looks up the clientId/response-channel pair for
+// the SubscribeRequest stream that owns subscriptionId. Takes the plain
+// subscriptionId string directly (mirroring getServiceRoutingData's
+// shape) rather than a JSON blob to parse - callers that have a JSON
+// response to extract it from should call getSubscriptionId first.
+//
+// Returns (-1, nil) when subscriptionId is empty. This guard matters:
+// every never-yet-subscribed or freshly-reset grpcRoutingDataList slot has
+// SubscriptionId at its Go zero-value "" (see resetGrpcRoutingData), so an
+// unguarded empty-string lookup would spuriously "find" the first such
+// unrelated slot - either an unallocated one (whose GrpcRespChannel is
+// also nil, so a caller sending into it deadlocks) or a live client that
+// simply hasn't subscribed to anything yet. This was previously reachable
+// via killSubscribeStream's predecessor code path, which looked up the
+// subscribe-side channel using the *response*'s subscriptionId field -
+// but the real unsubscribe ACK never carries one (see killSubscribeStream
+// for the full explanation), making that empty-string lookup a real,
+// reachable, un-guarded bug.
+func getSubscribeRoutingData(subscriptionId string) (int, chan string) {
+	if subscriptionId == "" {
+		return -1, nil
+	}
 	grpcStateMu.Lock()
 	defer grpcStateMu.Unlock()
 	for i := 0; i < MAXGRPCCLIENTS; i++ {
@@ -153,7 +182,16 @@ func updateGrpcServiceRoutingData(clientId int, serviceId string) {
 // clientId - assigned asynchronously by the manager hub - from the ACK
 // response they just received, so it can be used later to cancel the
 // session on stream disconnect.
+//
+// Returns -1 when serviceId is empty, for the same reason
+// getSubscribeRoutingData guards against an empty subscriptionId: every
+// never-yet-assigned or freshly-reset slot also has ServiceId=="" (Go zero
+// value), so an unguarded empty lookup would spuriously match an unrelated
+// slot.
 func getServiceRoutingData(serviceId string) int {
+	if serviceId == "" {
+		return -1
+	}
 	grpcStateMu.Lock()
 	defer grpcStateMu.Unlock()
 	for i := 0; i < MAXGRPCCLIENTS; i++ {
@@ -200,13 +238,35 @@ func setGrpcRoutingData(clientId int, grpcRespChan chan string, isMultipleEvent 
 	return false
 }
 
+// resetGrpcRoutingData frees clientId's routing slot. clientId == -1 is
+// the "no client assigned yet" sentinel (e.g. SubscribeRequest's
+// subscribeClientId before any response has arrived) and must never be
+// looked up here: since every unallocated slot's own ClientId is also -1
+// (see iniGrpcRoutingDataList), an unguarded call would match the first
+// unallocated slot and then call resetClientIdLocked(-1), which panics on
+// grpcClientIndexList[-1] - an unrecovered panic in this single-threaded
+// hub goroutine crashes the entire gRPC server process. This was
+// previously reachable simply by a client opening a SubscribeRequest
+// stream and disconnecting before the manager hub's first response
+// arrived (stream.Context().Done() fires with subscribeClientId still at
+// its initial -1).
 func resetGrpcRoutingData(clientId int) {
+	if clientId < 0 {
+		return
+	}
 	utils.Info.Printf("resetGrpcRoutingData:clientId=%d", clientId)
 	grpcStateMu.Lock()
 	defer grpcStateMu.Unlock()
 	for i := 0; i < MAXGRPCCLIENTS; i++ {
 		if grpcRoutingDataList[i].ClientId == clientId {
 			grpcRoutingDataList[i].ClientId = -1
+			// Clear stale SubscriptionId/ServiceId too, so a future lookup
+			// with an empty string (guarded against above/in
+			// getSubscribeRoutingData/getServiceRoutingData, but defense in
+			// depth) can never match this now-freed slot by leftover data
+			// from a previous occupant.
+			grpcRoutingDataList[i].SubscriptionId = ""
+			grpcRoutingDataList[i].ServiceId = ""
 			resetClientIdLocked(clientId)
 			break
 		}
@@ -235,10 +295,17 @@ func RemoveRoutingForwardResponse(response string) {
 func updateRoutingList(resp string, clientId int, isMultipleEvent bool) {
 	utils.Info.Printf("updateRoutingList:message=%s", resp)
 	if strings.Contains(resp, "unsubscribe") {
-		_, subscribeChan := getSubscribeRoutingData(resp)
-		subscribeChan <- resp
+		// The unsubscribe ACK is addressed back to whoever sent the
+		// unsubscribe request (clientId here) via the ordinary RouterId
+		// routing RemoveRoutingForwardResponse already performed - there is
+		// nothing left to do beyond freeing this caller's own routing slot.
+		// (Terminating the SIBLING SubscribeRequest stream that owned the
+		// subscription is handled synchronously by the UnsubscribeRequest
+		// RPC handler itself, via killSubscribeStream, using the
+		// subscriptionId from the client's own unsubscribe REQUEST - not
+		// from this response, which never carries one; see
+		// killSubscribeStream's doc comment.)
 		resetGrpcRoutingData(clientId)
-		//utils.Info.Printf("updateRoutingList:unsubscribe clientid=%s, subscription clientid=%s", clientId, subscribeClientId)
 	} else if strings.Contains(resp, `"action":"monitoring"`) {
 		// VISSv3.2 Service profile monitoring event: keep the routing entry
 		// alive while ONGOING (further events for this invoke/monitor
@@ -374,8 +441,62 @@ func (s *Server) SetRequest(ctx context.Context, in *pb.SetRequestMessage) (*pb.
 }
 
 func (s *Server) UnsubscribeRequest(ctx context.Context, in *pb.UnsubscribeRequestMessage) (*pb.UnsubscribeResponseMessage, error) {
+	// Terminate the sibling SubscribeRequest stream that owns this
+	// subscription, using the subscriptionId carried on THIS request - see
+	// killSubscribeStream's doc comment for why the response-based
+	// cross-routing this replaced was broken.
+	killSubscribeStream(in.GetSubscriptionId())
 	vssResp := dispatchGrpcUnaryRequest(utils.UnsubscribeRequestPbToJson(in))
 	return utils.UnsubscribeResponseJsonToPb(vssResp), nil
+}
+
+// killSubscribeStream terminates the SubscribeRequest stream that owns
+// subscriptionId, by sending it the KILL_MESSAGE it already understands
+// (see classifySubscribeResponse/extractClientId in SubscribeRequest's
+// loop below).
+//
+// This replaces a previous mechanism that tried to achieve the same thing
+// by piggy-backing on the unsubscribe-ACK RESPONSE: updateRoutingList's
+// "unsubscribe" branch would extract a "subscriptionId" field from the
+// ACK, look up the subscribing stream by it, and forward the ACK itself
+// as a makeshift kill signal. That never worked, because the real
+// unsubscribe ACK the server core produces (serviceMgr.go's
+// buildServiceResponseMap/handleServiceUnsubscribe) - and the gRPC
+// UnsubscribeResponseMessage proto itself - never carries a
+// "subscriptionId" field at all (only the REQUEST does; a client supplies
+// it to say what to unsubscribe from, but the server has no reason to
+// echo it back). So the old lookup always resolved subscriptionId="",
+// which - since every never-yet-subscribed or freshly-reset
+// grpcRoutingDataList slot also has SubscriptionId at its Go zero-value
+// "" - matched an unrelated slot. If that slot was unallocated
+// (ClientId==-1), its GrpcRespChannel was also nil, and sending into it
+// blocked forever inside GrpcMgrInit's single-threaded hub loop,
+// deadlocking every gRPC client, not just the one unsubscribing. If the
+// matched slot instead belonged to a live but unrelated client, the ACK
+// got misrouted into that client's own response channel.
+//
+// This function sidesteps all of that by using the subscriptionId
+// supplied on the UNSUBSCRIBE REQUEST itself (always present and
+// reliable - the request schema requires it), rather than trying to
+// extract one from a response that structurally never has it, and by
+// signalling the target stream directly rather than routing through the
+// manager hub's single-threaded response path at all.
+func killSubscribeStream(subscriptionId string) {
+	if subscriptionId == "" {
+		return
+	}
+	clientId, ch := getSubscribeRoutingData(subscriptionId)
+	if ch == nil {
+		// No active SubscribeRequest stream owns this id (already
+		// terminated, or the id was never valid) - nothing to kill.
+		return
+	}
+	killMsg := KILL_MESSAGE + " clientId:" + strconv.Itoa(clientId)
+	select {
+	case ch <- killMsg:
+	case <-time.After(grpcChannelSendTimeout):
+		utils.Error.Printf("killSubscribeStream: send timed out for clientId=%d, subscriptionId=%s", clientId, subscriptionId)
+	}
 }
 
 func (s *Server) SubscribeRequest(in *pb.SubscribeRequestMessage, stream pb.VISS_SubscribeRequestServer) error {
@@ -403,7 +524,7 @@ func (s *Server) SubscribeRequest(in *pb.SubscribeRequestMessage, stream pb.VISS
 				return nil
 			}
 			if subscribeClientId == -1 {
-				subscribeClientId, _ = getSubscribeRoutingData(vssResp)
+				subscribeClientId, _ = getSubscribeRoutingData(getSubscriptionId(vssResp))
 			}
 			pbResp := utils.SubscribeStreamJsonToPb(vssResp)
 			if err := stream.Send(pbResp); err != nil {

--- a/server/vissv2server/grpcMgr/grpcMgr_test.go
+++ b/server/vissv2server/grpcMgr/grpcMgr_test.go
@@ -7,6 +7,7 @@ package grpcMgr
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -276,9 +277,7 @@ func TestGetSubscribeRoutingData_FindsBySubscriptionId(t *testing.T) {
 	setGrpcRoutingData(id, ch, true)
 	updateGrpcRoutingData(id, "sub-ABCD")
 
-	// Build a minimal subscribe-response JSON that getSubscriptionId can parse.
-	resp := `{"action":"subscription","subscriptionId":"sub-ABCD"}`
-	gotId, gotCh := getSubscribeRoutingData(resp)
+	gotId, gotCh := getSubscribeRoutingData("sub-ABCD")
 	if gotId != id {
 		t.Fatalf("getSubscribeRoutingData: clientId = %d; want %d", gotId, id)
 	}
@@ -293,8 +292,7 @@ func TestGetSubscribeRoutingData_MissingId(t *testing.T) {
 	initLists()
 	defer initLists()
 
-	resp := `{"action":"subscription","subscriptionId":"sub-NOTFOUND"}`
-	gotId, gotCh := getSubscribeRoutingData(resp)
+	gotId, gotCh := getSubscribeRoutingData("sub-NOTFOUND")
 	if gotId != -1 {
 		t.Fatalf("getSubscribeRoutingData on missing id = %d; want -1", gotId)
 	}
@@ -303,20 +301,25 @@ func TestGetSubscribeRoutingData_MissingId(t *testing.T) {
 	}
 }
 
-// TestGetSubscribeRoutingData_MalformedJSON: a non-JSON response must
-// not panic; it should return -1 and nil.
-func TestGetSubscribeRoutingData_MalformedJSON(t *testing.T) {
+// TestGetSubscribeRoutingData_EmptyId: an empty subscriptionId (e.g. from
+// a response that never carries one, such as the real unsubscribe ACK -
+// see killSubscribeStream's doc comment) must return -1/nil, never match
+// an unrelated never-yet-subscribed slot whose SubscriptionId is also at
+// its Go zero-value "".
+func TestGetSubscribeRoutingData_EmptyId(t *testing.T) {
 	initLists()
 	defer initLists()
 
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("getSubscribeRoutingData panicked on malformed JSON: %v", r)
-		}
-	}()
-	gotId, gotCh := getSubscribeRoutingData(`{not valid json}`)
+	// Occupy a slot that has never had updateGrpcRoutingData called on it,
+	// so its SubscriptionId is "" - the exact condition that used to be
+	// misrouted-to/deadlocked-on.
+	if id := getClientId(); id != -1 {
+		setGrpcRoutingData(id, make(chan string, 1), false)
+	}
+
+	gotId, gotCh := getSubscribeRoutingData("")
 	if gotId != -1 || gotCh != nil {
-		t.Logf("getSubscribeRoutingData on bad JSON: id=%d ch=%v (both -1/nil expected)", gotId, gotCh)
+		t.Fatalf("getSubscribeRoutingData(\"\") = (%d, %v); want (-1, nil)", gotId, gotCh)
 	}
 }
 
@@ -406,25 +409,18 @@ func TestUpdateRoutingList_SubscribeErrorResetsClientId(t *testing.T) {
 	}
 }
 
-// TestUpdateRoutingList_UnsubscribeForwardsAndResets: an "unsubscribe"
-// response must forward to the subscribe channel and reset the client.
-// We simulate both the subscribe-side and unsubscribe-side clientIds.
-func TestUpdateRoutingList_UnsubscribeForwardsAndResets(t *testing.T) {
+// TestUpdateRoutingList_UnsubscribeResetsCaller: an "unsubscribe" ACK
+// response must free the CALLER's own routing slot (the client that sent
+// the unsubscribe request). It must NOT try to forward anything to a
+// "subscribe-side" channel looked up via a "subscriptionId" field on the
+// response - the real ACK never carries one (see killSubscribeStream's
+// doc comment on grpcMgr.go); terminating the sibling SubscribeRequest
+// stream is now killSubscribeStream's job, driven by the unsubscribe
+// REQUEST's own subscriptionId, tested separately below.
+func TestUpdateRoutingList_UnsubscribeResetsCaller(t *testing.T) {
 	initLists()
 	defer initLists()
 
-	// Set up the subscribe-side channel. getSubscribeRoutingData looks
-	// up by subscriptionId, so we need a routing entry with a matching
-	// subscriptionId.
-	subCh := make(chan string, 1)
-	subId := getClientId()
-	if subId == -1 {
-		t.Fatalf("no free slot for subscribe client")
-	}
-	setGrpcRoutingData(subId, subCh, true)
-	updateGrpcRoutingData(subId, "sub-UNSUB")
-
-	// Set up the unsubscribe-side channel.
 	unsubCh := make(chan string, 1)
 	unsubId := getClientId()
 	if unsubId == -1 {
@@ -432,33 +428,67 @@ func TestUpdateRoutingList_UnsubscribeForwardsAndResets(t *testing.T) {
 	}
 	setGrpcRoutingData(unsubId, unsubCh, false)
 
-	// The "unsubscribe" response carries the subscriptionId so
-	// getSubscribeRoutingData can find the subscribe-side channel.
-	resp := `{"action":"unsubscribe","subscriptionId":"sub-UNSUB"}`
+	// The real production ACK shape: no "subscriptionId" field.
+	resp := `{"action":"unsubscribe","requestId":"1","ts":"T"}`
+	updateRoutingList(resp, unsubId, false)
 
-	// updateRoutingList sends on subscribeChan, which blocks unless
-	// consumed. Run it in a goroutine so we can drain subCh.
-	done := make(chan struct{})
-	go func() {
-		updateRoutingList(resp, unsubId, false)
-		close(done)
-	}()
-
-	// Drain the message sent to the subscribe-side channel.
-	select {
-	case got := <-subCh:
-		_ = got
-	case <-done:
-		t.Fatalf("updateRoutingList returned before forwarding to subscribe channel")
-	}
-	<-done
-
-	// The unsubscribe client slot should now be freed.
 	grpcStateMu.Lock()
 	taken := grpcClientIndexList[unsubId]
 	grpcStateMu.Unlock()
 	if taken {
 		t.Fatalf("unsubscribe client slot %d still taken; want freed", unsubId)
+	}
+}
+
+// TestKillSubscribeStream_SendsKillMessageToOwningStream confirms the new
+// mechanism: given the unsubscribe REQUEST's own subscriptionId (always
+// present, unlike the response), killSubscribeStream looks up the
+// SubscribeRequest stream that owns it and sends the KILL_MESSAGE that
+// stream's loop already understands (classifySubscribeResponse/
+// extractClientId).
+func TestKillSubscribeStream_SendsKillMessageToOwningStream(t *testing.T) {
+	initLists()
+	defer initLists()
+
+	subCh := make(chan string, 1)
+	subId := getClientId()
+	if subId == -1 {
+		t.Fatalf("no free slot for subscribe client")
+	}
+	setGrpcRoutingData(subId, subCh, true)
+	updateGrpcRoutingData(subId, "sub-KILL")
+
+	killSubscribeStream("sub-KILL")
+
+	select {
+	case got := <-subCh:
+		if !strings.Contains(got, KILL_MESSAGE) {
+			t.Fatalf("killSubscribeStream sent %q; want it to contain %q", got, KILL_MESSAGE)
+		}
+		if extractClientId(got) != subId {
+			t.Fatalf("killSubscribeStream sent clientId %d (parsed from %q); want %d", extractClientId(got), got, subId)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("killSubscribeStream did not send a kill message within 2s")
+	}
+}
+
+// TestKillSubscribeStream_UnknownSubscriptionId_NoOp: an unknown or empty
+// subscriptionId must be a silent no-op, not a nil-channel send/deadlock.
+func TestKillSubscribeStream_UnknownSubscriptionId_NoOp(t *testing.T) {
+	initLists()
+	defer initLists()
+
+	done := make(chan struct{})
+	go func() {
+		killSubscribeStream("")
+		killSubscribeStream("sub-NEVER-REGISTERED")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("killSubscribeStream blocked on an unknown/empty subscriptionId")
 	}
 }
 
@@ -599,6 +629,82 @@ func (m *mockSubscribeStream) SendHeader(_ metadata.MD) error  { return nil }
 func (m *mockSubscribeStream) SetTrailer(_ metadata.MD)        {}
 func (m *mockSubscribeStream) SendMsg(_ interface{}) error     { return nil }
 func (m *mockSubscribeStream) RecvMsg(_ interface{}) error     { return nil }
+
+// TestSubscribeRequest_DisconnectBeforeAnyResponse_DoesNotPanic
+// reproduces a real crash: a client opens a SubscribeRequest stream and
+// disconnects (context cancelled) before the manager hub has sent back
+// ANY response at all - not even the initial subscribe ack/error. In that
+// case subscribeClientId is still its initial sentinel -1 when
+// ctx.Done() fires, and the Done() branch calls
+// resetGrpcRoutingData(subscribeClientId). Before the fix,
+// resetGrpcRoutingData had no guard against clientId==-1: it matched the
+// first unallocated routing slot (whose ClientId is also -1 by
+// initialisation) and called resetClientIdLocked(-1), which panics on
+// grpcClientIndexList[-1] - an unrecovered panic in this hub goroutine
+// crashes the entire gRPC server process, taking down every other gRPC
+// client too.
+func TestSubscribeRequest_DisconnectBeforeAnyResponse_DoesNotPanic(t *testing.T) {
+	initLists()
+	defer initLists()
+
+	// The Done() branch also calls utils.AddRoutingForwardRequest on
+	// grpcMgrChan; without a receiver that send blocks forever (nil channel
+	// by default in tests). Mirrors
+	// TestSubscribeRequest_NormalEventThenContextCancel's setup.
+	testMgrChan := make(chan string, 4)
+	origMgrChan := grpcMgrChan
+	grpcMgrChan = testMgrChan
+	defer func() { grpcMgrChan = origMgrChan }()
+	go func(ch chan string) {
+		for range ch {
+		}
+	}(testMgrChan)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := &mockSubscribeStream{ctx: ctx, cancel: cancel}
+	in := &pb.SubscribeRequestMessage{Path: "Vehicle.Speed", RequestId: "99"}
+
+	srv := &Server{}
+	done := make(chan error, 1)
+	panicked := make(chan interface{}, 1)
+	go func() {
+		// A panic inside SubscribeRequest (running in this goroutine) would
+		// NOT be caught by a defer/recover in the test's own goroutine -
+		// Go panics only propagate within the goroutine they occur in; an
+		// unrecovered panic here would crash the entire test binary. So the
+		// recover must live in THIS goroutine to convert a would-be crash
+		// into a normal test failure.
+		defer func() {
+			if r := recover(); r != nil {
+				panicked <- r
+				return
+			}
+		}()
+		done <- srv.SubscribeRequest(in, stream)
+	}()
+
+	// Consume the initial forwarded request but never reply to it - the
+	// hub simply never gets around to responding before the client hangs
+	// up, which is the scenario under test.
+	select {
+	case <-grpcClientChan[0]:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("SubscribeRequest did not forward request to grpcClientChan[0]")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("SubscribeRequest returned error: %v", err)
+		}
+	case r := <-panicked:
+		t.Fatalf("SubscribeRequest panicked on disconnect before any response: %v", r)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("SubscribeRequest did not return within 2s")
+	}
+}
 
 // TestSubscribeRequest_ContextCancelledReturnsNil: when the streaming
 // context is cancelled immediately, SubscribeRequest must send the


### PR DESCRIPTION
## Summary

Fixes a real, latent bug in the gRPC transport's `UnsubscribeRequest`/`SubscribeRequest` cross-routing (found while reviewing PR #202's context), plus an adjacent crash bug discovered while fixing it. Neither is caused by #202 or #203 - both are pre-existing.

## Bug 1: UnsubscribeRequest never actually terminates the sibling SubscribeRequest stream (and can deadlock the whole gRPC hub)

`SubscribeRequest` is a server-streaming RPC; `UnsubscribeRequest` is a separate unary RPC, potentially on a different connection, with its own routing slot. To terminate the original stream, `updateRoutingList`'s `"unsubscribe"` branch tried to look up the subscribing stream's channel by extracting a `"subscriptionId"` field from the **unsubscribe ACK response**. Problem: the real ACK the server core produces (`serviceMgr.go`'s `buildServiceResponseMap`/`handleServiceUnsubscribe`) never carries that field - and neither does the gRPC `UnsubscribeResponseMessage` proto message itself (only the *request* has it). So the lookup always resolved `subscriptionId=""`.

Every never-yet-subscribed or freshly-reset `grpcRoutingDataList` slot also has `SubscriptionId` at its Go zero-value `""` (the slice is never cleared per-field on reset, only `ClientId`). So the empty-string lookup spuriously matched an unrelated slot:
- If unallocated (`ClientId==-1`), its channel was also `nil`, and the code did `nilChan <- resp` - **blocking forever inside `GrpcMgrInit`'s single-threaded hub loop, deadlocking every gRPC client**, not just the one unsubscribing.
- If it belonged to a live but unrelated client, the ACK got misrouted into that client's own response channel.

The one existing test masked this by manually fabricating a `subscriptionId` field on its synthetic response that production code never actually produces.

**Fix**: `killSubscribeStream` (new) looks up the subscribing stream using the subscriptionId carried on the **unsubscribe request itself** (always present and reliable), and sends it the existing `KILL_MESSAGE` format `SubscribeRequest`'s loop already understands - directly, bypassing the single-threaded hub response path entirely. `updateRoutingList`'s `"unsubscribe"` branch now only frees the calling client's own slot.

## Bug 2 (found while fixing bug 1): disconnecting a SubscribeRequest before any response arrives crashes the whole gRPC server

`SubscribeRequest`'s `subscribeClientId` starts at `-1` and stays there until the first response arrives. If the client disconnects first (`ctx.Done()` fires before that), `resetGrpcRoutingData(-1)` was called with no guard - matching the first unallocated slot (also `ClientId==-1`) and calling `resetClientIdLocked(-1)`, indexing `grpcClientIndexList[-1]`. **This is an unrecovered panic that crashes the entire process** (no panic recovery is configured anywhere in `grpcMgr.go`). Confirmed reproducible and fixed with a simple guard.

## Other hardening (defense in depth)

- `getSubscribeRoutingData`/`getServiceRoutingData` now reject an empty id up front, closing this class of bug for any future caller (PR #202's `getServiceRoutingData` uses the identical pattern and was theoretically exposed to the same issue, though not yet reachable in practice).
- `resetGrpcRoutingData` now clears a freed slot's stale `SubscriptionId`/`ServiceId` (previously only `ClientId` was reset).

## Testing

- `TestSubscribeRequest_DisconnectBeforeAnyResponse_DoesNotPanic` reproduces the crash - confirmed to fail with `runtime error: index out of range [-1]` against the pre-fix code, passes after the fix.
- `TestKillSubscribeStream_SendsKillMessageToOwningStream` / `_UnknownSubscriptionId_NoOp` cover the new mechanism.
- `TestUpdateRoutingList_UnsubscribeResetsCaller` replaces the old bug-masking test, using the real (subscriptionId-less) ACK shape.
- `TestGetSubscribeRoutingData_EmptyId` covers the new empty-string guard.
- Existing `getSubscribeRoutingData` tests updated for the new plain-subscriptionId-string signature (previously took a JSON blob to parse internally - now callers extract the id themselves, mirroring `getServiceRoutingData`'s shape).
- `go vet` and `go test -race` clean for the package.
- Full repo `go build`/`go test` show no new failures - same pre-existing, environment-specific failures (Windows file-permission-mode assertions, a temp-file-cleanup race, a local-MQTT-broker-dependent test) reproduce identically on `v3.2.5` before this change.
