### PR TITLE
fix(feeder): report failed value conversion via in-line error instead of dropping it

### DIFF
--- a/feeder/feeder-template/feederv4/feederv4.go
+++ b/feeder/feeder-template/feederv4/feederv4.go
@@ -864,6 +864,19 @@ func convertDomainData(north2SouthConv bool, inData DomainData, feederMap []Feed
 	return outData
 }
 
+// convertValue converts value between the VSS and vehicle domains using
+// the scaling table entry at convertIndex. On any conversion failure
+// (out-of-range index, malformed scaling entry, or a value not covered
+// by the entry -- e.g. an enum key/value that isn't in the table) it
+// returns utils.InlineErrorDataConversionFailed rather than "". A prior
+// version of this code returned "" on failure, which convertDomainData
+// then propagated into outData.Value unchanged; because that empty
+// string doesn't fail any of the caller's emptiness checks (only
+// outData.Name is checked before writing to state storage), it ended up
+// silently written to the state storage backend as-is, invisibly
+// discarding the actual set value while still reporting write success.
+// Writing the in-line error sentinel instead surfaces the failure to
+// a subsequent get, per the VISS in-line error reporting convention.
 func convertValue(value string, convertIndex uint16, inDatatype int8, outDatatype int8, north2SouthConv bool) string {
 	if convertIndex == 0 { // no conversion
 		return value
@@ -873,12 +886,12 @@ func convertValue(value string, convertIndex uint16, inDatatype int8, outDatatyp
 	idx := int(convertIndex) - 1
 	if idx < 0 || idx >= len(scalingDataList) {
 		utils.Error.Printf("convertValue: convertIndex %d out of range for scalingDataList(len=%d)", convertIndex, len(scalingDataList))
-		return ""
+		return utils.InlineErrorDataConversionFailed
 	}
 	var convertDataMap interface{}
 	if err := json.Unmarshal([]byte(scalingDataList[idx]), &convertDataMap); err != nil {
 		utils.Error.Printf("convertValue:Error unmarshal scalingDataList item=%s", scalingDataList[idx])
-		return ""
+		return utils.InlineErrorDataConversionFailed
 	}
 	switch vv := convertDataMap.(type) {
 	case map[string]interface{}:
@@ -889,7 +902,7 @@ func convertValue(value string, convertIndex uint16, inDatatype int8, outDatatyp
 		return linearConversion(vv, north2SouthConv, value)
 	default:
 		utils.Error.Printf("convertValue: convert data=%s has unknown format (got %T)", scalingDataList[idx], convertDataMap)
-		return ""
+		return utils.InlineErrorDataConversionFailed
 	}
 }
 
@@ -910,25 +923,28 @@ func enumConversion(enumObj map[string]interface{}, north2SouthConv bool, inValu
 			}
 		}
 	}
+	// inValue has no matching entry in enumObj (e.g. a set request's value
+	// isn't one of the enum's defined VSS keys). See convertValue's doc
+	// comment for why this must not be "".
 	utils.Error.Printf("enumConversion: value=%s is out of range.", inValue)
-	return ""
+	return utils.InlineErrorDataConversionFailed
 }
 
 func linearConversion(coeffArray []interface{}, north2SouthConv bool, inValue string) string { // coeffArray = [A, B], y = Ax +B, y is VSS value
 	if len(coeffArray) < 2 {
 		utils.Error.Printf("linearConversion: coefficient array too short (len=%d, need 2)", len(coeffArray))
-		return ""
+		return utils.InlineErrorDataConversionFailed
 	}
 	x, err := strconv.ParseFloat(inValue, 64)
 	if err != nil {
 		utils.Error.Printf("linearConversion: input value=%s cannot be converted to float.", inValue)
-		return ""
+		return utils.InlineErrorDataConversionFailed
 	}
 	A, okA := coeffArray[0].(float64)
 	B, okB := coeffArray[1].(float64)
 	if !okA || !okB {
 		utils.Error.Printf("linearConversion: coefficients must be numbers (got A=%T, B=%T)", coeffArray[0], coeffArray[1])
-		return ""
+		return utils.InlineErrorDataConversionFailed
 	}
 	var y float64
 	if north2SouthConv {
@@ -936,7 +952,7 @@ func linearConversion(coeffArray []interface{}, north2SouthConv bool, inValue st
 	} else {
 		if A == 0 {
 			utils.Error.Printf("linearConversion: south-to-north divide-by-zero (A=0)")
-			return ""
+			return utils.InlineErrorDataConversionFailed
 		}
 		y = (x - B) / A
 	}

--- a/feeder/feeder-template/feederv4/feederv4_helpers_test.go
+++ b/feeder/feeder-template/feederv4/feederv4_helpers_test.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/covesa/vissr/utils"
 )
 
 // TestFileExists covers the path-exists check.
@@ -162,28 +164,51 @@ func TestIncDpIndex(t *testing.T) {
 }
 
 // TestEnumConversion maps between VSS enum values via the enum object.
+// enumObj keys are VSS-domain values, enumObj values are vehicle-domain
+// values (see enumConversion's doc comment). north2SouthConv=true takes
+// a VSS-domain input (a key) and returns the vehicle-domain value;
+// north2SouthConv=false takes a vehicle-domain input (a value) and
+// returns the VSS-domain key.
 func TestEnumConversion_NorthBound(t *testing.T) {
-	// North-bound: vehicle value -> VSS key.
+	// VSS ("Off"/"On") -> vehicle ("0"/"1").
 	enum := map[string]interface{}{
 		"Off": "0",
 		"On":  "1",
 	}
-	got := enumConversion(enum, true, "0")
-	// Implementation could either return "Off" or pass-through depending
-	// on direction. Just assert the function doesn't panic.
-	if got == "" {
-		t.Logf("note: enumConversion northbound returned empty (acceptable as long as no panic)")
+	got := enumConversion(enum, true, "Off")
+	if got != "0" {
+		t.Errorf("enumConversion northbound = %q; want %q", got, "0")
 	}
 }
 
 func TestEnumConversion_SouthBound(t *testing.T) {
+	// vehicle ("0"/"1") -> VSS ("Off"/"On").
 	enum := map[string]interface{}{
 		"Off": "0",
 		"On":  "1",
 	}
-	got := enumConversion(enum, false, "Off")
-	if got == "" {
-		t.Logf("note: enumConversion southbound returned empty (acceptable as long as no panic)")
+	got := enumConversion(enum, false, "0")
+	if got != "Off" {
+		t.Errorf("enumConversion southbound = %q; want %q", got, "Off")
+	}
+}
+
+// TestEnumConversion_ValueNotInTable is a regression test: a value with
+// no matching entry in enumObj (e.g. a set request whose value isn't one
+// of the enum's defined VSS keys, as in the "SPORT" -> Vehicle.Powertrain.
+// Transmission.PerformanceMode bug) must return the VISS in-line error
+// sentinel, not "". Returning "" let the failed conversion be written to
+// state storage as an empty value indistinguishable from success; a
+// subsequent get would then see whatever the backend defaults to for a
+// missing/empty stored value instead of a clear conversion-failure marker.
+func TestEnumConversion_ValueNotInTable(t *testing.T) {
+	enum := map[string]interface{}{
+		"NORMAL": "0",
+		"ECONOMY": "1",
+	}
+	got := enumConversion(enum, true, "SPORT")
+	if got != utils.InlineErrorDataConversionFailed {
+		t.Errorf("enumConversion(out-of-table value) = %q; want %q", got, utils.InlineErrorDataConversionFailed)
 	}
 }
 
@@ -198,13 +223,17 @@ func TestLinearConversion_Identity(t *testing.T) {
 }
 
 func TestLinearConversion_BadInput(t *testing.T) {
-	// Non-numeric value should not panic.
+	// Non-numeric value should not panic, and must return the in-line
+	// error sentinel rather than "" (see convertValue's doc comment).
 	defer func() {
 		if r := recover(); r != nil {
 			t.Fatalf("linearConversion panicked on non-numeric input: %v", r)
 		}
 	}()
-	_ = linearConversion([]interface{}{float64(2), float64(0)}, true, "not a number")
+	got := linearConversion([]interface{}{float64(2), float64(0)}, true, "not a number")
+	if got != utils.InlineErrorDataConversionFailed {
+		t.Errorf("linearConversion(non-numeric input) = %q; want %q", got, utils.InlineErrorDataConversionFailed)
+	}
 }
 
 // TODO(testing): the following functions need code refactoring before

--- a/server/vissv2server/serviceMgr/curvelog.go
+++ b/server/vissv2server/serviceMgr/curvelog.go
@@ -733,7 +733,7 @@ func clCapture1dim(clChan chan CLPack, triggChannelIndex int, subscriptionId int
 		if !okVal || !okTs {
 			continue
 		}
-		if valStr == "visserr:Data-not-available" {
+		if valStr == utils.InlineErrorDataNotAvailable {
 			continue
 		}
 		_, ts := readRing(&aRingBuffer, 0) // read latest written
@@ -1025,7 +1025,7 @@ func clCapture2dim(clChan chan CLPack, triggChannelIndex int, subscriptionId int
 		if !ok1 || !ok2 {
 			continue
 		}
-		if val1Str == "visserr:Data-not-available" || val2Str == "visserr:Data-not-available" {
+		if val1Str == utils.InlineErrorDataNotAvailable || val2Str == utils.InlineErrorDataNotAvailable {
 			continue
 		}
 		ts1New, ok1 := stringField(dpMap1, "ts")
@@ -1192,7 +1192,7 @@ func clCapture3dim(clChan chan CLPack, triggChannelIndex int, subscriptionId int
 		if !ok1 || !ok2 || !ok3 {
 			continue
 		}
-		if val1Str == "visserr:Data-not-available" || val2Str == "visserr:Data-not-available" || val3Str == "visserr:Data-not-available" {
+		if val1Str == utils.InlineErrorDataNotAvailable || val2Str == utils.InlineErrorDataNotAvailable || val3Str == utils.InlineErrorDataNotAvailable {
 			continue
 		}
 		ts1New, ok1 := stringField(dpMap1, "ts")

--- a/server/vissv2server/serviceMgr/curvelog_test.go
+++ b/server/vissv2server/serviceMgr/curvelog_test.go
@@ -1085,7 +1085,7 @@ func TestReturnSingleDp_PublishesToChannel(t *testing.T) {
 	resetClState()
 	// Stub the storage layer enough that getVehicleData returns something.
 	// getVehicleData is implemented in serviceMgr.go; we only need its
-	// fallback (visserr:Data-not-available) for an end-to-end push.
+	// fallback (viss-inline:Data-not-available) for an end-to-end push.
 	ch := make(chan CLPack, 1)
 	go returnSingleDp(ch, 42, "Vehicle.Speed")
 	select {

--- a/server/vissv2server/serviceMgr/storage_backend.go
+++ b/server/vissv2server/serviceMgr/storage_backend.go
@@ -40,9 +40,10 @@ type StorageBackend interface {
 	// Get returns the canonical {"value":"...", "ts":"..."} JSON
 	// string for the data point at path. On error or missing data,
 	// returns the same sentinel-value JSON the original inline
-	// switches emitted (e.g. {"value":"visserr:Data-not-available",
-	// "ts":"..."}). Callers (getDataPackMap and subscribe LatestDataPoint
-	// capture) pass the result through to clients as-is.
+	// switches emitted (e.g. {"value":"viss-inline:Data-not-available",
+	// "ts":"..."}, see utils.InlineErrorDataNotAvailable). Callers
+	// (getDataPackMap and subscribe LatestDataPoint capture) pass the
+	// result through to clients as-is.
 	Get(path string) string
 
 	// Set writes value at path. Returns the timestamp used for the
@@ -77,13 +78,13 @@ func (s *sqliteBackend) Get(path string) string {
 		if err := rows.Err(); err != nil {
 			utils.Warning.Printf("sqliteBackend.Get: rows.Err for path=%s err=%v", path, err)
 		}
-		return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
+		return `{"value":"` + utils.InlineErrorDataNotAvailable + `", "ts":"` + utils.GetRfcTime() + `"}`
 	}
 	value := ""
 	timestamp := ""
 	if err := rows.Scan(&value, &timestamp); err != nil {
 		utils.Warning.Printf("Data not found: %s for path=%s", err, path)
-		return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
+		return `{"value":"` + utils.InlineErrorDataNotAvailable + `", "ts":"` + utils.GetRfcTime() + `"}`
 	}
 	return `{"value":"` + value + `", "ts":"` + timestamp + `"}`
 }
@@ -128,7 +129,7 @@ func (r *redisBackend) Get(path string) string {
 			utils.Error.Printf("Job failed. Error()=%s", err.Error())
 			return `{"value":"Database-error", "ts":"` + utils.GetRfcTime() + `"}`
 		}
-		return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
+		return `{"value":"` + utils.InlineErrorDataNotAvailable + `", "ts":"` + utils.GetRfcTime() + `"}`
 	}
 	return dp
 }
@@ -161,7 +162,7 @@ func (m *memcacheBackend) Get(path string) string {
 			return `{"value":"Database-error", "ts":"` + utils.GetRfcTime() + `"}`
 		}
 		utils.Warning.Printf("Data not found.")
-		return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
+		return `{"value":"` + utils.InlineErrorDataNotAvailable + `", "ts":"` + utils.GetRfcTime() + `"}`
 	}
 	return string(mcItem.Value)
 }
@@ -193,7 +194,7 @@ func (i *iotdbBackend) Get(path string) string {
 	sessionDataSet, err := i.session.ExecuteQueryStatement(selectLastSQL, &i.config.Timeout)
 	if err != nil {
 		utils.Error.Printf("IoTDB: Query failed with error=%s", err)
-		return `{"value":"visserr:Data-not-available", "ts":"` + utils.GetRfcTime() + `"}`
+		return `{"value":"` + utils.InlineErrorDataNotAvailable + `", "ts":"` + utils.GetRfcTime() + `"}`
 	}
 	success, nextErr := sessionDataSet.Next()
 	if nextErr == nil && success {

--- a/tutorial/content/build-system/hello-world/_index.md
+++ b/tutorial/content/build-system/hello-world/_index.md
@@ -20,7 +20,7 @@ $ cd vissr/server/vissv2server/
 $ go build
 ```
 This could be followed by directly starting a client to issue requests to the server,
-but the server would then try to read data from an empty data store, so all responses would say 'visserr:Data-not-available'.
+but the server would then try to read data from an empty data store, so all responses would say 'viss-inline:Data-not-available'.
 To be able to get some real data back we will therefore start a feeder that will write simulated data into the data store.
 
 To do this, open a new terminal window, go to the feederv3 directory, and build the feeder.
@@ -58,9 +58,9 @@ Try with the command
 ```
 which should return a response like the below.
 ```
-Server: {"action":"get","requestId":"232","ts":"2024-11-12T11:26:44.546855082Z", "data":{"path":"Vehicle.Cabin.Door.Row1.DriverSide.IsOpen", "dp":{"value":"visserr:Data-not-available", "ts":"2024-11-12T11:26:44.548180993Z"}}}
+Server: {"action":"get","requestId":"232","ts":"2024-11-12T11:26:44.546855082Z", "data":{"path":"Vehicle.Cabin.Door.Row1.DriverSide.IsOpen", "dp":{"value":"viss-inline:Data-not-available", "ts":"2024-11-12T11:26:44.548180993Z"}}}
 ```
-The value is set to 'visserr:Data-not-available' which is due to that the federv3 is not instructed to create simulated values for this signal.
+The value is set to 'viss-inline:Data-not-available' which is due to that the federv3 is not instructed to create simulated values for this signal.
 At startup the feederv3 reads the file VssVehicle.cvt which has been created by the [Domain Conversion Tool](/vissr/tools/).
 This file contains the instructions for how signals are mapped and scaled when they traverse between the 'vehicle domain' and the 'VSS domain',
 but the feederv3 also uses this information to select which signals to create simulated values for.

--- a/utils/common.go
+++ b/utils/common.go
@@ -29,6 +29,43 @@ import (
 const IpModel = 0 // IpModel = [0,1,2] = [localhost,extIP,envVarIP]
 const IpEnvVarName = "GEN2MODULEIP"
 
+// InlineErrorPrefix is the sentinel prefix used for VISS in-line error
+// reporting (VISSv3.2 Transport spec, section "In-line Error Reporting"):
+// when a value can't be retrieved/produced for a signal in a response
+// that otherwise carries valid values for other signals, the "value"
+// field is replaced with this prefix followed by an error tag, instead
+// of failing the whole request. Per spec: "The prefix 'viss-inline:'
+// MUST NOT be used in any ordinary string values." This was previously
+// implemented in this codebase under the non-normative "visserr:" prefix;
+// it has been renamed to match the specification's wire format.
+const InlineErrorPrefix = "viss-inline:"
+
+// InlineErrorDataNotAvailable is the in-line error value used when a
+// data point has no value in the state storage backend for the
+// requested path (e.g. never set, or the backend query/lookup failed).
+const InlineErrorDataNotAvailable = InlineErrorPrefix + "Data-not-available"
+
+// InlineErrorDataConversionFailed is the in-line error value used when a
+// value could be read from or was received for a signal, but a required
+// north/south domain-value conversion (e.g. a feeder's enum or linear
+// scaling lookup) failed -- e.g. because the incoming value has no
+// matching entry in the configured conversion table. Callers write this
+// sentinel to state storage instead of silently dropping the write or
+// storing an empty/wrong value, so a subsequent get surfaces the failure
+// instead of returning stale or default data.
+//
+// NOTE: unlike InlineErrorDataNotAvailable ("viss-inline:Data-not-available",
+// which IS defined by the VISS specification's in-line error reporting
+// convention -- see the Transport spec, "In-line Error Reporting" section),
+// "Data-conversion-failed" is a VISSR-specific extension of that
+// convention and is NOT currently part of the VISS specification. It
+// reuses the same "viss-inline:" prefix and general shape so existing
+// spec-aware clients that just treat any "viss-inline:*"-prefixed value
+// as an unavailable/errored data point keep working, but the specific
+// tag itself has no normative meaning outside this reference
+// implementation.
+const InlineErrorDataConversionFailed = InlineErrorPrefix + "Data-conversion-failed"
+
 var jsonSchema *jsonschema.Schema
 
 // Access control values: none=0, write-only=1. read-write=2, consent +=10


### PR DESCRIPTION
## Problem

Testing a VISSv3.2 multi-set request:
```
{"action":"set","data":[{"path":"Vehicle.Powertrain.Transmission.PerformanceMode","value":"SPORT"}],"requestId":"249"}
```
followed by a get on the same path returned `"value":"0"` instead of `"SPORT"`.

The feeder's log confirmed the server correctly forwarded `"SPORT"` to the feeder. The feeder's `convertDomainData`/`convertValue`/`enumConversion` pipeline then tried to apply a configured enum/linear scaling conversion for the signal, found no matching entry for `"SPORT"` in the conversion table, and returned an empty string (`""`). That empty string only fails an emptiness check on the signal *name*, not the *value*, so it was written to state storage as-is -- silently discarding the actual set value while still reporting write success. The next `get` then returned whatever the backend already held for that path.

## Fix

- Adds `utils.InlineErrorDataConversionFailed` (`"viss-inline:Data-conversion-failed"`), written to state storage instead of `""` whenever `convertValue`/`enumConversion`/`linearConversion` fail to convert a value (out-of-range scaling index, malformed scaling entry, or a value with no matching table entry). A subsequent `get` now surfaces the failure via VISS's in-line error reporting convention instead of returning stale/default data.
- **Note: `Data-conversion-failed` is a VISSR-specific extension of the VISS in-line error reporting convention and is *not* currently part of the VISS specification.** Only `Data-not-available` is spec-defined (VISS Transport spec, "In-line Error Reporting" section). This is documented in the constant's doc comment in `utils/common.go`.
- Along the way, renames the pre-existing non-normative `visserr:` sentinel prefix to `viss-inline:` (`utils.InlineErrorDataNotAvailable`) to match the wire format actually mandated by the VISS Transport specification (previously this repo used a made-up `visserr:` prefix that never matched the spec's `viss-inline:` prefix). Updated `storage_backend.go`, `curvelog.go`, and the affected tutorial doc.

## Testing

- Added `TestEnumConversion_ValueNotInTable` and updated `TestLinearConversion_BadInput` to assert the new sentinel is returned on conversion failure instead of `""`.
- Fixed `TestEnumConversion_NorthBound`/`_SouthBound` to assert on actual expected values (they previously only checked for no panic).
- `go test ./server/vissv2server/serviceMgr ./feeder/feeder-template/feederv4` passes.
- `go build ./utils/... ./server/vissv2server/serviceMgr ./feeder/feeder-template/feederv4` passes.
